### PR TITLE
docs: add security overview to README docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,7 @@ Only a subset of docs appear in the sections above. Full index:
 - [docs/roadmap.md](docs/roadmap.md) — Planned integrations and features based on community demand
 
 **Security**
+- [docs/security/SECURITY.md](docs/security/SECURITY.md) — Security overview: auth, RBAC, controls, supply chain
 - [docs/security/hardening.md](docs/security/hardening.md) — Production hardening checklist
 - [docs/security/threat_model.md](docs/security/threat_model.md) — STRIDE analysis, attack surfaces
 - [docs/security/vulnerability_response_playbook.md](docs/security/vulnerability_response_playbook.md) — Incident response


### PR DESCRIPTION
## Summary

- Adds `docs/security/SECURITY.md` to the Security section of the README docs index, alongside the existing links to `hardening.md`, `threat_model.md`, and `vulnerability_response_playbook.md`

This was missed when PR #31 was merged — the supply chain security content landed but the README link pointing to it did not.

## Test plan

- [ ] Verify the link renders correctly in the README
- [ ] Confirm it points to `docs/security/SECURITY.md` (not the root-level `SECURITY.md`)

https://claude.ai/code/session_01FYa7R48r7NRkfynWMJEWEd