### PR TITLE
ci(security): add dual container scan job — Grype + Trivy binary v0.69.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,55 @@ jobs:
         # 2.19.2 is the latest release; no upstream fix available yet.
         run: pip install -r requirements.txt && pip-audit --requirement requirements.txt --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539
 
+  container-scan:
+    name: Container image scan (Grype + Trivy)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      # Single-arch build loaded into the local Docker daemon for scanning.
+      # Multi-arch builds (linux/amd64,linux/arm64) cannot be loaded locally —
+      # a separate amd64-only build is required here.
+      - name: Build image for scanning (linux/amd64)
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: opendqv:ci
+          cache-from: type=gha
+
+      # --- Grype (primary scanner — Anchore) ---
+      - name: Install Grype
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Scan with Grype
+        run: grype opendqv:ci --fail-on high --only-fixed
+
+      # --- Trivy binary v0.69.3 ---
+      # NOTE: Do NOT use aquasecurity/trivy-action or aquasecurity/setup-trivy.
+      # Both GitHub Actions repos had version tags force-pushed with malicious commits
+      # on 2026-03-19 (TeamPCP supply chain attack). The Trivy binary downloaded
+      # directly at a pinned version is safe. v0.69.3 is the last known clean release.
+      # Review this pin when Aqua Security publishes a confirmed post-remediation release.
+      - name: Install Trivy binary (v0.69.3)
+        run: |
+          curl -sSfL \
+            https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-64bit.tar.gz \
+            | tar -xz -C /usr/local/bin trivy
+
+      - name: Scan with Trivy
+        run: |
+          trivy image opendqv:ci \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --severity CRITICAL,HIGH
+
   integration:
     name: Integration tests (live stack)
     runs-on: ubuntu-latest

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -337,34 +337,44 @@ secrets:
 
 ## 12. Container Image Scanning
 
-### Recommended scanner: Grype + Syft (Anchore)
+### Automated CI scanning: Grype + Trivy (dual scanner)
 
-The primary recommended scanner is **Grype** paired with **Syft** for SBOM generation (both by Anchore). Grype is free, open source, and unaffected by the March 2026 Trivy supply chain incident (see note below).
+OpenDQV's CI runs both **Grype** (Anchore) and **Trivy** on every push to `main` and every PR via the `container-scan` job in `.github/workflows/ci.yml`. Running both tools gives broader coverage — they pull from overlapping but not identical vulnerability databases, and Grype tends to have fewer false positives while Trivy adds misconfiguration and secrets detection.
+
+Both scanners fail the build on CRITICAL/HIGH findings where a fix is available. Findings with no upstream fix are excluded (`--only-fixed` / `--ignore-unfixed`).
+
+To run the same scan locally before pushing:
 
 ```bash
-# Install
-curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+# Grype
 curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+grype opendqv:latest --fail-on high --only-fixed
 
-# Scan via SBOM (recommended — generates an SBOM and scans it)
-syft opendqv:latest -o json | grype --fail-on high
-
-# Or scan the image directly
-grype opendqv:latest --fail-on high
+# Trivy binary (see version note below — do NOT use trivy-action)
+curl -sSfL \
+  https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-64bit.tar.gz \
+  | tar -xz -C /usr/local/bin trivy
+trivy image opendqv:latest --ignore-unfixed --exit-code 1 --severity CRITICAL,HIGH
 ```
 
-A `container-scan` CI job using Grype is planned but not yet automated — run it locally or in your deployment pipeline until the CI job is added. CRITICAL and HIGH findings with a fix available should block the build.
+### Trivy version pinning — March 2026 incident
 
-### Note on Trivy (March 2026)
+On March 19, 2026, the threat actor TeamPCP compromised Aqua Security's CI/CD pipeline and:
+- Published a malicious Trivy binary (v0.69.4) to GitHub Releases, Docker Hub, and GHCR
+- Force-pushed backdoored commits to nearly all version tags in `aquasecurity/trivy-action` and `aquasecurity/setup-trivy`
 
-On March 19, 2026, the threat actor TeamPCP compromised Aqua Security's CI/CD pipeline and published a malicious Trivy binary (v0.69.4) and force-pushed backdoored commits to nearly all version tags in `aquasecurity/trivy-action` and `aquasecurity/setup-trivy`. Pipelines referencing version tags silently ran credential-stealing malware. The same stolen credentials enabled the downstream LiteLLM PyPI attack on March 24.
+Pipelines referencing version tags (e.g. `@v0.35.0`) silently ran credential-stealing malware. The same stolen credentials enabled the downstream LiteLLM PyPI attack on March 24.
 
 **OpenDQV's own CI pipelines did not use `trivy-action` and were not exposed.**
 
-If you choose to use Trivy:
-- Avoid v0.69.4 — use v0.69.3 or a post-remediation release
-- Never reference `aquasecurity/trivy-action` or `aquasecurity/setup-trivy` by version tag — pin to an exact commit hash
-- Prefer running the Trivy binary directly (not via the GitHub Action) during the recovery period
+| Component | Status |
+|---|---|
+| Trivy binary v0.69.3 | Safe — last clean release; used in CI |
+| Trivy binary v0.69.4 | **Compromised — do not use** |
+| `aquasecurity/trivy-action` (any version tag) | **Avoid** — tags were poisoned; pin to exact commit hash only |
+| `aquasecurity/setup-trivy` (any version tag) | **Avoid** — same |
+
+OpenDQV's CI downloads the Trivy binary directly (not via the GitHub Action). Review and update the `v0.69.3` pin once Aqua Security publishes a confirmed post-remediation release.
 
 ### Baseline scan — 2026-03-10
 
@@ -381,6 +391,6 @@ Post-fix scan result: **0 CRITICAL, 0 HIGH** across all packages and OS layers.
 
 ### Keeping the image clean
 
-- When the `container-scan` CI job is added, it should run on every push to `main` and `develop` and on all PRs to `main`.
+- The `container-scan` CI job runs on every push to `main` and on all PRs to `main` (`.github/workflows/ci.yml`).
 - When a new HIGH/CRITICAL finding appears: if a fix exists, bump the relevant package in `requirements.txt` or the Dockerfile pre-pin line and rebuild.
 - `python:3.11-slim` OS-layer findings (Debian packages) with no upstream fix can be excluded with `--ignore-unfixed` / `--only-fixed`. Monitor these periodically — bump the base image tag when a patched slim image is released.


### PR DESCRIPTION
## Summary

- Adds a `container-scan` job to `ci.yml` running on every push to `main` and every PR
- Runs **both Grype and Trivy** for broader coverage (overlapping but not identical vulnerability databases)
- Trivy uses the **binary directly at v0.69.3** — `trivy-action` and `setup-trivy` are explicitly not used following the March 19 2026 TeamPCP compromise
- Updates `hardening.md` section 12 to document the now-automated job, dual-scanner rationale, and a safe/unsafe table for Trivy components

## Key implementation notes

**Multi-arch constraint:** `docker-publish.yml` builds `linux/amd64,linux/arm64` — multi-arch BuildKit images cannot be loaded into the local Docker daemon. The scan job does a separate `linux/amd64`-only build with `load: true`. All action refs use commit hashes matching the existing pattern in `docker-publish.yml`.

**Trivy binary vs. action:** The March 2026 attack poisoned `aquasecurity/trivy-action` and `aquasecurity/setup-trivy` tags. The Trivy binary downloaded directly at a pinned version (v0.69.3) is safe and is what this job uses.

## Test plan

- [ ] Open a PR and confirm the `container-scan` job runs and both Grype and Trivy steps pass
- [ ] Confirm `hardening.md` section 12 accurately reflects the automated CI job
- [ ] Trivy pin (`v0.69.3`) to be reviewed when Aqua publishes a confirmed post-remediation release

https://claude.ai/code/session_01FYa7R48r7NRkfynWMJEWEd