### PR TITLE
chore: untrack accidentally-committed .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"640f7fab-4474-409b-9cd7-de87d18410ea","pid":551182,"acquiredAt":1777131677613}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ nohup.out
 
 # Runtime PID lock files (machine-specific, never commit)
 .opendqv_*.lock
+.claude/*.lock
 
 # OpenAPI spec — generated dynamically by FastAPI at runtime (/openapi.json, /docs, /redoc)
 # Never commit the static file; it will always drift. Let FastAPI serve the live spec.


### PR DESCRIPTION
`.claude/scheduled_tasks.lock` is a Claude Code runtime lock committed by accident — the only file ever tracked under `.claude/`. It's machine-specific and transient, with no place in the repo. Removes it from the index and gitignores `.claude/*.lock` so it can't be re-committed (matching the existing `.opendqv_*.lock` rule).

Left untouched, deliberately:
- **`.opendqv_workbench.lock`** — a workbench process is actively holding it (live PID on port 8501); already gitignored.
- **`poetry.lock`** — dependency lockfile, not a temporary lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)