### PR TITLE
sec: stop echoing caught-exception detail to API clients (CWE-209)

### DIFF
--- a/opendqv/api/routes_federation.py
+++ b/opendqv/api/routes_federation.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -11,6 +12,8 @@ from fastapi.responses import StreamingResponse
 import opendqv.api.deps as _d
 import opendqv.config as config
 from opendqv.security.auth import get_current_user
+
+logger = logging.getLogger(__name__)
 
 sub_router = APIRouter()
 
@@ -202,7 +205,11 @@ async def federation_sync_status(
                         "count": len(diverged),
                     })
         except Exception as exc:
-            result["peer_error"] = str(exc)
+            # SEC/CWE-209: log the sync failure detail server-side; surface a
+            # generic, non-null marker to the client (kept truthy so callers can
+            # still detect that this peer failed).
+            logger.warning("federation sync: peer %r error: %s", peer, exc)
+            result["peer_error"] = "peer sync failed"
 
     return result
 

--- a/opendqv/core/importers/csv_rules.py
+++ b/opendqv/core/importers/csv_rules.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 
 import csv
 import io
+import logging
 from collections import Counter
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -234,11 +237,13 @@ def import_csv_rules(csv_content: str, contract_name: str = "csv_import") -> dic
         try:
             rule = handler(field, value)
         except Exception as exc:
+            # SEC/CWE-209: log detail server-side, return a generic reason.
+            logger.warning("CSV importer handler error (row %s, field %r, rule %r): %s", total, field, rule_type, exc)
             skipped.append({
                 "row": total,
                 "field": field,
                 "rule_type": rule_type,
-                "reason": f"handler error: {exc}",
+                "reason": "handler error",
             })
             continue
 

--- a/opendqv/core/importers/dbt.py
+++ b/opendqv/core/importers/dbt.py
@@ -7,9 +7,12 @@ tests as well as common dbt_utils and dbt_expectations tests.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections import Counter
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import yaml
 
@@ -181,10 +184,12 @@ def _process_column(column: dict, name_counter: Counter) -> tuple[list[dict], li
         try:
             partial_rules = handler(cfg, col_name)
         except Exception as exc:
+            # SEC/CWE-209: log detail server-side, return a generic reason.
+            logger.warning("dbt importer handler error for test %r (col %r): %s", test_name, col_name, exc)
             skipped.append({
                 "test": test_name,
                 "column": col_name,
-                "reason": f"handler error: {exc}",
+                "reason": "handler error",
             })
             continue
 

--- a/opendqv/core/importers/great_expectations.py
+++ b/opendqv/core/importers/great_expectations.py
@@ -6,9 +6,12 @@ Supports both GX 0.x and 1.x suite formats.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections import Counter
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import yaml
 
@@ -240,9 +243,12 @@ def import_gx_suite(suite_json: dict) -> dict:
         try:
             partial_rules = handler(kwargs)
         except Exception as exc:
+            # SEC/CWE-209: log the exception detail server-side; return a generic
+            # reason so a caught runtime error is not echoed to the API client.
+            logger.warning("GX importer handler error for %r: %s", exp_type, exc)
             skipped.append({
                 "expectation_type": exp_type,
-                "reason": f"handler error: {exc}",
+                "reason": "handler error",
             })
             continue
 

--- a/opendqv/core/importers/soda.py
+++ b/opendqv/core/importers/soda.py
@@ -7,9 +7,12 @@ inline check expressions like ``missing_count(email) = 0``.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections import Counter
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import yaml
 
@@ -285,9 +288,11 @@ def import_soda_checks(checks_yaml: dict) -> dict:
             try:
                 partial_rules = handler(field, operator, value, config)
             except Exception as exc:
+                # SEC/CWE-209: log detail server-side, return a generic reason.
+                logger.warning("Soda importer handler error for %s(%s): %s", metric, field, exc)
                 skipped.append({
                     "check": f"{metric}({field}) {operator} {value}",
-                    "reason": f"handler error: {exc}",
+                    "reason": "handler error",
                 })
                 continue
 

--- a/opendqv/core/trace_log.py
+++ b/opendqv/core/trace_log.py
@@ -230,7 +230,11 @@ def verify_trace_log(log_path: Optional[str] = None) -> dict:
             try:
                 entry = json.loads(line)
             except json.JSONDecodeError as e:
-                return {"valid": False, "broken_at": count, "entries": count, "error": f"JSON parse error: {e}"}
+                # SEC/CWE-209: log the parser detail server-side; return a generic
+                # location-only error (consistent with the sibling mismatch cases)
+                # rather than echoing the exception text to the caller.
+                logger.warning("trace log verify: JSON parse error at entry %d: %s", count, e)
+                return {"valid": False, "broken_at": count, "entries": count, "error": f"JSON parse error at entry {count}"}
 
             stored_prev = entry.get("prev_hash", "")
             stored_hash = entry.get("entry_hash", "")

--- a/tests/test_cwe209_error_message_hardening.py
+++ b/tests/test_cwe209_error_message_hardening.py
@@ -14,6 +14,7 @@ Two layers of guard:
 """
 
 import inspect
+import json
 
 import opendqv.api.routes_federation as _fed
 import opendqv.core.trace_log as _trace
@@ -21,6 +22,7 @@ import opendqv.core.importers.great_expectations as _gx
 import opendqv.core.importers.soda as _soda
 import opendqv.core.importers.dbt as _dbt
 import opendqv.core.importers.csv_rules as _csv
+from opendqv.core.importers.csv_rules import import_csv_rules
 
 
 # Vulnerable fragments assembled from parts so this file does not flag itself
@@ -51,6 +53,51 @@ class TestNoExceptionTextInResponses:
         src = inspect.getsource(_fed)
         assert _PEER_LEAK not in src
         assert 'result["peer_error"] = "peer sync failed"' in src
+
+
+def _raise(*_a, **_k):
+    raise KeyError("SECRET-LEAK-xyz")
+
+
+_SECRET = "SECRET-LEAK-xyz"
+
+
+class TestImporterHandlerErrorBehaviour:
+    """Trigger each importer's handler-error branch and assert the exception
+    text is NOT echoed into the result (only the generic reason is) — this also
+    exercises the server-side logging path the fix added."""
+
+    def test_gx_handler_error(self, monkeypatch):
+        from opendqv.core.importers.great_expectations import import_gx_suite
+        monkeypatch.setitem(_gx._HANDLERS, "expect_column_values_to_not_be_null", _raise)
+        suite = {"expectations": [
+            {"expectation_type": "expect_column_values_to_not_be_null",
+             "kwargs": {"column": "email"}}
+        ]}
+        result = import_gx_suite(suite)
+        assert _SECRET not in json.dumps(result)
+        assert any(s.get("reason") == "handler error" for s in result.get("skipped", []))
+
+    def test_soda_handler_error(self, monkeypatch):
+        from opendqv.core.importers.soda import import_soda_checks
+        monkeypatch.setitem(_soda._METRIC_HANDLERS, "missing_count", _raise)
+        result = import_soda_checks({"checks for customers": ["missing_count(email) = 0"]})
+        assert _SECRET not in json.dumps(result)
+
+    def test_dbt_handler_error(self, monkeypatch):
+        from opendqv.core.importers.dbt import import_dbt_schema
+        monkeypatch.setitem(_dbt._HANDLERS, "not_null", _raise)
+        schema = {"models": [
+            {"name": "m", "columns": [{"name": "c", "tests": ["not_null"]}]}
+        ]}
+        result = import_dbt_schema(schema)
+        assert _SECRET not in json.dumps(result)
+
+    def test_csv_handler_error(self, monkeypatch):
+        monkeypatch.setitem(_csv._RULE_HANDLERS, "not_empty", _raise)
+        result = import_csv_rules("field,rule_type,value\nemail,not_empty,\n", "t")
+        assert _SECRET not in json.dumps(result)
+        assert any(s.get("reason") == "handler error" for s in result.get("skipped", []))
 
 
 class TestTraceLogParseErrorBehaviour:

--- a/tests/test_cwe209_error_message_hardening.py
+++ b/tests/test_cwe209_error_message_hardening.py
@@ -1,0 +1,70 @@
+"""CWE-209 — caught exception detail must not be echoed to API clients.
+
+Regression guard for the 2026-08-05 hardening. Five CodeQL py/stack-trace-exposure
+findings shared one shape: a caught runtime exception's message was embedded into
+a response/result field (`str(exc)` / `f"...: {exc}"`). The fix logs the detail
+server-side and returns a generic, bounded message instead.
+
+Two layers of guard:
+  1. Source-level — the specific vulnerable expressions must not reappear in the
+     five hardened modules (catches a copy-paste regression directly).
+  2. Behavioural — the trace-log verifier returns a generic, location-only parse
+     error that keeps the stable "JSON parse error" prefix but drops the raw
+     JSONDecodeError text.
+"""
+
+import inspect
+
+import opendqv.api.routes_federation as _fed
+import opendqv.core.trace_log as _trace
+import opendqv.core.importers.great_expectations as _gx
+import opendqv.core.importers.soda as _soda
+import opendqv.core.importers.dbt as _dbt
+import opendqv.core.importers.csv_rules as _csv
+
+
+# Vulnerable fragments assembled from parts so this file does not flag itself
+# when the guard greps for them (mirrors the TestNoRegressedTestPatterns idiom).
+_EXC = "{" + "exc}"
+_E = "{" + "e}"
+_HANDLER_LEAK = "handler error: " + _EXC          # f"handler error: {exc}"
+_PARSE_LEAK = "JSON parse error: " + _E           # f"JSON parse error: {e}"
+_PEER_LEAK = 'peer_error"] = str(' + "exc)"       # result["peer_error"] = str(exc)
+
+
+class TestNoExceptionTextInResponses:
+    def test_importers_use_generic_handler_reason(self):
+        for mod in (_gx, _soda, _dbt, _csv):
+            src = inspect.getsource(mod)
+            assert _HANDLER_LEAK not in src, (
+                f"{mod.__name__} reintroduced raw exception text in a skip reason"
+            )
+            assert '"reason": "handler error"' in src, (
+                f"{mod.__name__} lost the generic handler-error reason"
+            )
+
+    def test_trace_log_parse_error_is_generic(self):
+        src = inspect.getsource(_trace)
+        assert _PARSE_LEAK not in src
+
+    def test_federation_peer_error_is_generic(self):
+        src = inspect.getsource(_fed)
+        assert _PEER_LEAK not in src
+        assert 'result["peer_error"] = "peer sync failed"' in src
+
+
+class TestTraceLogParseErrorBehaviour:
+    def test_json_parse_error_omits_exception_text(self, tmp_path):
+        bad = tmp_path / "trace.jsonl"
+        # Malformed JSON — the raw JSONDecodeError would name line/column/char.
+        bad.write_text("{not valid json at all\n", encoding="utf-8")
+        result = _trace.verify_trace_log(str(bad))
+        assert result["valid"] is False
+        # Stable prefix preserved (consumers/tests rely on it) ...
+        assert "JSON parse error" in result["error"]
+        # ... but the raw parser detail is gone.
+        assert "line 1" not in result["error"]
+        assert "column" not in result["error"]
+        assert "char" not in result["error"]
+        # It reports the entry index instead.
+        assert "entry" in result["error"]


### PR DESCRIPTION
Closes the 5 CodeQL **py/stack-trace-exposure** findings — a pre-existing
backlog, all the same shape: a caught runtime exception's message was embedded
into a response/result field and returned to the client.

## Fix — log server-side, return a generic message
| Site | Before | After |
|---|---|---|
| importers GX/soda/dbt/csv_rules | `"reason": f"handler error: {exc}"` | `"handler error"` (exc logged at WARNING) |
| core/trace_log.py (audit verify) | `f"JSON parse error: {e}"` | `"JSON parse error at entry N"` — keeps the stable prefix consumers rely on, drops raw parser detail |
| api/routes_federation.py | `result["peer_error"] = str(exc)` | generic `"peer sync failed"` (kept truthy so callers still detect failure) |

## Deliberately unchanged
The ~dozen `raise HTTPException(detail=str(exc))` sites — those are intentional
4xx validation feedback (pydantic/`ValueError` messages that help the caller fix
their request), and CodeQL correctly does **not** flag them. Only caught-runtime
exceptions leaking into otherwise-successful responses are hardened.

## Severity
All five are **low** — RBAC-bounded (editor/admin/auditor endpoints) and leak an
error *string*, not secrets or a full traceback. This is defense-in-depth, not a
live exposure.

## Tests
New recurrence guard (`tests/test_cwe209_error_message_hardening.py`): source-level
(the vulnerable expressions can't reappear) + behavioural (trace-log parse error
is generic). Full suite green: **4185 passed, 23 skipped**.

Note: the 14 py/path-injection (false positives — strict contract-name allowlist)
and 1 py/redos (deliberate test pattern) findings are handled separately by
dismissal in the Security tab, not by code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)