### PR TITLE
CRT177 Tier 1 — v2.3.29: NaN false-pass, checksum-500, SSRF IPv6-transition hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to OpenDQV are documented here.
 
+## [2.3.29] - 2026-08-06
+
+Security and correctness release (CRT177 Tier 1). Three fixes surfaced in a
+first-hand engine discovery pass; the SSRF rewrite was adversarially
+red-teamed across four rounds before merge (see Security). All fixes are
+independent of `AUTH_MODE` and apply in the default posture. No change to the
+contract format.
+
+### Fixed
+
+- **NaN / infinity false-pass in numeric rules (correctness).** A `NaN`
+  (or the string `"nan"`) passed `min`, `max`, and `range` rules on both the
+  single-record and batch paths — `NaN` compares `False` to every bound, and a
+  single-sided `min`/`max` rule also let `±inf` through. Non-finite values are
+  now rejected as a type mismatch (`OPENDQV_TYPE_MISMATCH`) with a clear
+  message. A genuinely-absent optional numeric field (missing key or `null`)
+  still passes — the batch path reads the original record value so a missing
+  field stays distinct from an explicit `NaN`.
+- **Unhandled-exception DoS on checksum rules (CWE-248 → HTTP 500).** A field
+  whose value contained a Unicode digit such as `²` (U+00B2) crashed the
+  validator: `str.isdigit()` accepts it but `int()` raises. Affected
+  `mod10_gs1`, `nhs_mod11`, `cpf_mod11`, and `isin_luhn`. Checksum inputs are
+  now validated as ASCII digits (a clean "invalid checksum"), and the
+  single-record path fails closed on any unexpected checker error rather than
+  returning 500 — matching the batch path.
+
+### Security
+
+- **SEC-008 — SSRF guard IPv6 bypasses.** The shared `assert_url_public` guard
+  (used by webhooks **and** the `lookup` rule fetcher) allowed several
+  internal-reaching addresses: `0.0.0.0`, IPv4-mapped IPv6
+  (`::ffff:169.254.169.254`), IPv6 link-local (`fe80::/10`), NAT64
+  (`64:ff9b::…`), IPv4-compatible (`::a9fe:a9fe`), ISATAP (`::5efe:…`), and
+  CGNAT (`100.64/10`). The guard was rewritten to an allowlist-by-
+  classification: it blocks **every** IPv6→IPv4 transition/embedding form
+  outright (IPv4-mapped, IPv4-compatible, NAT64 well-known prefix, 6to4,
+  Teredo, ISATAP) and otherwise permits only globally-routable addresses. The
+  same policy guards DNS-resolved addresses, closing DNS64/rebinding variants.
+  Residual (disclosed, architecturally unclosable): NAT64 operator
+  Network-Specific Prefixes and 6rd/MAP operator prefixes are indistinguishable
+  from ordinary global IPv6.
+- **SEC-008 — authenticated SSRF in `GET /federation/sync-status`.** The
+  caller-controlled `peer` parameter was fetched with no SSRF guard, allowing
+  any authenticated caller to make the server request an arbitrary internal
+  URL. `peer` is now validated through `assert_url_public` before the request
+  (HTTP 400 on a disallowed target).
+
 ## [2.3.28] - 2026-07-20
 
 Security release closing a secret-exfiltration hole in the `lookup` rule's

--- a/opendqv/api/routes_federation.py
+++ b/opendqv/api/routes_federation.py
@@ -174,6 +174,20 @@ async def federation_sync_status(
     }
 
     if peer:
+        # SEC-008: the peer URL is caller-controlled — it must pass the same
+        # SSRF guard as webhooks and lookup rules before we fetch it, or `peer`
+        # is an authenticated SSRF primitive (e.g.
+        # `http://169.254.169.254/latest/meta-data/?` reaching cloud metadata).
+        # A blocked/invalid peer is a client error (400), kept distinct from a
+        # genuine peer-sync failure below. httpx defaults follow_redirects=False
+        # so a single pre-request check is sufficient (no redirect-hop
+        # revalidation, unlike the urllib lookup fetcher). (CRT177)
+        from opendqv.core.webhooks import assert_url_public
+        try:
+            assert_url_public(peer, label="Federation peer URL")
+        except ValueError:
+            # Generic message — do not echo the parsed URL/IP back (CWE-209).
+            raise HTTPException(status_code=400, detail="Peer URL is not permitted.")
         try:
             async with httpx.AsyncClient(timeout=5.0) as http:
                 resp = await http.get(f"{peer.rstrip('/')}/api/v1/contracts")

--- a/opendqv/core/validator.py
+++ b/opendqv/core/validator.py
@@ -9,6 +9,7 @@ Both return structured results with per-field errors and severity.
 """
 
 import csv
+import math
 import os
 import re
 import logging
@@ -166,9 +167,29 @@ def validate_record(
 
     for rule in rules:
         value = record.get(rule.field)
-        failure = _check_rule(value, rule, record)
-        if not failure and rule.cached_has_age_constraint:
-            failure = _check_age(value, rule)
+        try:
+            failure = _check_rule(value, rule, record)
+            if not failure and rule.cached_has_age_constraint:
+                failure = _check_age(value, rule)
+        except Exception:
+            # Fail closed. An unexpected error inside a checker must never
+            # crash the worker — an unhandled exception surfaces as HTTP 500,
+            # a remotely-triggerable DoS. The batch path already fails closed
+            # on exception; bring the single-record path to parity by
+            # rejecting the record with a generic message (CWE-209: never
+            # echo the exception detail to the caller).
+            logger.exception(
+                "validate_record: checker raised on rule=%s field=%s — failing closed",
+                rule.name, rule.field,
+            )
+            errors.append(FieldError(
+                field=rule.field,
+                rule=rule.name,
+                message="Rule could not be evaluated; record rejected (fail-closed).",
+                severity=Severity.ERROR.value,
+                error_code="OPENDQV_RULE_ERROR",
+            ).to_dict())
+            continue
 
         if failure:
             # v2.3.23 outside-review #3: detect type-mismatch sentinel.
@@ -236,6 +257,18 @@ def _check_condition(rule: Rule, record: Optional[dict]) -> bool:
     return True
 
 
+def _is_ascii_digits(s: str) -> bool:
+    """True only for a non-empty run of ASCII 0-9.
+
+    str.isdigit() also returns True for Unicode digit characters such as
+    superscripts (U+00B2 '²') and other scripts' digits, but int() raises on
+    the former — so an isdigit()-gated int() is an unhandled-ValueError (500)
+    primitive. An identifier check-string is never validly non-ASCII, so
+    reject those here and return a clean "invalid checksum" instead of crashing.
+    """
+    return s.isascii() and s.isdigit()
+
+
 def _validate_checksum(value: str, algorithm: str) -> bool:
     """Validate identifier check digits. Returns True if checksum is valid."""
     s = str(value).strip().upper()
@@ -243,7 +276,7 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
     if algorithm == "mod10_gs1":
         # GS1 Mod-10 — used for GTIN-8, GTIN-12, GTIN-13, GTIN-14, GLN, SSCC
         digits = s.replace(" ", "").replace("-", "")
-        if not digits.isdigit():
+        if not _is_ascii_digits(digits):
             return False
         total = 0
         for i, d in enumerate(reversed(digits[:-1])):
@@ -262,7 +295,7 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
         for ch in rearranged:
             if ch.isalpha():
                 numeric += str(ord(ch) - ord('A') + 10)
-            elif ch.isdigit():
+            elif ch in "0123456789":
                 numeric += ch
             else:
                 return False
@@ -288,9 +321,11 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
         for ch in s[:-1]:
             if ch.isalpha():
                 expanded += str(ord(ch) - ord('A') + 10)
-            elif ch.isdigit():
+            elif ch in "0123456789":
                 expanded += ch
             else:
+                # Reject Unicode digits (str.isdigit() True but int() raises)
+                # and any other non-alphanumeric — invalid, not a crash.
                 return False
         # Luhn on expanded digits
         total = 0
@@ -315,7 +350,7 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
         for ch in s:
             if ch.isalpha():
                 numeric += str(ord(ch) - ord('A') + 10)
-            elif ch.isdigit():
+            elif ch in "0123456789":
                 numeric += ch
             else:
                 return False
@@ -327,7 +362,7 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
     elif algorithm == "nhs_mod11":
         # NHS Number: 10 digits, weights 10..2, check digit is last
         digits = s.replace(" ", "")
-        if len(digits) != 10 or not digits.isdigit():
+        if len(digits) != 10 or not _is_ascii_digits(digits):
             return False
         total = sum(int(d) * w for d, w in zip(digits[:9], range(10, 1, -1)))
         remainder = total % 11
@@ -341,7 +376,7 @@ def _validate_checksum(value: str, algorithm: str) -> bool:
     elif algorithm == "cpf_mod11":
         # Brazilian CPF: 11 digits, two check digits
         digits = s.replace(".", "").replace("-", "")
-        if len(digits) != 11 or not digits.isdigit():
+        if len(digits) != 11 or not _is_ascii_digits(digits):
             return False
         if len(set(digits)) == 1:
             return False  # all same digit is invalid
@@ -481,6 +516,18 @@ _TYPE_MISMATCH_PREFIX = "__OPENDQV_TYPE_MISMATCH__::"
 
 
 def _type_mismatch_msg(rule: Rule, value) -> str:
+    # A NaN or infinity is not a valid finite measurement — the canonical
+    # "corrupt number" a broken upstream pipeline emits. It parses as a float
+    # but must never satisfy a numeric bound (NaN compares False to every
+    # bound; ±inf slips single-sided min/max rules), so it surfaces here as a
+    # type/domain mismatch with an accurate, non-generic message.
+    if isinstance(value, float) and not math.isfinite(value):
+        got = "NaN" if math.isnan(value) else "infinity"
+        return (
+            f"{_TYPE_MISMATCH_PREFIX}"
+            f"{rule.type} rule on field '{rule.field}' expected a finite "
+            f"numeric value, got {got}"
+        )
     return (
         f"{_TYPE_MISMATCH_PREFIX}"
         f"{rule.type} rule on field '{rule.field}' expected numeric "
@@ -510,7 +557,10 @@ def _check_min(value, rule: Rule, record: Optional[dict] = None) -> Optional[str
         except (TypeError, ValueError):
             return _type_mismatch_msg(rule, value)
     try:
-        if float(value) < rule.min_value:
+        v = float(value)
+        if not math.isfinite(v):
+            return _type_mismatch_msg(rule, value)
+        if v < rule.min_value:
             return rule.error_message
     except (TypeError, ValueError):
         return _type_mismatch_msg(rule, value)
@@ -526,7 +576,10 @@ def _check_max(value, rule: Rule, record: Optional[dict] = None) -> Optional[str
         except (TypeError, ValueError):
             return _type_mismatch_msg(rule, value)
     try:
-        if float(value) > rule.max_value:
+        v = float(value)
+        if not math.isfinite(v):
+            return _type_mismatch_msg(rule, value)
+        if v > rule.max_value:
             return rule.error_message
     except (TypeError, ValueError):
         return _type_mismatch_msg(rule, value)
@@ -543,6 +596,8 @@ def _check_range(value, rule: Rule, record: Optional[dict] = None) -> Optional[s
             return _type_mismatch_msg(rule, value)
     try:
         v = float(value)
+        if not math.isfinite(v):
+            return _type_mismatch_msg(rule, value)
         if rule.min_value is not None and v < rule.min_value:
             return rule.error_message
         if rule.max_value is not None and v > rule.max_value:
@@ -1358,6 +1413,7 @@ def validate_batch(
             try:
                 failing_indices = _batch_check_rule(
                     con, df, rule, failing_type_mismatches=failing_type_mismatches,
+                    records=records,
                 )
             except Exception as e:
                 # Log only rule metadata — never include record field values.
@@ -1468,7 +1524,7 @@ def validate_batch(
     }
 
 
-def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches: Optional[dict] = None) -> set[int]:
+def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches: Optional[dict] = None, records: Optional[list[dict]] = None) -> set[int]:
     """Run a single rule against the batch via DuckDB. Returns set of failing row indices.
 
     v2.3.23 outside-review #3 (Sonnet aec401d0381905d97): for numeric
@@ -1476,11 +1532,29 @@ def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches
     is populated as `{idx: type_mismatch_message}` so the caller can
     swap the error_code to OPENDQV_TYPE_MISMATCH on those rows. Other
     rule types are unaffected.
+
+    `records` is the original list of dicts (row idx aligned with df).
+    The numeric branches read the raw value from it rather than the
+    DataFrame cell: pandas collapses a missing key AND an explicit NaN
+    both to np.nan, which would make an absent optional numeric field
+    (legitimately skipped) indistinguishable from a corrupt NaN value
+    (must be rejected). Reading the original dict restores the single-
+    record semantics exactly — missing key → None → absent → pass;
+    explicit NaN/inf → rejected as non-finite.
     """
     field = rule.field
     failing = set()
     if failing_type_mismatches is None:
         failing_type_mismatches = {}
+
+    def _orig_val(idx):
+        # Numeric branches read the raw record value so a missing key
+        # (absent → skip) stays distinct from an explicit NaN/inf
+        # (non-finite → reject). Defensive fallback to the DataFrame cell
+        # if records was not supplied (records is always passed today).
+        if records is not None:
+            return records[idx].get(field)
+        return df[field].iloc[idx]
 
     if rule.type == "regex" and rule.pattern:
         # DuckDB doesn't support \w, \s, \d shorthand classes — fall back to Python.
@@ -1515,7 +1589,7 @@ def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches
         # violation. Per-row check is slower (~10x) but correct;
         # v2.4 may reintroduce a hybrid TRY_CAST + per-row fallback.
         for idx in range(len(df)):
-            failure = _check_min(df[field].iloc[idx], rule)
+            failure = _check_min(_orig_val(idx), rule)
             if failure is not None:
                 failing.add(idx)
                 if failure.startswith(_TYPE_MISMATCH_PREFIX):
@@ -1523,7 +1597,7 @@ def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches
 
     elif rule.type == "max" and rule.max_value is not None:
         for idx in range(len(df)):
-            failure = _check_max(df[field].iloc[idx], rule)
+            failure = _check_max(_orig_val(idx), rule)
             if failure is not None:
                 failing.add(idx)
                 if failure.startswith(_TYPE_MISMATCH_PREFIX):
@@ -1531,7 +1605,7 @@ def _batch_check_rule(con, df: pd.DataFrame, rule: Rule, failing_type_mismatches
 
     elif rule.type == "range" and rule.min_value is not None and rule.max_value is not None:
         for idx in range(len(df)):
-            failure = _check_range(df[field].iloc[idx], rule)
+            failure = _check_range(_orig_val(idx), rule)
             if failure is not None:
                 failing.add(idx)
                 if failure.startswith(_TYPE_MISMATCH_PREFIX):

--- a/opendqv/core/webhooks.py
+++ b/opendqv/core/webhooks.py
@@ -69,30 +69,79 @@ BATCH_EVENT_SCHEMA = {
 }
 
 
-# Private/reserved IP ranges that must not be reachable via webhook URLs.
-# Prevents SSRF attacks where a registered webhook causes the server to probe
-# internal infrastructure (cloud metadata, Docker internal network, etc.).
-_BLOCKED_NETWORKS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata (AWS/GCP/Azure)
-    ipaddress.ip_network("127.0.0.0/8"),       # loopback
-    ipaddress.ip_network("::1/128"),            # IPv6 loopback
-    ipaddress.ip_network("fc00::/7"),           # IPv6 unique-local
-]
+# RFC 6052 NAT64 Well-Known Prefix. is_global is True for the whole /96
+# regardless of the embedded IPv4, so where a NAT64 gateway is on-path
+# (IPv6-only cloud subnets, e.g. IPv6-only EKS/GKE nodes) a literal such as
+# 64:ff9b::a9fe:a9fe would reach 169.254.169.254 (cloud metadata). Unwrap and
+# classify the embedded IPv4 instead. Residual: operator-chosen Network-
+# Specific Prefixes (RFC 6052 §2.2) are indistinguishable from ordinary global
+# IPv6 and cannot be closed by a generic classifier — accepted risk, same tier
+# as Teredo and the DNS-rebinding TOCTOU. (CRT177 pre-impl red-team, Sonnet.)
+# IPv6 → IPv4 transition / embedding forms. Each one carries or tunnels an
+# IPv4 that `ipaddress.is_global` does NOT see (it classifies the v6 wrapper,
+# not the embedded v4), so each is an SSRF bypass if allowed. We do NOT try to
+# unwrap-and-selectively-allow (that design missed NAT64, then IPv4-compatible,
+# then ISATAP across three review rounds — every miss was a live bypass).
+# Instead we BLOCK the whole transition space outright: none of these literal
+# forms has a legitimate webhook/lookup-egress use, so blocking them is
+# fail-safe (a detected form is blocked even if we could not correctly extract
+# its embedded v4). Detectable set, by prefix:
+#   ::ffff:0:0/96  IPv4-mapped          (RFC 4291 §2.5.5.2)
+#   ::/96          IPv4-compatible       (RFC 4291 §2.5.5.1, deprecated)
+#   64:ff9b::/96   NAT64 well-known      (RFC 6052)
+#   2002::/16      6to4                  (RFC 3056)
+#   2001::/32      Teredo                (RFC 4380)
+# plus ISATAP (RFC 5214), matched by its interface-id signature below.
+# Residual accepted risk (indistinguishable from ordinary global IPv6 without
+# out-of-band knowledge, same tier as the DNS-rebinding TOCTOU): NAT64
+# operator-chosen Network-Specific Prefixes (RFC 6052 §2.2) and 6rd
+# operator prefixes (RFC 5969).
+_IPV6_TRANSITION_PREFIXES = (
+    ipaddress.ip_network("::ffff:0:0/96"),
+    ipaddress.ip_network("::/96"),
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("2002::/16"),
+    ipaddress.ip_network("2001::/32"),
+)
+
+# ISATAP interface identifier (low 64 bits): 0000:5EFE:v4 (private/any v4) or
+# 0200:5EFE:v4 (U/L bit set, public v4), under ANY routing prefix — so it is
+# matched by bits 32–63 rather than by a prefix. (Caught in CRT177 round-3
+# re-verify, Sonnet.)
+_ISATAP_IID_SIGNATURES = (0x00005EFE, 0x02005EFE)
+
+
+def _is_transition_ipv6(ip) -> bool:
+    """True if `ip` is any IPv6 transition/embedding form that carries or
+    tunnels an IPv4 (see _IPV6_TRANSITION_PREFIXES). Such forms are blocked
+    wholesale for SSRF safety."""
+    if not isinstance(ip, ipaddress.IPv6Address):
+        return False
+    if any(ip in net for net in _IPV6_TRANSITION_PREFIXES):
+        return True
+    if ((int(ip) >> 32) & 0xFFFFFFFF) in _ISATAP_IID_SIGNATURES:
+        return True
+    return False
 
 
 def _is_private_ip(ip_str: str) -> bool:
-    """Return True if the IP address string belongs to a blocked (private/reserved) network."""
+    """SEC-008: True if the address must be blocked for SSRF.
+
+    Two rules, both fail-safe:
+      1. Any IPv6 transition/embedding form (see _is_transition_ipv6) — blocked
+         outright, because is_global cannot see the embedded/tunnelled IPv4.
+      2. Otherwise, allow only globally-routable addresses (is_global). This
+         allowlist-by-classification covers private/RFC1918, loopback,
+         link-local, cloud-metadata, reserved, unspecified, multicast, and
+         CGNAT in one check — the old hand-rolled denylist missed 0.0.0.0/8,
+         fe80::/10, and every mapped form (all confirmed bypasses, CRT177)."""
     try:
         ip = ipaddress.ip_address(ip_str)
-        for network in _BLOCKED_NETWORKS:
-            if ip in network:
-                return True
-        return False
     except ValueError:
         return False
+    if _is_transition_ipv6(ip):
+        return True
+    return not ip.is_global
 
 
 def _check_resolved_ips(hostname: str, url: str, label: str = "Webhook URL") -> None:
@@ -156,21 +205,21 @@ def assert_url_public(url: str, label: str = "URL") -> None:
     if hostname.lower() in ("localhost", "localhost.localdomain"):
         raise ValueError(f"{label} must not target localhost: {url!r}")
 
-    # If the hostname is a literal IP address, check directly
+    # If the hostname is a literal IP address, classify it directly.
     try:
         ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None  # not an IP literal — fall through to DNS resolution
+
+    if ip is not None:
         if _is_private_ip(str(ip)):
             raise ValueError(
                 f"{label} targets a private/reserved IP address ({ip}): {url!r}"
             )
-        # It's a valid public literal IP — no DNS resolution needed
+        # Valid globally-routable literal IP — no DNS resolution needed.
         return
-    except ValueError as exc:
-        if label in str(exc):
-            raise
-        # Not a valid IP literal — proceed to DNS resolution
 
-    # SEC-008: DNS rebinding protection — resolve and check every returned IP
+    # SEC-008: DNS rebinding protection — resolve and check every returned IP.
     _check_resolved_ips(hostname, url, label)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opendqv"
-version = "2.3.28"
+version = "2.3.29"
 description = "OpenDQV Core — open-source, contract-driven data quality validation engine for data pipelines and API boundaries"
 authors = ["Sunny Sharma"]
 license = "MIT"

--- a/tests/test_crt177_ssrf.py
+++ b/tests/test_crt177_ssrf.py
@@ -1,0 +1,71 @@
+"""
+CRT177 Tier 1 SSRF recurrence tests (Protocol 32 — pair every fix with its guard).
+
+The shared SEC-008 SSRF guard (assert_url_public — webhooks + lookup rules)
+allowed 0.0.0.0, IPv4-mapped IPv6, IPv6 link-local, NAT64, ISATAP, and CGNAT.
+Rewritten to BLOCK every IPv6→IPv4 transition/embedding form WHOLESALE and
+allow only plain global unicast (see opendqv/core/webhooks.py). Three prior
+"unwrap-and-allow" designs each missed a distinct form (NAT64, IPv4-compatible,
+ISATAP) — Sonnet caught all three; the wholesale block ends the class.
+
+The federation sync-status route wiring (finding #3) is guarded in
+tests/test_federation_api.py::TestFederationSyncCompare.test_sync_rejects_ssrf_peer.
+"""
+import pytest
+
+from opendqv.core.webhooks import assert_url_public
+
+
+class TestSSRFGuardBlocklist:
+    MUST_BLOCK = [
+        "http://0.0.0.0:8000/",
+        "http://0:8000/",
+        "http://127.0.0.1:8000/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://100.64.1.1/",                          # CGNAT
+        "http://[::ffff:169.254.169.254]/",            # IPv4-mapped IMDS
+        "http://[::ffff:127.0.0.1]:8000/",             # IPv4-mapped loopback
+        "http://[fe80::1]/",                           # IPv6 link-local
+        "http://[::]/",                                # unspecified
+        "http://[64:ff9b::a9fe:a9fe]/",                # NAT64 → 169.254.169.254 (Sonnet r1)
+        "http://[64:ff9b::7f00:1]/",                   # NAT64 → 127.0.0.1
+        "http://[::a9fe:a9fe]/",                       # IPv4-compatible → 169.254.169.254 (Sonnet r2)
+        "http://[::7f00:1]/",                          # IPv4-compatible → 127.0.0.1
+        "http://[::a00:1]/",                           # IPv4-compatible → 10.0.0.1
+        "http://[::5efe:169.254.169.254]/",            # ISATAP → 169.254.169.254 (Sonnet r3)
+        "http://[::5efe:127.0.0.1]/",                  # ISATAP → 127.0.0.1
+        "http://[::200:5efe:a9fe:a9fe]/",              # ISATAP U/L-bit signature (0200:5efe)
+        "http://[2001:db8::5efe:a9fe:a9fe]/",          # ISATAP under a non-Teredo prefix (IID signature catch)
+        "http://[2002:a00:1::]/",                      # 6to4 → 10.0.0.1
+        "http://[2002:808:808::]/",                    # 6to4 → 8.8.8.8 — transition form blocked wholesale
+        "http://[::ffff:8.8.8.8]/",                    # IPv4-mapped public — transition form blocked wholesale
+        "http://2130706433/",                          # decimal 127.0.0.1 (via getaddrinfo)
+        "http://localhost/",
+        "http://[2001:db8::1]/",                       # documentation range (not global)
+        "ftp://example.com/",                          # non-http scheme
+    ]
+    MUST_ALLOW = [
+        "https://example.com/webhook",
+        "http://8.8.8.8/",
+        "http://1.1.1.1/",
+        "http://[2606:4700:4700::1111]/",              # Cloudflare public v6 (plain global unicast)
+        "http://[2620:fe::fe]/",                       # Quad9 public v6 (plain global unicast)
+    ]
+
+    @pytest.mark.parametrize("url", MUST_BLOCK)
+    def test_blocked(self, url):
+        with pytest.raises(ValueError):
+            assert_url_public(url, label="Test URL")
+
+    @pytest.mark.parametrize("url", MUST_ALLOW)
+    def test_allowed(self, url):
+        assert_url_public(url, label="Test URL")  # must not raise
+
+    def test_userinfo_does_not_smuggle_internal_host(self):
+        # urlparse().hostname must resolve to the real target, not be fooled by
+        # embedded credentials pointing the visible host elsewhere.
+        with pytest.raises(ValueError):
+            assert_url_public("http://public.com@169.254.169.254/", label="Test URL")

--- a/tests/test_crt177_validator.py
+++ b/tests/test_crt177_validator.py
@@ -1,0 +1,105 @@
+"""
+CRT177 Tier 1 validator recurrence tests (Protocol 32 — pair every fix with its guard).
+
+Two engine-correctness fixes from the Fable 5 discovery pass (2026-08-06):
+
+  #1  NaN / ±inf silently passed every numeric rule (min/max/range) on both
+      the single-record and DuckDB batch paths — a false-pass in the engine's
+      core job. Now rejected as a non-finite type mismatch, WITHOUT regressing
+      a genuinely-absent optional numeric field (missing key / null → pass).
+
+  #2  Unicode-digit input to checksum rules crashed the validator with an
+      unhandled ValueError (str.isdigit() accepts '²' but int('²') raises) →
+      HTTP 500 DoS on /validate. Now a clean "invalid checksum". Plus a
+      fail-closed safety net so no future checker exception can 500 the worker.
+"""
+import pytest
+
+from opendqv.core.validator import validate_record, validate_batch
+from opendqv.core.rule_parser import Rule
+
+
+# ── #1 NaN / inf ────────────────────────────────────────────────────────────
+class TestNonFiniteNumericRejected:
+    def _rules(self):
+        return [
+            Rule(name="min", field="p", type="min", min_value=0),
+            Rule(name="max", field="p", type="max", max_value=100),
+            Rule(name="rng", field="p", type="range", min_value=0, max_value=100),
+        ]
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), "nan"])
+    def test_single_record_rejects_non_finite(self, bad):
+        r = validate_record({"p": bad}, self._rules())
+        assert r["valid"] is False
+        assert r["errors"], f"{bad!r} should have produced an error"
+
+    def test_nan_message_is_accurate(self):
+        r = validate_record({"p": float("nan")}, [Rule(name="min", field="p", type="min", min_value=0)])
+        assert "finite" in r["errors"][0]["message"].lower()
+        assert r["errors"][0]["error_code"] == "OPENDQV_TYPE_MISMATCH"
+
+    @pytest.mark.parametrize("good", [0, 50, 100, 0.0, "50", "28.50"])
+    def test_valid_finite_values_still_pass(self, good):
+        r = validate_record({"p": good}, self._rules())
+        assert r["valid"] is True, f"{good!r} should pass"
+
+    def test_min_only_rule_rejects_inf(self):
+        # Regression: inf < min is False, so a single-sided min rule used to
+        # let +inf through. It must now fail as non-finite.
+        r = validate_record({"p": float("inf")}, [Rule(name="min", field="p", type="min", min_value=0)])
+        assert r["valid"] is False
+
+    def test_batch_rejects_nan_and_inf(self):
+        rule = Rule(name="min", field="price", type="min", min_value=0)
+        records = [
+            {"price": 50},           # 0 pass
+            {"price": float("nan")}, # 1 reject
+            {"price": -5},           # 2 fail (below min)
+            {},                      # 3 pass — missing optional field
+            {"price": None},         # 4 pass — null → absent
+            {"price": float("inf")}, # 5 reject
+        ]
+        res = validate_batch(records, [rule])
+        by_idx = {r["index"]: r for r in res["results"]}
+        assert by_idx[0]["valid"] is True
+        assert by_idx[1]["valid"] is False
+        assert by_idx[2]["valid"] is False
+        assert by_idx[3]["valid"] is True   # no regression: absent optional numeric
+        assert by_idx[4]["valid"] is True   # no regression: null → absent
+        assert by_idx[5]["valid"] is False
+
+    def test_batch_missing_optional_numeric_not_regressed(self):
+        # A whole batch of records omitting an optional numeric field must all
+        # pass a min/max rule — the pandas NaN-for-missing must not be read as
+        # a non-finite value.
+        rule = Rule(name="max", field="score", type="max", max_value=100)
+        records = [{"other": "x"} for _ in range(20)]
+        res = validate_batch(records, [rule])
+        assert res["summary"]["failed"] == 0
+
+
+# ── #2 checksum unicode-digit crash ─────────────────────────────────────────
+class TestChecksumUnicodeDigitNoCrash:
+    ALGOS = ["mod10_gs1", "nhs_mod11", "cpf_mod11", "isin_luhn", "iban_mod97", "lei_mod97"]
+
+    @pytest.mark.parametrize("algo", ALGOS)
+    @pytest.mark.parametrize("length", [8, 10, 11, 12, 20])
+    def test_unicode_digits_do_not_crash(self, algo, length):
+        # '²' (U+00B2): str.isdigit() True, int('²') raises. Must be a clean
+        # invalid result, never an unhandled exception.
+        rule = Rule(name=algo, field="c", type="checksum", checksum_algorithm=algo)
+        res = validate_record({"c": "²" * length}, [rule])
+        assert res["valid"] is False
+
+    @pytest.mark.parametrize("algo", ALGOS)
+    def test_mixed_unicode_and_ascii_digits(self, algo):
+        rule = Rule(name=algo, field="c", type="checksum", checksum_algorithm=algo)
+        res = validate_record({"c": "12²456789012"}, [rule])
+        assert res["valid"] is False
+
+    def test_valid_gtin_still_passes(self):
+        # A real valid GTIN-13 must still validate (fix rejects only non-ASCII).
+        rule = Rule(name="gtin", field="c", type="checksum", checksum_algorithm="mod10_gs1")
+        res = validate_record({"c": "4006381333931"}, [rule])
+        assert res["valid"] is True

--- a/tests/test_federation_api.py
+++ b/tests/test_federation_api.py
@@ -175,13 +175,19 @@ class TestFederationSyncCompare:
         assert data["peer_error"] is None
 
     def test_sync_with_unreachable_peer_sets_peer_error(self, client, auth_headers):
-        """When peer is unreachable, peer_error is populated (lines 204-205)."""
+        """When peer is unreachable, peer_error is populated (lines 204-205).
+
+        CRT177: the peer must be a public IP so it passes the SSRF guard
+        (added to this endpoint); the httpx layer is still mocked to simulate
+        the connection failure. A hostname like ``unreachable.invalid`` would
+        now fail closed at the guard (NXDOMAIN → 400) before httpx is reached.
+        """
         import httpx as _httpx
         import unittest.mock as mock
 
         with mock.patch("httpx.AsyncClient.get", side_effect=_httpx.ConnectError("refused")):
             r = client.get(
-                "/api/v1/federation/sync-status?peer=http://unreachable.invalid",
+                "/api/v1/federation/sync-status?peer=http://8.8.8.8/",
                 headers=auth_headers,
             )
 
@@ -200,7 +206,9 @@ class TestFederationSyncCompare:
 
         with mock.patch("httpx.AsyncClient.get", return_value=mock_resp):
             r = client.get(
-                "/api/v1/federation/sync-status?peer=http://mock-peer.local",
+                # CRT177: public IP peer so it passes the SSRF guard; the
+                # httpx response is mocked to drive the divergence path.
+                "/api/v1/federation/sync-status?peer=http://8.8.8.8/",
                 headers=auth_headers,
             )
 
@@ -208,6 +216,29 @@ class TestFederationSyncCompare:
         data = r.json()
         assert isinstance(data["diverged"], list)
         assert data["peer_error"] is None
+
+    def test_sync_rejects_ssrf_peer(self, client, auth_headers):
+        """CRT177 finding #3: a caller-controlled peer that targets an
+        internal/loopback/metadata address must be rejected with 400 BEFORE
+        any request is made — not fetched and echoed. Recurrence guard for the
+        authenticated-SSRF hole in GET /federation/sync-status."""
+        import unittest.mock as mock
+
+        ssrf_peers = [
+            "http://169.254.169.254/latest/meta-data/?",  # cloud metadata (path neutralised with ?)
+            "http://127.0.0.1:8000/",                     # loopback
+            "http://[::ffff:169.254.169.254]/",           # IPv4-mapped IPv6 metadata
+            "http://[64:ff9b::a9fe:a9fe]/",               # NAT64-embedded metadata
+            "http://10.0.0.1/",                           # RFC1918
+        ]
+        # If the guard ever regresses, this mock proves no outbound call slipped through.
+        with mock.patch("httpx.AsyncClient.get", side_effect=AssertionError("SSRF: request must not be made")):
+            for peer in ssrf_peers:
+                r = client.get(
+                    f"/api/v1/federation/sync-status?peer={peer}",
+                    headers=auth_headers,
+                )
+                assert r.status_code == 400, f"{peer!r} should be rejected, got {r.status_code}"
 
 
 class TestFederationSSEStream:

--- a/tests/test_p1_features.py
+++ b/tests/test_p1_features.py
@@ -704,15 +704,17 @@ class TestFederationSyncStatus:
         r = client.get("/api/v1/federation/sync-status", headers=auth_headers)
         assert r.json()["diverged"] == []
 
-    def test_with_unreachable_peer_returns_peer_error(self, client, auth_headers):
+    def test_localhost_peer_rejected_ssrf(self, client, auth_headers):
+        # CRT177 finding #3: a localhost/internal peer must be rejected by the
+        # SSRF guard (400) before any request is made — previously this was
+        # fetched, making `peer` an authenticated SSRF primitive. The
+        # unreachable-public-peer → peer_error path is covered in
+        # test_federation_api.py::TestFederationSyncCompare.
         r = client.get(
             "/api/v1/federation/sync-status?peer=http://localhost:19999",
             headers=auth_headers,
         )
-        assert r.status_code == 200
-        data = r.json()
-        assert data["peer"] == "http://localhost:19999"
-        assert data["peer_error"] is not None
+        assert r.status_code == 400
 
     def test_node_id_matches_config(self, client, auth_headers):
         import opendqv.config as config


### PR DESCRIPTION
## CRT177 Tier 1 — security + correctness release (v2.3.29)

Three fixes from a first-hand engine discovery pass. All are independent of `AUTH_MODE` and bite in the default posture. No contract-format change. The SSRF rewrite was adversarially red-teamed by Sonnet across four rounds before merge.

### Fixes

**1. NaN / ±inf false-pass in numeric rules (correctness).** `{"price": NaN}` (and the string `"nan"`) passed `min`/`max`/`range` on both single-record and batch paths — `NaN` compares `False` to every bound, and a single-sided `min`/`max` rule also let `±inf` through. Non-finite values now reject as `OPENDQV_TYPE_MISMATCH`. The batch path reads the original record value so a **missing** optional numeric field (pandas `np.nan`) stays distinct from an **explicit** `NaN` — no regression for absent/null.

**2. Checksum unhandled-exception DoS (CWE-248 → HTTP 500).** A Unicode digit such as `²` (U+00B2) crashed the validator (`str.isdigit()` True, `int()` raises) on `mod10_gs1`/`nhs_mod11`/`cpf_mod11`/`isin_luhn`. Checksum inputs are now ASCII-digit validated, and `validate_record` fails closed on any unexpected checker error — matching the batch path.

**3. SEC-008 SSRF hardening.** The shared `assert_url_public` guard (webhooks **and** lookup rules) allowed `0.0.0.0`, IPv4-mapped IPv6, link-local, NAT64, IPv4-compatible, ISATAP, and CGNAT. The prior "unwrap-then-allow" design was bypass-by-default (Sonnet broke it three times, each a distinct form). Replaced with a **fail-safe wholesale block** of every IPv6→IPv4 transition/embedding form, allowing only globally-routable addresses; the same policy guards DNS-resolved addresses. Also: `GET /federation/sync-status` fetched the caller-controlled `peer` with **no** guard (authenticated SSRF) — now validated through `assert_url_public` (HTTP 400 on a disallowed target). Fourth review round verdict: *ENDS-THE-CLASS*.

Disclosed residual (architecturally unclosable, in code comments): NAT64 operator NSP + 6rd/MAP operator prefixes are indistinguishable from ordinary global IPv6.

### Tests
- New `tests/test_crt177_validator.py` (NaN single+batch incl. no-regression; checksum crash class).
- New `tests/test_crt177_ssrf.py` (full block/allow vector table incl. NAT64/IPv4-compatible/ISATAP).
- Federation SSRF-peer rejection guard + two federation tests updated off the old fetch-any-peer behaviour.
- Full suite: **4275 passed, 23 skipped, 0 failed** (baseline 4189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)