### PR TITLE
CRT177 Tier 2 — v2.3.30: contract governance (profiler/import overwrite, status authz, lifecycle persistence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to OpenDQV are documented here.
 
+## [2.3.30] - 2026-08-06
+
+Contract-governance release (CRT177 Tier 2, patch tier). Closes four paths that
+bypassed ACTIVE-contract immutability, the maker-checker approval workflow, or
+both. Design reviewed before implementation. No public API change; no contract
+format change.
+
+**Behaviour change worth noting:** `POST /import/*?save=true` now genuinely
+persists as `draft`. The CSV and ODCS importers previously landed as `active`
+because the status stamp was written to the wrong level of the YAML document —
+the route already *documented* and *reported* `draft`, so this aligns disk with
+the documented contract rather than changing it.
+
+### Security
+
+- **Profiler contract-save was unguarded and destructive.** `POST /profile?save=true`
+  and `POST /profile/file?save=true` had no role guard — every `/import/*`
+  sibling requires `editor`/`admin` (SEC-010) — and wrote with a bare
+  `open(name.yaml, "w")` and no existence check. Because the name is
+  caller-supplied, `?contract_name=customer&save=true` **replaced a live ACTIVE
+  contract** with profiler-generated rules and reloaded it, defeating ACTIVE
+  immutability and the approval workflow in one unprivileged request. Now
+  requires `editor`/`admin`, and returns `409` rather than overwriting any
+  existing non-DRAFT contract. Profiling *without* `save` is unchanged.
+- **Contract status changes were authorized only when promoting to ACTIVE.**
+  `POST /contracts/{name}/status` checked the caller's role solely for the
+  ACTIVE target, so any authenticated principal — including `reader`,
+  `auditor`, and `validator` — could archive or demote a production contract.
+  Archiving a live contract is a validation outage; demoting one to DRAFT
+  unlocks rule mutation, so demote-then-edit defeated maker-checker. Any
+  transition **to** or **out of** ACTIVE now requires `approver`/`admin`; all
+  other transitions require `editor`/`admin`.
+- **Imports could persist as ACTIVE, skipping approval.** The import routes
+  stamped `status`/`source`/`created_by` onto the top level of the YAML
+  document while the loader reads them from the nested `contract:` block, so
+  every stamp was a silent no-op. The CSV importer (hardcoded `active`) and the
+  ODCS importer (caller-controlled `info.status`) therefore persisted as ACTIVE
+  — live, immutable, never approved. Provenance is now recorded on all eight
+  importers (`created_by` maps to `proposed_by`).
+- **Imports could overwrite a live ACTIVE contract.** The contract name is
+  caller-supplied and the import write had no existence check, so
+  `POST /import/*?save=true` aimed at an existing contract replaced its rules
+  wholesale — and, once imports correctly landed as DRAFT, demoted it too,
+  which is precisely what the status guard above restricts to approver/admin.
+  Both bulk-write surfaces (import and profiler) now share one guard: `409`
+  unless the target contract is absent or already DRAFT. A read-only import
+  preview (`save=false`) onto an existing name is unaffected.
+
+### Fixed
+
+- **Contract lifecycle state did not survive a reload.** The YAML serializer
+  wrote only `rules` and `version`, so `submit_for_review`, `approve_contract`,
+  and `reject_contract` updated memory and history but never reached disk — an
+  approval reverted to the on-disk status on the next restart or
+  `POST /contracts/reload` while the history chain claimed ACTIVE. Because
+  `set_status` (the demote/archive path) *did* persist, the durability
+  guarantee was inverted: the ungoverned transition was durable and the
+  governed one was not. Status and provenance (`source`, `proposed_by/at`,
+  `approved_by/at`, `rejected_by/at`, `rejection_reason`) are now serialized
+  structurally on every transition, and rejection metadata is read back on load.
+- **Status write-back could corrupt a contract.** `set_status` persisted via an
+  unanchored `^( +status: )\S+` regex that rewrote **every** indented `status:`
+  line in the file — corrupting a rule field named `status` or a context
+  override — and wrote non-atomically. Replaced with structured serialization
+  through the shared atomic writer.
+
 ## [2.3.29] - 2026-08-06
 
 Security and correctness release (CRT177 Tier 1). Three fixes surfaced in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,12 @@ the documented contract rather than changing it.
   which is precisely what the status guard above restricts to approver/admin.
   Both bulk-write surfaces (import and profiler) now share one guard: `409`
   unless the target contract is absent or already DRAFT. A read-only import
-  preview (`save=false`) onto an existing name is unaffected.
+  preview (`save=false`) onto an existing name is unaffected. The guard matches
+  names **case-insensitively**: the registry lookup is case-sensitive but the
+  write is not, and on a case-insensitive filesystem (Windows and macOS
+  defaults) `Customer.yaml` and `customer.yaml` are the same file — so a
+  case-variant name would otherwise have slipped past the check and replaced the
+  contract it was meant to protect.
 
 ### Fixed
 
@@ -62,6 +67,16 @@ the documented contract rather than changing it.
   governed one was not. Status and provenance (`source`, `proposed_by/at`,
   `approved_by/at`, `rejected_by/at`, `rejection_reason`) are now serialized
   structurally on every transition, and rejection metadata is read back on load.
+  This covers the legacy (flat `rules:` list) and onboarding (`fields:`)
+  formats too — they have no `contract:` block, so their state is written at
+  the top level of the document and read back from there.
+- **A failed state write is no longer silent.** If a lifecycle transition
+  cannot be written to disk (for example an unwritable contracts directory),
+  the registry now raises `ContractPersistenceError` instead of logging and
+  continuing — previously the API returned `200`, fired the
+  `opendqv.contract.approved` webhook, and only a restart revealed that the
+  approval had not been durable. A contract held purely in memory, with no YAML
+  file to persist to, is unaffected.
 - **Status write-back could corrupt a contract.** `set_status` persisted via an
   unanchored `^( +status: )\S+` regex that rewrote **every** indented `status:`
   line in the file — corrupting a rule field named `status` or a context

--- a/opendqv/api/deps.py
+++ b/opendqv/api/deps.py
@@ -92,21 +92,50 @@ def _assert_contract_overwritable(name: str, user: str, surface: str) -> None:
 
     Creating a new contract, or refreshing an existing DRAFT, stays allowed.
     """
-    existing = registry.get(name) if registry else None
-    if existing is not None and existing.status != ContractStatus.DRAFT:
-        logger.warning(
-            "contract_overwrite_blocked contract=%s surface=%s caller=%s status=%s",
-            name, surface, user, existing.status.value,
-        )
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"Contract '{name}' already exists with status "
-                f"'{existing.status.value}' and will not be overwritten by {surface}. "
-                f"Use a different name, or create a draft version first via "
-                f"POST /api/v1/contracts/{name}/version."
-            ),
-        )
+    if not registry:
+        return
+
+    # Match case-insensitively. The lookup is a case-SENSITIVE dict, but the
+    # write is `open(f"{name}.yaml", "w")` on a filesystem that may be
+    # case-INSENSITIVE (Windows and macOS defaults — both supported targets).
+    # There, "Customer" and "customer" are the same inode, so a case-sensitive
+    # "doesn't exist" verdict would let the write silently replace a live ACTIVE
+    # contract — the very hole this guard closes. On a case-sensitive
+    # filesystem the same input instead plants a confusable near-duplicate
+    # beside the governed contract. Both are refused. (CRT177 Tier 2)
+    folded = name.casefold()
+    for existing_name in list(registry._contracts.keys()):
+        if existing_name.casefold() != folded:
+            continue
+        existing = registry.get(existing_name)
+        if existing is None:
+            continue
+        if existing_name != name:
+            logger.warning(
+                "contract_overwrite_blocked contract=%s conflicts_with=%s surface=%s caller=%s",
+                name, existing_name, surface, user,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Contract name '{name}' differs only by case from the existing contract "
+                    f"'{existing_name}' and will not be written by {surface}. Use a distinct name."
+                ),
+            )
+        if existing.status != ContractStatus.DRAFT:
+            logger.warning(
+                "contract_overwrite_blocked contract=%s surface=%s caller=%s status=%s",
+                name, surface, user, existing.status.value,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Contract '{name}' already exists with status "
+                    f"'{existing.status.value}' and will not be overwritten by {surface}. "
+                    f"Use a different name, or create a draft version first via "
+                    f"POST /api/v1/contracts/{name}/version."
+                ),
+            )
 
 
 def _assert_contract_mutable(contract, name: str, user: str, op: str) -> None:

--- a/opendqv/api/deps.py
+++ b/opendqv/api/deps.py
@@ -75,6 +75,40 @@ def _check_validate_in_states(contract, contract_name: str, allow_draft: bool) -
             )
 
 
+def _assert_contract_overwritable(name: str, user: str, surface: str) -> None:
+    """Refuse to replace a governed contract via a bulk file-write surface.
+
+    CRT177 Tier 2. The import and profiler `save=true` paths write contract YAML
+    with a bare `open(..., "w")` and then `registry.reload()`. They never went
+    through the rule-mutation API, so `_assert_contract_mutable` (the 409 that
+    protects ACTIVE contracts) never ran — and the contract name is
+    caller-supplied. An `editor` could therefore point an import at the name of
+    a live ACTIVE contract and replace its rules wholesale.
+
+    That also bypasses the status-transition guard: because imports now
+    correctly land as DRAFT, overwriting an ACTIVE contract would *demote* it —
+    something `POST /contracts/{name}/status` deliberately restricts to
+    approver/admin, since DRAFT unlocks rule mutation.
+
+    Creating a new contract, or refreshing an existing DRAFT, stays allowed.
+    """
+    existing = registry.get(name) if registry else None
+    if existing is not None and existing.status != ContractStatus.DRAFT:
+        logger.warning(
+            "contract_overwrite_blocked contract=%s surface=%s caller=%s status=%s",
+            name, surface, user, existing.status.value,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Contract '{name}' already exists with status "
+                f"'{existing.status.value}' and will not be overwritten by {surface}. "
+                f"Use a different name, or create a draft version first via "
+                f"POST /api/v1/contracts/{name}/version."
+            ),
+        )
+
+
 def _assert_contract_mutable(contract, name: str, user: str, op: str) -> None:
     if contract.status == ContractStatus.ACTIVE:
         logger.warning(

--- a/opendqv/api/routes_contracts.py
+++ b/opendqv/api/routes_contracts.py
@@ -572,10 +572,20 @@ async def change_contract_status(
 
     Governance workflow: draft → active → archived
 
-    Maker-checker: promoting a contract to 'active' requires the 'approver' or
-    'admin' role. Writers may only set contracts to 'draft' or 'archived'.
-    This enforces separation of duties — the person who writes a contract cannot
-    also be the person who promotes it to production.
+    Maker-checker (CRT177 Tier 2 — now enforced on EVERY transition):
+
+    * Any transition that promotes a contract **to** ACTIVE, or that takes one
+      **out of** ACTIVE (demote to draft, archive a live contract), requires
+      `approver` or `admin`. Demotion is not a lesser act than promotion: DRAFT
+      unlocks rule mutation, so an editor who could demote-then-edit would
+      defeat the separation of duties that promotion enforces. Archiving a live
+      contract is a validation outage.
+    * All other transitions (e.g. draft → archived, archived → draft,
+      review → draft) require `editor` or `admin`.
+
+    Previously the role check fired ONLY when the target status was ACTIVE, so
+    any authenticated principal — including `reader`, `auditor`, and
+    `validator` — could archive or demote a production ACTIVE contract.
     """
     try:
         new_status = ContractStatus(status.lower())
@@ -593,6 +603,28 @@ async def change_contract_status(
             detail=(
                 f"Promoting a contract to 'active' requires the 'approver' or 'admin' role. "
                 f"Current role: '{role}'. Request approval from a contract approver."
+            ),
+        )
+
+    # CRT177 Tier 2: transitions OUT of ACTIVE carry the same weight as
+    # promotion — demote unlocks rule mutation (maker-checker bypass) and
+    # archiving a live contract is a validation outage.
+    if contract.status == ContractStatus.ACTIVE and new_status != ContractStatus.ACTIVE:
+        if role not in ("admin", "approver"):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"Changing an ACTIVE contract to '{new_status.value}' requires the "
+                    f"'approver' or 'admin' role. Current role: '{role}'."
+                ),
+            )
+    elif new_status != ContractStatus.ACTIVE and role not in ("admin", "approver", "editor"):
+        # Every remaining transition is still a governed write.
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Changing contract status requires the 'editor', 'approver' or 'admin' role. "
+                f"Current role: '{role}'."
             ),
         )
 

--- a/opendqv/api/routes_imports.py
+++ b/opendqv/api/routes_imports.py
@@ -19,6 +19,35 @@ from opendqv.security.auth import get_current_user, get_current_role
 sub_router = APIRouter()
 
 
+def _apply_import_meta(doc: dict, created_by: str = "") -> None:
+    """Stamp import provenance onto the contract block (CRT177 Tier 2).
+
+    These keys were previously set on the TOP LEVEL of the YAML document
+    (``doc["status"]``), but the loader reads them from the NESTED ``contract:``
+    block (``_parse_contract_format`` → ``c.get("status", "active")``). Every
+    one of them was therefore a silent no-op on disk:
+
+    * ``status: draft`` never applied — so the CSV importer (which hardcodes
+      ``status: active``) and the ODCS importer (which takes a caller-controlled
+      ``info.status``, defaulting to active) persisted contracts as **ACTIVE**,
+      live for validation and immutable, with the approval workflow skipped
+      entirely. The other six importers escaped only because they already nest
+      ``status: draft`` themselves.
+    * ``source`` and ``created_by`` never applied on ANY of the eight importers,
+      so import provenance was lost from the audit trail.
+
+    ``created_by`` maps to ``proposed_by``, which is the attribution field the
+    loader and the review workflow actually read.
+    """
+    block = doc.get("contract")
+    if not isinstance(block, dict):
+        return
+    block["source"] = "import"
+    block["status"] = "draft"
+    if created_by:
+        block["proposed_by"] = created_by
+
+
 @sub_router.post("/import/gx")
 @_d._default_limit
 async def import_great_expectations(
@@ -50,10 +79,7 @@ async def import_great_expectations(
         _d._validate_contract_name(contract_name)
         yaml_content = gx_suite_to_yaml(suite)
         _dd = _yaml.safe_load(yaml_content)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         contracts_dir = str(config.CONTRACTS_DIR)
         file_path = os.path.join(contracts_dir, f"{contract_name}.yaml")
@@ -99,10 +125,7 @@ async def import_dbt(
             for name, yaml_content in pairs:
                 if name == contract_name:
                     _dd = _yaml.safe_load(yaml_content)
-                    _dd["source"] = "import"
-                    _dd["status"] = "draft"
-                    if created_by:
-                        _dd["created_by"] = created_by
+                    _apply_import_meta(_dd, created_by)
                     yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
                     file_path = os.path.join(contracts_dir, f"{contract_name}.yaml")
                     with open(file_path, "w", encoding="utf-8") as f:
@@ -147,10 +170,7 @@ async def import_soda(
         for name, yaml_content in pairs:
             _d._validate_contract_name(name)
             _dd = _yaml.safe_load(yaml_content)
-            _dd["source"] = "import"
-            _dd["status"] = "draft"
-            if created_by:
-                _dd["created_by"] = created_by
+            _apply_import_meta(_dd, created_by)
             yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
             file_path = os.path.join(contracts_dir, f"{name}.yaml")
             with open(file_path, "w", encoding="utf-8") as f:
@@ -192,10 +212,7 @@ async def import_csv(
     if save:
         yaml_content = csv_rules_to_yaml(csv_content, contract_name)
         _dd = _yaml.safe_load(yaml_content)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         contracts_dir = str(config.CONTRACTS_DIR)
         file_path = os.path.join(contracts_dir, f"{contract_name}.yaml")
@@ -241,10 +258,7 @@ async def import_odcs_contract(
         contract_name, yaml_content = odcs_to_yaml(contract_data, contract_name or None)
         _d._validate_contract_name(contract_name)
         _dd = _yaml.safe_load(yaml_content)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         contracts_dir = str(config.CONTRACTS_DIR)
         file_path = os.path.join(contracts_dir, f"{contract_name}.yaml")
@@ -286,10 +300,7 @@ async def import_from_csvw(
         result = import_csvw(body)
         yaml_output = csvw_to_yaml(body, contract_name)
         _dd = _yaml.safe_load(yaml_output)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_output = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         resp = {
             "rules": result["rules"],
@@ -339,10 +350,7 @@ async def import_from_otel(
         result = import_otel(body)
         yaml_output = otel_to_yaml(body, contract_name)
         _dd = _yaml.safe_load(yaml_output)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_output = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         resp = {
             "rules": result["rules"],
@@ -393,10 +401,7 @@ async def import_from_ndc(
         result = import_ndc(body)
         yaml_output = ndc_to_yaml(body, contract_name)
         _dd = _yaml.safe_load(yaml_output)
-        _dd["source"] = "import"
-        _dd["status"] = "draft"
-        if created_by:
-            _dd["created_by"] = created_by
+        _apply_import_meta(_dd, created_by)
         yaml_output = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
         resp = {
             "rules": result["rules"],

--- a/opendqv/api/routes_imports.py
+++ b/opendqv/api/routes_imports.py
@@ -77,6 +77,7 @@ async def import_great_expectations(
     if save:
         contract_name = result["contract"]["name"]
         _d._validate_contract_name(contract_name)
+        _d._assert_contract_overwritable(contract_name, user, "import")
         yaml_content = gx_suite_to_yaml(suite)
         _dd = _yaml.safe_load(yaml_content)
         _apply_import_meta(_dd, created_by)
@@ -121,6 +122,7 @@ async def import_dbt(
         for item in result["contracts"]:
             contract_name = item["contract"]["name"]
             _d._validate_contract_name(contract_name)
+            _d._assert_contract_overwritable(contract_name, user, "import")
             pairs = dbt_schema_to_yaml(schema)
             for name, yaml_content in pairs:
                 if name == contract_name:
@@ -169,6 +171,7 @@ async def import_soda(
         pairs = soda_checks_to_yaml(checks)
         for name, yaml_content in pairs:
             _d._validate_contract_name(name)
+            _d._assert_contract_overwritable(name, user, "import")
             _dd = _yaml.safe_load(yaml_content)
             _apply_import_meta(_dd, created_by)
             yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
@@ -205,6 +208,8 @@ async def import_csv(
     csv_content = body_bytes.decode("utf-8")
 
     _d._validate_contract_name(contract_name)
+    if save:
+        _d._assert_contract_overwritable(contract_name, user, "import")
     result = import_csv_rules(csv_content, contract_name)
     result["contract"]["source"] = "import"
     result["contract"]["status"] = "draft"
@@ -257,6 +262,7 @@ async def import_odcs_contract(
     if save:
         contract_name, yaml_content = odcs_to_yaml(contract_data, contract_name or None)
         _d._validate_contract_name(contract_name)
+        _d._assert_contract_overwritable(contract_name, user, "import")
         _dd = _yaml.safe_load(yaml_content)
         _apply_import_meta(_dd, created_by)
         yaml_content = _yaml.dump(_dd, default_flow_style=False, allow_unicode=True, sort_keys=False)
@@ -296,6 +302,8 @@ async def import_from_csvw(
     if role not in ("editor", "admin"):
         raise HTTPException(status_code=403, detail=f"Role '{role}' is not permitted. Required: editor or admin.")
     _d._validate_contract_name(contract_name)
+    if save:
+        _d._assert_contract_overwritable(contract_name, user, "import")
     try:
         result = import_csvw(body)
         yaml_output = csvw_to_yaml(body, contract_name)
@@ -346,6 +354,8 @@ async def import_from_otel(
     if role not in ("editor", "admin"):
         raise HTTPException(status_code=403, detail=f"Role '{role}' is not permitted. Required: editor or admin.")
     _d._validate_contract_name(contract_name)
+    if save:
+        _d._assert_contract_overwritable(contract_name, user, "import")
     try:
         result = import_otel(body)
         yaml_output = otel_to_yaml(body, contract_name)
@@ -397,6 +407,8 @@ async def import_from_ndc(
     if role not in ("editor", "admin"):
         raise HTTPException(status_code=403, detail=f"Role '{role}' is not permitted. Required: editor or admin.")
     _d._validate_contract_name(contract_name)
+    if save:
+        _d._assert_contract_overwritable(contract_name, user, "import")
     try:
         result = import_ndc(body)
         yaml_output = ndc_to_yaml(body, contract_name)

--- a/opendqv/api/routes_profiler.py
+++ b/opendqv/api/routes_profiler.py
@@ -6,13 +6,12 @@ from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Reques
 import opendqv.api.deps as _d
 import opendqv.config as config
 from opendqv.core.profiler import profile_records
-from opendqv.core.rule_parser import ContractStatus
 from opendqv.security.auth import get_current_user, get_current_role
 
 sub_router = APIRouter()
 
 
-def _assert_may_save_profile(role: str, contract_name: str) -> None:
+def _assert_may_save_profile(role: str, contract_name: str, user: str = "") -> None:
     """Guard the profiler's `save=true` contract-write path (CRT177 Tier 2).
 
     Two holes closed here:
@@ -35,16 +34,9 @@ def _assert_may_save_profile(role: str, contract_name: str) -> None:
             status_code=403,
             detail=f"Role '{role}' is not permitted to save contracts. Required: editor or admin.",
         )
-    existing = _d.registry.get(contract_name)
-    if existing is not None and existing.status != ContractStatus.DRAFT:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"Contract '{contract_name}' already exists with status "
-                f"'{existing.status.value}' and will not be overwritten by the profiler. "
-                f"Profile into a new name, or create a draft version first."
-            ),
-        )
+    # Shared with the import routes — both are bulk file-write surfaces that
+    # bypass the rule-mutation API's ACTIVE guard.
+    _d._assert_contract_overwritable(contract_name, user, "the profiler")
 
 
 @sub_router.post("/profile")
@@ -60,7 +52,7 @@ async def profile_data(
     """Analyze records and auto-generate an OpenDQV contract with suggested rules."""
     _d._validate_contract_name(contract_name)
     if save:
-        _assert_may_save_profile(role, contract_name)
+        _assert_may_save_profile(role, contract_name, user)
     result = profile_records(records, contract_name=contract_name)
 
     if save:
@@ -96,7 +88,7 @@ async def profile_file(
     """
     _d._validate_contract_name(contract_name)
     if save:
-        _assert_may_save_profile(role, contract_name)
+        _assert_may_save_profile(role, contract_name, user)
     content = await file.read()
     filename = file.filename or ""
     df = _d._parse_upload(content, filename)

--- a/opendqv/api/routes_profiler.py
+++ b/opendqv/api/routes_profiler.py
@@ -1,14 +1,50 @@
 import os
 import yaml as _yaml
 
-from fastapi import APIRouter, Body, Depends, File, Query, Request, UploadFile
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Request, UploadFile
 
 import opendqv.api.deps as _d
 import opendqv.config as config
 from opendqv.core.profiler import profile_records
-from opendqv.security.auth import get_current_user
+from opendqv.core.rule_parser import ContractStatus
+from opendqv.security.auth import get_current_user, get_current_role
 
 sub_router = APIRouter()
+
+
+def _assert_may_save_profile(role: str, contract_name: str) -> None:
+    """Guard the profiler's `save=true` contract-write path (CRT177 Tier 2).
+
+    Two holes closed here:
+
+    1. **No role guard.** Every sibling write path (`/import/*`) requires
+       editor/admin (SEC-010); the profiler save did not, so ANY authenticated
+       principal — including `reader`/`validator`/`auditor` — could write a
+       contract.
+    2. **Destructive overwrite by name.** The write was a bare
+       ``open(f"{contract_name}.yaml", "w")`` with no existence check, and
+       `_validate_contract_name` is charset-only. `?contract_name=customer`
+       therefore REPLACED the live ACTIVE `customer` contract with
+       profiler-generated rules and reloaded it — bypassing ACTIVE
+       immutability and the approval workflow in a single unprivileged request.
+
+    Profiling into a *new* name, or refreshing one's own DRAFT, stays allowed.
+    """
+    if role not in ("editor", "admin"):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{role}' is not permitted to save contracts. Required: editor or admin.",
+        )
+    existing = _d.registry.get(contract_name)
+    if existing is not None and existing.status != ContractStatus.DRAFT:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Contract '{contract_name}' already exists with status "
+                f"'{existing.status.value}' and will not be overwritten by the profiler. "
+                f"Profile into a new name, or create a draft version first."
+            ),
+        )
 
 
 @sub_router.post("/profile")
@@ -19,9 +55,12 @@ async def profile_data(
     contract_name: str = Query("profiled", description="Name for the generated contract"),
     save: bool = Query(False, description="Save as YAML contract"),
     user=Depends(get_current_user),
+    role: str = Depends(get_current_role),
 ):
     """Analyze records and auto-generate an OpenDQV contract with suggested rules."""
     _d._validate_contract_name(contract_name)
+    if save:
+        _assert_may_save_profile(role, contract_name)
     result = profile_records(records, contract_name=contract_name)
 
     if save:
@@ -46,6 +85,7 @@ async def profile_file(
     contract_name: str = Query("profiled", description="Name for the generated contract"),
     save: bool = Query(False, description="Save as YAML contract"),
     user=Depends(get_current_user),
+    role: str = Depends(get_current_role),
 ):
     """
     Profile records from an uploaded CSV or Parquet file.
@@ -55,6 +95,8 @@ async def profile_file(
     Max file size: configured via OPENDQV_MAX_UPLOAD_MB (default 10MB).
     """
     _d._validate_contract_name(contract_name)
+    if save:
+        _assert_may_save_profile(role, contract_name)
     content = await file.read()
     filename = file.filename or ""
     df = _d._parse_upload(content, filename)

--- a/opendqv/core/contracts.py
+++ b/opendqv/core/contracts.py
@@ -22,6 +22,34 @@ from .rule_parser import Rule, Severity, ContractStatus
 
 class UnknownContextError(ValueError):
     """Raised when a named context is specified but does not exist in the contract."""
+
+
+def _read_meta(raw: dict) -> dict:
+    """Read lifecycle status + provenance written at the top level of a YAML doc.
+
+    Used by the legacy and onboarding formats, which have no `contract:` block
+    (CRT177 Tier 2). Absent keys are omitted so DataContract's own defaults
+    apply — notably `status`, which must not be forced when the file never
+    carried one.
+    """
+    out: dict = {}
+    if raw.get("status") is not None:
+        out["status"] = raw["status"]
+    for field in ("source", "proposed_by", "proposed_at", "approved_by",
+                  "approved_at", "rejected_by", "rejected_at", "rejection_reason"):
+        if raw.get(field) is not None:
+            out[field] = raw[field]
+    return out
+
+
+class ContractPersistenceError(RuntimeError):
+    """Raised when a lifecycle transition could not be written to the contract's YAML file.
+
+    The transition has already been applied in memory and recorded in history,
+    so the caller must be told the change is not durable — it will revert on the
+    next reload. Silently swallowing this is what allowed an approval to live
+    only in memory (CRT177 Tier 2).
+    """
 from .storage import ContractHistoryBackend
 
 import opendqv.config as config
@@ -951,6 +979,10 @@ class ContractRegistry:
             description=raw.get("description", ""),
             rules=rules,
             contexts=raw.get("contexts", {}),
+            # CRT177 Tier 2: this format has no `contract:` block, so lifecycle
+            # status and provenance are persisted at the top level. Read them
+            # back or a transition is silently lost on reload.
+            **_read_meta(raw),
         )
 
     def _parse_onboarding_format(self, raw: dict, path: Path) -> DataContract:
@@ -1007,6 +1039,9 @@ class ContractRegistry:
             owner=metadata.get("author", ""),
             rules=rules,
             contexts=raw.get("contexts", {}),
+            # CRT177 Tier 2: lifecycle status/provenance are persisted at the
+            # top level for this format too (no `contract:` block).
+            **_read_meta(raw),
         )
 
     def get(self, name: str, version: str = "latest") -> Optional[DataContract]:
@@ -1411,17 +1446,30 @@ class ContractRegistry:
                 block[field] = value
 
     def _persist_contract_meta(self, name: str, contract: "DataContract") -> None:
-        """Persist status + provenance only (no rule changes), best-effort.
+        """Persist status + provenance only (no rule changes).
 
         Used by the lifecycle transitions (set_status, submit, approve, reject).
-        Failure to write must not roll back an in-memory transition that has
-        already been recorded in history, so this logs rather than raises —
-        matching the pre-existing set_status behaviour.
+
+        A contract with no YAML file on disk (constructed in memory) has nothing
+        to persist to — that is a legitimate state, logged at debug and ignored.
+
+        Anything else is reported. A transition that did not reach disk is a lie
+        to the caller: memory and history would say ACTIVE while the next reload
+        reverts to the on-disk status. That silent divergence is the exact
+        defect this method exists to fix, so it must not be swallowed here.
         """
+        path = self._contract_paths.get(name)
+        if not path or not path.exists():
+            logger.debug("No YAML file for contract %s — nothing to persist", name)
+            return
         try:
             self._write_contract_yaml(name, contract, include_rules=False)
         except Exception as exc:
-            logger.warning("Could not persist status/provenance for %s: %s", name, exc)
+            logger.error("Could not persist status/provenance for %s: %s", name, exc)
+            raise ContractPersistenceError(
+                f"Contract '{name}' transitioned to '{contract.status.value}' in memory but the "
+                f"change could not be written to disk; it will revert on the next reload."
+            ) from exc
 
     def _write_contract_yaml(self, name: str, contract: "DataContract", include_rules: bool = True) -> None:
         """Write contract state back to the YAML file atomically.
@@ -1444,6 +1492,13 @@ class ContractRegistry:
                 f"(e.g. !!python/object). Remove them manually and re-save. "
                 f"Detail: {exc}"
             ) from exc
+        if "contract" not in raw:
+            # Legacy (flat `rules:` list) and onboarding (`fields:`) formats have
+            # no `contract:` block. Writing the meta into a block that isn't
+            # there would be a silent no-op that loses the transition, so write
+            # it at the top level — which is where _parse_legacy_format and
+            # _parse_onboarding_format now read it back from. (CRT177 Tier 2)
+            self._apply_contract_meta(raw, contract)
         if "contract" in raw:
             if include_rules:
                 # Use mode='json' to ensure enum values are serialised as plain strings,

--- a/opendqv/core/contracts.py
+++ b/opendqv/core/contracts.py
@@ -933,6 +933,12 @@ class ContractRegistry:
             # own approve workflow.
             approved_by=c.get("approved_by"),
             approved_at=c.get("approved_at"),
+            # CRT177 Tier 2: rejection metadata is now serialised by
+            # reject_contract, so it must be read back or it is lost on reload.
+            # Keep this set in sync with _PERSISTED_META_FIELDS.
+            rejected_by=c.get("rejected_by"),
+            rejected_at=c.get("rejected_at"),
+            rejection_reason=c.get("rejection_reason"),
         )
 
     def _parse_legacy_format(self, raw: dict, path: Path) -> DataContract:
@@ -1084,31 +1090,12 @@ class ContractRegistry:
         logger.info("Contract %s v%s status changed to %s", name, contract.version, status.value)
 
         # Write the new status back to the YAML file so it survives reload.
-        path = self._contract_paths.get(name)
-        if path and path.exists():
-            try:
-                import re
-                text = path.read_text(encoding="utf-8")
-                # Replace an existing "  status: <value>" line inside the contract block.
-                new_text, n = re.subn(
-                    r'^( +status: )\S+',
-                    lambda m: m.group(1) + status.value,
-                    text,
-                    flags=re.MULTILINE,
-                )
-                if n == 0:
-                    # status field absent — insert it after the "name:" line.
-                    new_text = re.sub(
-                        r'(^contract:\n( +)name:.*\n)',
-                        lambda m: m.group(0) + m.group(2) + f"status: {status.value}\n",
-                        text,
-                        flags=re.MULTILINE,
-                    )
-                path.write_text(new_text, encoding="utf-8")
-                logger.info("Wrote status=%s back to %s", status.value, path.name)
-            except Exception as exc:
-                logger.warning("Could not write status back to YAML for %s: %s", name, exc)
-
+        # CRT177 Tier 2: this used an unanchored `^( +status: )\S+` regex that
+        # rewrote EVERY indented `status:` line in the file — it would corrupt a
+        # nested `status` key (e.g. inside contexts: or a rule) and the write was
+        # non-atomic. Replaced with structured serialisation through the shared
+        # atomic writer.
+        self._persist_contract_meta(name, contract)
         return contract
 
     def submit_for_review(self, name: str, version: str, proposed_by: str) -> Optional[DataContract]:
@@ -1122,6 +1109,9 @@ class ContractRegistry:
         contract.proposed_by = proposed_by
         contract.proposed_at = datetime.now(timezone.utc).isoformat()
         self.history.record_version(contract)
+        # CRT177 Tier 2: persist — this transition previously lived only in
+        # memory, so a restart/reload silently reverted it to the on-disk status.
+        self._persist_contract_meta(name, contract)
         return contract
 
     def approve_contract(self, name: str, version: str, approved_by: str) -> Optional[DataContract]:
@@ -1135,6 +1125,10 @@ class ContractRegistry:
         contract.approved_by = approved_by
         contract.approved_at = datetime.now(timezone.utc).isoformat()
         self.history.record_version(contract, approved_by=approved_by)
+        # CRT177 Tier 2: an approval is the single most important transition to
+        # persist — without this it reverted to `draft` on the next reload while
+        # history claimed ACTIVE.
+        self._persist_contract_meta(name, contract)
         return contract
 
     def reject_contract(self, name: str, version: str, rejected_by: str, reason: str) -> Optional[DataContract]:
@@ -1149,6 +1143,8 @@ class ContractRegistry:
         contract.rejected_at = datetime.now(timezone.utc).isoformat()
         contract.rejection_reason = reason
         self.history.record_version(contract)
+        # CRT177 Tier 2: persist the rejection + its reason.
+        self._persist_contract_meta(name, contract)
         return contract
 
     def create_draft(
@@ -1393,8 +1389,47 @@ class ContractRegistry:
         logger.info("delete_rule contract=%s rule=%s version=%s", name, rule_name, contract.version)
         return contract
 
-    def _write_contract_yaml(self, name: str, contract: "DataContract") -> None:
-        """Write contract rules back to the YAML file atomically."""
+    # Lifecycle + provenance fields that must survive a reload.
+    # MUST stay in sync with _parse_contract_format — a field written here but
+    # not read there is silently lost on the next reload. (CRT177 Tier 2: the
+    # serializer previously wrote only rules+version, so an approval lived in
+    # memory only and reverted to the on-disk status on restart/reload.)
+    _PERSISTED_META_FIELDS: tuple = (
+        "source",
+        "proposed_by", "proposed_at",
+        "approved_by", "approved_at",
+        "rejected_by", "rejected_at", "rejection_reason",
+    )
+
+    @classmethod
+    def _apply_contract_meta(cls, block: dict, contract: "DataContract") -> None:
+        """Write lifecycle status + provenance into a raw ``contract:`` block."""
+        block["status"] = contract.status.value
+        for field in cls._PERSISTED_META_FIELDS:
+            value = getattr(contract, field, None)
+            if value is not None:
+                block[field] = value
+
+    def _persist_contract_meta(self, name: str, contract: "DataContract") -> None:
+        """Persist status + provenance only (no rule changes), best-effort.
+
+        Used by the lifecycle transitions (set_status, submit, approve, reject).
+        Failure to write must not roll back an in-memory transition that has
+        already been recorded in history, so this logs rather than raises —
+        matching the pre-existing set_status behaviour.
+        """
+        try:
+            self._write_contract_yaml(name, contract, include_rules=False)
+        except Exception as exc:
+            logger.warning("Could not persist status/provenance for %s: %s", name, exc)
+
+    def _write_contract_yaml(self, name: str, contract: "DataContract", include_rules: bool = True) -> None:
+        """Write contract state back to the YAML file atomically.
+
+        Always persists lifecycle status + provenance; rules and version are
+        written only when ``include_rules`` (the lifecycle transitions do not
+        touch rules).
+        """
         path = self._contract_paths.get(name)
         if not path or not path.exists():
             raise RuntimeError(f"No YAML path found for contract '{name}'")
@@ -1410,15 +1445,17 @@ class ContractRegistry:
                 f"Detail: {exc}"
             ) from exc
         if "contract" in raw:
-            # Use mode='json' to ensure enum values are serialised as plain strings,
-            # not as Python-specific YAML tags (e.g. Severity.ERROR → 'error').
-            rules_out = [
-                r.model_dump(by_alias=True, exclude_none=True, mode='json')
-                for r in contract.rules
-            ]
-            raw["contract"]["rules"] = rules_out
-            # ACT-047-02: persist the version field (may have been updated by draft patch counter).
-            raw["contract"]["version"] = contract.version
+            if include_rules:
+                # Use mode='json' to ensure enum values are serialised as plain strings,
+                # not as Python-specific YAML tags (e.g. Severity.ERROR → 'error').
+                rules_out = [
+                    r.model_dump(by_alias=True, exclude_none=True, mode='json')
+                    for r in contract.rules
+                ]
+                raw["contract"]["rules"] = rules_out
+                # ACT-047-02: persist the version field (may have been updated by draft patch counter).
+                raw["contract"]["version"] = contract.version
+            self._apply_contract_meta(raw["contract"], contract)
         tmp = path.with_suffix(".yaml.tmp")
         tmp.write_text(yaml.safe_dump(raw, default_flow_style=False, allow_unicode=True, sort_keys=False), encoding="utf-8")
         tmp.replace(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opendqv"
-version = "2.3.29"
+version = "2.3.30"
 description = "OpenDQV Core — open-source, contract-driven data quality validation engine for data pipelines and API boundaries"
 authors = ["Sunny Sharma"]
 license = "MIT"

--- a/tests/test_contracts_extended.py
+++ b/tests/test_contracts_extended.py
@@ -697,12 +697,16 @@ class TestChangeContractStatusArchive:
     def teardown_method(self):
         _remove_contract(self._NAME)
 
-    def test_archive_draft_contract(self, client, auth_headers):
-        """Archiving a DRAFT contract (DRAFT→ARCHIVED) returns 200 with status=archived."""
+    def test_archive_draft_contract(self, client, editor_headers):
+        """Archiving a DRAFT contract (DRAFT→ARCHIVED) returns 200 with status=archived.
+
+        CRT177 Tier 2: status changes are governed writes — editor+ required.
+        This previously passed with a `validator` token.
+        """
         r = client.post(
             f"/api/v1/contracts/{self._NAME}/status",
             params={"status": "archived"},
-            headers=auth_headers,
+            headers=editor_headers,
         )
         assert r.status_code == 200
         data = r.json()

--- a/tests/test_crt177_governance.py
+++ b/tests/test_crt177_governance.py
@@ -18,10 +18,44 @@ Three write paths bypassed the contract-governance invariants:
 
   * **Import status.** Covered in tests/test_crt177_imports.py.
 """
+import yaml
+
 import pytest
 
 
 ALL_ROLE_FIXTURES = ["reader_headers", "auditor_headers", "auth_headers"]  # auth_headers == validator
+
+
+def _make_active(name: str):
+    """Create a dedicated ACTIVE contract for a test.
+
+    These tests must NOT drive a shared bundled contract (e.g. `customer`)
+    through the API: `POST /contracts/{name}/status` is rate-limited to
+    10/minute, so a restore call can be refused with 429 and leave the shared
+    contract demoted — silently breaking every downstream test that assumes it
+    is ACTIVE. Own the fixture, and set up / tear down through the registry,
+    which is not rate-limited.
+    """
+    from opendqv.api.routes import registry
+
+    path = registry.contracts_dir / f"{name}.yaml"
+    path.write_text(yaml.safe_dump({"contract": {
+        "name": name, "version": "1.0", "status": "active",
+        "description": "CRT177 governance fixture", "owner": "pytest",
+        "rules": [{"name": "r1", "field": "email", "type": "not_empty",
+                   "error_message": "email is required"}],
+    }}), encoding="utf-8")
+    registry.reload()
+    return name
+
+
+def _destroy(name: str):
+    from opendqv.api.routes import registry
+
+    registry._contracts.pop(name, None)
+    path = registry.contracts_dir / f"{name}.yaml"
+    if path.exists():
+        path.unlink()
 
 
 class TestProfilerSaveRequiresRole:
@@ -52,25 +86,32 @@ class TestProfilerSaveRequiresRole:
 class TestProfilerCannotOverwriteGovernedContract:
     """The destructive-overwrite hole: profiling onto an existing ACTIVE name."""
 
+    _NAME = "crt177_gov_profiler"
+
+    def setup_method(self):
+        _make_active(self._NAME)
+
+    def teardown_method(self):
+        _destroy(self._NAME)
+
     def test_editor_cannot_clobber_active_contract(self, client, editor_headers):
-        # `customer` is a bundled ACTIVE contract.
         r = client.post(
             "/api/v1/profile",
             json=[{"totally": "unrelated"}, {"totally": "shape"}],
-            params={"contract_name": "customer", "save": "true"},
+            params={"contract_name": self._NAME, "save": "true"},
             headers=editor_headers,
         )
         assert r.status_code == 409, "profiler must refuse to overwrite a non-DRAFT contract"
 
     def test_active_contract_survives_the_attempt(self, client, editor_headers):
-        before = client.get("/api/v1/contracts/customer").json()
+        before = client.get(f"/api/v1/contracts/{self._NAME}").json()
         client.post(
             "/api/v1/profile",
             json=[{"totally": "unrelated"}],
-            params={"contract_name": "customer", "save": "true"},
+            params={"contract_name": self._NAME, "save": "true"},
             headers=editor_headers,
         )
-        after = client.get("/api/v1/contracts/customer").json()
+        after = client.get(f"/api/v1/contracts/{self._NAME}").json()
         assert after["status"] == before["status"] == "active"
         assert len(after.get("rules", [])) == len(before.get("rules", [])), \
             "ACTIVE contract rules must be untouched by a refused profiler save"
@@ -83,7 +124,14 @@ class TestImportCannotOverwriteGovernedContract:
     because imports now correctly land as DRAFT, doing so also *demoted* it,
     which `POST /contracts/{name}/status` restricts to approver/admin."""
 
-    _ACTIVE = "customer"
+    _ACTIVE = "crt177_gov_import"
+
+    def setup_method(self):
+        _make_active(self._ACTIVE)
+
+    def teardown_method(self):
+        _destroy(self._ACTIVE)
+        _destroy("crt177_import_fresh")
 
     def _gx_suite(self, name):
         return {
@@ -128,15 +176,71 @@ class TestImportCannotOverwriteGovernedContract:
         assert r.status_code == 200
 
 
+class TestOverwriteGuardIsCaseInsensitive:
+    """The guard looks up a case-SENSITIVE dict but writes to a filesystem that
+    may be case-INSENSITIVE (Windows/macOS defaults — both supported targets),
+    where `Customer.yaml` and `customer.yaml` are the same inode. A
+    case-sensitive "doesn't exist" verdict would let the write silently replace
+    a live ACTIVE contract. Found by adversarial review of the first cut."""
+
+    _NAME = "crt177_case_target"
+
+    def setup_method(self):
+        _make_active(self._NAME)
+
+    def teardown_method(self):
+        _destroy(self._NAME)
+        _destroy("crt177_case_fresh")
+
+    @pytest.mark.parametrize("variant", [
+        "crt177_case_target",      # exact
+        "CRT177_CASE_TARGET",      # upper
+        "Crt177_Case_Target",      # mixed
+    ])
+    def test_profiler_refuses_every_casing(self, client, editor_headers, variant):
+        r = client.post(
+            "/api/v1/profile", json=[{"a": 1}],
+            params={"contract_name": variant, "save": "true"},
+            headers=editor_headers,
+        )
+        assert r.status_code == 409, f"casing {variant!r} must not bypass the guard"
+
+    def test_import_refuses_case_variant(self, client, editor_headers):
+        r = client.post(
+            "/api/v1/import/gx", params={"save": "true"},
+            json={"expectation_suite_name": "CRT177_Case_Target",
+                  "expectations": [{"expectation_type": "expect_column_values_to_not_be_null",
+                                    "kwargs": {"column": "x"}}]},
+            headers=editor_headers,
+        )
+        assert r.status_code == 409
+
+    def test_distinct_name_still_allowed(self, client, editor_headers):
+        r = client.post(
+            "/api/v1/profile", json=[{"a": 1}],
+            params={"contract_name": "crt177_case_fresh", "save": "true"},
+            headers=editor_headers,
+        )
+        assert r.status_code == 200
+
+
 class TestStatusChangeAuthorization:
     """Every transition is a governed write — not just promotion to ACTIVE."""
+
+    _NAME = "crt177_gov_status"
+
+    def setup_method(self):
+        _make_active(self._NAME)
+
+    def teardown_method(self):
+        _destroy(self._NAME)
 
     @pytest.mark.parametrize("hdr_name", ALL_ROLE_FIXTURES)
     @pytest.mark.parametrize("target", ["draft", "archived"])
     def test_low_privilege_cannot_demote_or_archive_active(self, client, request, hdr_name, target):
         headers = request.getfixturevalue(hdr_name)
         r = client.post(
-            "/api/v1/contracts/customer/status",
+            f"/api/v1/contracts/{self._NAME}/status",
             params={"status": target},
             headers=headers,
         )
@@ -148,7 +252,7 @@ class TestStatusChangeAuthorization:
     def test_editor_cannot_demote_active(self, client, editor_headers):
         """Demote carries promotion's weight: editor-then-edit would defeat maker-checker."""
         r = client.post(
-            "/api/v1/contracts/customer/status",
+            f"/api/v1/contracts/{self._NAME}/status",
             params={"status": "draft"},
             headers=editor_headers,
         )
@@ -156,14 +260,14 @@ class TestStatusChangeAuthorization:
 
     def test_approver_can_demote_active(self, client, approver_headers):
         r = client.post(
-            "/api/v1/contracts/customer/status",
+            f"/api/v1/contracts/{self._NAME}/status",
             params={"status": "draft"},
             headers=approver_headers,
         )
         assert r.status_code == 200
         # restore
         client.post(
-            "/api/v1/contracts/customer/status",
+            f"/api/v1/contracts/{self._NAME}/status",
             params={"status": "active"},
             headers=approver_headers,
         )
@@ -171,7 +275,7 @@ class TestStatusChangeAuthorization:
     def test_validator_still_cannot_activate(self, client, auth_headers):
         """Pre-existing SEC guard must remain intact."""
         r = client.post(
-            "/api/v1/contracts/customer/status",
+            f"/api/v1/contracts/{self._NAME}/status",
             params={"status": "active"},
             headers=auth_headers,
         )

--- a/tests/test_crt177_governance.py
+++ b/tests/test_crt177_governance.py
@@ -76,6 +76,58 @@ class TestProfilerCannotOverwriteGovernedContract:
             "ACTIVE contract rules must be untouched by a refused profiler save"
 
 
+class TestImportCannotOverwriteGovernedContract:
+    """The import routes are the profiler hole's twin: caller-supplied contract
+    name, bare `open(..., "w")`, no existence check. An editor could point an
+    import at a live ACTIVE contract and replace its rules wholesale — and
+    because imports now correctly land as DRAFT, doing so also *demoted* it,
+    which `POST /contracts/{name}/status` restricts to approver/admin."""
+
+    _ACTIVE = "customer"
+
+    def _gx_suite(self, name):
+        return {
+            "expectation_suite_name": name,
+            "expectations": [{
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "crt177_probe"},
+            }],
+        }
+
+    def test_import_save_onto_active_name_is_refused(self, client, editor_headers):
+        r = client.post(
+            "/api/v1/import/gx", params={"save": "true"},
+            json=self._gx_suite(self._ACTIVE), headers=editor_headers,
+        )
+        assert r.status_code == 409
+
+    def test_active_contract_survives_import_attempt(self, client, editor_headers):
+        before = client.get(f"/api/v1/contracts/{self._ACTIVE}").json()
+        client.post(
+            "/api/v1/import/gx", params={"save": "true"},
+            json=self._gx_suite(self._ACTIVE), headers=editor_headers,
+        )
+        after = client.get(f"/api/v1/contracts/{self._ACTIVE}").json()
+        assert after["status"] == before["status"] == "active"
+        assert len(after.get("rules", [])) == len(before.get("rules", [])), \
+            "an import must not replace the rules of an ACTIVE contract"
+
+    def test_preview_without_save_is_still_allowed(self, client, editor_headers):
+        """The guard gates the WRITE — a read-only preview must not 409."""
+        r = client.post(
+            "/api/v1/import/gx",
+            json=self._gx_suite(self._ACTIVE), headers=editor_headers,
+        )
+        assert r.status_code == 200
+
+    def test_import_to_a_new_name_still_saves(self, client, editor_headers):
+        r = client.post(
+            "/api/v1/import/gx", params={"save": "true"},
+            json=self._gx_suite("crt177_import_fresh"), headers=editor_headers,
+        )
+        assert r.status_code == 200
+
+
 class TestStatusChangeAuthorization:
     """Every transition is a governed write — not just promotion to ACTIVE."""
 

--- a/tests/test_crt177_governance.py
+++ b/tests/test_crt177_governance.py
@@ -1,0 +1,126 @@
+"""
+CRT177 Tier 2 — governance / RBAC recurrence tests (Protocol 32).
+
+Three write paths bypassed the contract-governance invariants:
+
+  * **Profiler save.** `POST /profile?save=true` and `/profile/file?save=true`
+    had NO role guard (every `/import/*` sibling requires editor/admin per
+    SEC-010) and did a bare `open(f"{contract_name}.yaml", "w")` with no
+    existence check — so ANY authenticated principal could REPLACE a live
+    ACTIVE contract with profiler-generated rules and reload it, defeating
+    ACTIVE immutability and the approval workflow in one request.
+
+  * **Status changes.** `POST /contracts/{name}/status` checked the caller's
+    role ONLY when the target status was ACTIVE, so any principal —
+    `reader`/`auditor`/`validator` — could archive or demote a production
+    contract. Demote is not a lesser act than promote: DRAFT unlocks rule
+    mutation, so demote-then-edit defeats maker-checker.
+
+  * **Import status.** Covered in tests/test_crt177_imports.py.
+"""
+import pytest
+
+
+ALL_ROLE_FIXTURES = ["reader_headers", "auditor_headers", "auth_headers"]  # auth_headers == validator
+
+
+class TestProfilerSaveRequiresRole:
+    """Profiler contract-write path must match /import/* (editor/admin)."""
+
+    @pytest.mark.parametrize("hdr_name", ALL_ROLE_FIXTURES)
+    def test_low_privilege_roles_cannot_save(self, client, request, hdr_name):
+        headers = request.getfixturevalue(hdr_name)
+        r = client.post(
+            "/api/v1/profile",
+            json=[{"a": 1}, {"a": 2}],
+            params={"contract_name": "crt177_profile_rbac", "save": "true"},
+            headers=headers,
+        )
+        assert r.status_code == 403, f"{hdr_name} must not be able to save a contract"
+
+    def test_profiling_without_save_is_open_to_any_authenticated_role(self, client, auth_headers):
+        """The guard must gate the WRITE, not profiling itself."""
+        r = client.post(
+            "/api/v1/profile",
+            json=[{"a": 1}, {"a": 2}],
+            params={"contract_name": "crt177_profile_readonly"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200
+
+
+class TestProfilerCannotOverwriteGovernedContract:
+    """The destructive-overwrite hole: profiling onto an existing ACTIVE name."""
+
+    def test_editor_cannot_clobber_active_contract(self, client, editor_headers):
+        # `customer` is a bundled ACTIVE contract.
+        r = client.post(
+            "/api/v1/profile",
+            json=[{"totally": "unrelated"}, {"totally": "shape"}],
+            params={"contract_name": "customer", "save": "true"},
+            headers=editor_headers,
+        )
+        assert r.status_code == 409, "profiler must refuse to overwrite a non-DRAFT contract"
+
+    def test_active_contract_survives_the_attempt(self, client, editor_headers):
+        before = client.get("/api/v1/contracts/customer").json()
+        client.post(
+            "/api/v1/profile",
+            json=[{"totally": "unrelated"}],
+            params={"contract_name": "customer", "save": "true"},
+            headers=editor_headers,
+        )
+        after = client.get("/api/v1/contracts/customer").json()
+        assert after["status"] == before["status"] == "active"
+        assert len(after.get("rules", [])) == len(before.get("rules", [])), \
+            "ACTIVE contract rules must be untouched by a refused profiler save"
+
+
+class TestStatusChangeAuthorization:
+    """Every transition is a governed write — not just promotion to ACTIVE."""
+
+    @pytest.mark.parametrize("hdr_name", ALL_ROLE_FIXTURES)
+    @pytest.mark.parametrize("target", ["draft", "archived"])
+    def test_low_privilege_cannot_demote_or_archive_active(self, client, request, hdr_name, target):
+        headers = request.getfixturevalue(hdr_name)
+        r = client.post(
+            "/api/v1/contracts/customer/status",
+            params={"status": target},
+            headers=headers,
+        )
+        assert r.status_code == 403, (
+            f"{hdr_name} must not be able to set an ACTIVE contract to {target!r} — "
+            f"archive is a validation outage and demote unlocks rule mutation"
+        )
+
+    def test_editor_cannot_demote_active(self, client, editor_headers):
+        """Demote carries promotion's weight: editor-then-edit would defeat maker-checker."""
+        r = client.post(
+            "/api/v1/contracts/customer/status",
+            params={"status": "draft"},
+            headers=editor_headers,
+        )
+        assert r.status_code == 403
+
+    def test_approver_can_demote_active(self, client, approver_headers):
+        r = client.post(
+            "/api/v1/contracts/customer/status",
+            params={"status": "draft"},
+            headers=approver_headers,
+        )
+        assert r.status_code == 200
+        # restore
+        client.post(
+            "/api/v1/contracts/customer/status",
+            params={"status": "active"},
+            headers=approver_headers,
+        )
+
+    def test_validator_still_cannot_activate(self, client, auth_headers):
+        """Pre-existing SEC guard must remain intact."""
+        r = client.post(
+            "/api/v1/contracts/customer/status",
+            params={"status": "active"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 403

--- a/tests/test_crt177_imports.py
+++ b/tests/test_crt177_imports.py
@@ -1,0 +1,95 @@
+"""
+CRT177 Tier 2 — import governance recurrence tests (Protocol 32).
+
+`routes_imports.py` stamped provenance onto the TOP LEVEL of the YAML document
+(``doc["status"] = "draft"``) while the loader reads it from the NESTED
+``contract:`` block (``_parse_contract_format`` → ``c.get("status", "active")``).
+Every stamp was therefore a silent no-op on disk:
+
+  * The CSV importer hardcodes ``status: active`` and the ODCS importer takes a
+    caller-controlled ``info.status`` (default ``active``) inside the nested
+    block — so `?save=true` on those two persisted contracts as **ACTIVE**:
+    immediately live for validation, immutable to rule edits, and never routed
+    through draft → review → approve. An `editor` achieved ACTIVE with no
+    approver. The API response meanwhile reported ``status: draft``, so response
+    and persisted state disagreed.
+  * ``source`` and ``created_by`` were dropped on ALL EIGHT importers, losing
+    import provenance from the audit trail.
+"""
+import yaml
+
+import pytest
+
+from opendqv.api.routes_imports import _apply_import_meta
+from opendqv.core.contracts import ContractRegistry
+from opendqv.core.rule_parser import ContractStatus
+
+
+def _roundtrip(tmp_path, contract_body, created_by=""):
+    """Stamp a contract doc the way an import save does, then load it back."""
+    doc = yaml.safe_load(yaml.safe_dump({"contract": contract_body}))
+    _apply_import_meta(doc, created_by)
+    (tmp_path / f"{contract_body['name']}.yaml").write_text(
+        yaml.safe_dump(doc), encoding="utf-8"
+    )
+    return ContractRegistry(tmp_path).get(contract_body["name"])
+
+
+class TestImportAlwaysLandsAsDraft:
+    @pytest.mark.parametrize("declared_status", ["active", "draft", "archived", None])
+    def test_status_forced_to_draft_on_disk(self, tmp_path, declared_status):
+        """Whatever the importer emitted, a saved import must load as DRAFT."""
+        body = {"name": "imp1", "version": "1.0", "rules": []}
+        if declared_status is not None:
+            body["status"] = declared_status
+        c = _roundtrip(tmp_path, body)
+        assert c.status == ContractStatus.DRAFT, (
+            f"importer-declared status {declared_status!r} must not survive — "
+            f"an import must never land ACTIVE and skip approval"
+        )
+
+    def test_csv_style_active_contract_is_neutralised(self, tmp_path):
+        """csv_rules.py hardcodes status: active — the ACTIVE-bypass source."""
+        c = _roundtrip(tmp_path, {"name": "imp_csv", "version": "1.0",
+                                  "status": "active", "rules": []})
+        assert c.status == ContractStatus.DRAFT
+
+    def test_odcs_style_caller_controlled_status_is_neutralised(self, tmp_path):
+        """odcs.py takes status from caller-supplied info.status."""
+        c = _roundtrip(tmp_path, {"name": "imp_odcs", "version": "1.0",
+                                  "status": "active", "rules": []})
+        assert c.status == ContractStatus.DRAFT
+
+
+class TestImportProvenanceReachesDisk:
+    def test_source_is_recorded(self, tmp_path):
+        c = _roundtrip(tmp_path, {"name": "imp2", "version": "1.0", "rules": []})
+        assert c.source == "import"
+
+    def test_created_by_is_recorded_as_proposed_by(self, tmp_path):
+        """created_by maps to proposed_by — the field the loader actually reads."""
+        c = _roundtrip(tmp_path, {"name": "imp3", "version": "1.0", "rules": []},
+                       created_by="alice")
+        assert c.proposed_by == "alice"
+
+    def test_meta_written_into_nested_block_not_top_level(self, tmp_path):
+        """The root cause: stamps must land inside `contract:`, not beside it."""
+        doc = yaml.safe_load(yaml.safe_dump({"contract": {"name": "imp4", "rules": []}}))
+        _apply_import_meta(doc, "bob")
+        assert doc["contract"]["status"] == "draft"
+        assert doc["contract"]["source"] == "import"
+        assert doc["contract"]["proposed_by"] == "bob"
+        assert "status" not in doc, "stamp must not be written at the top level"
+        assert "source" not in doc
+
+
+class TestApplyImportMetaIsSafe:
+    def test_no_contract_block_is_a_noop(self):
+        doc = {"something_else": {}}
+        _apply_import_meta(doc, "alice")  # must not raise
+        assert "status" not in doc
+
+    def test_non_dict_contract_block_is_a_noop(self):
+        doc = {"contract": "not-a-dict"}
+        _apply_import_meta(doc, "alice")  # must not raise
+        assert doc["contract"] == "not-a-dict"

--- a/tests/test_crt177_persistence.py
+++ b/tests/test_crt177_persistence.py
@@ -17,11 +17,17 @@ provenance never reached disk:
 Both are fixed by serialising status + provenance structurally through the
 shared atomic writer.
 """
+import os
+
 import yaml
 
 import pytest
 
-from opendqv.core.contracts import ContractRegistry
+from opendqv.core.contracts import (
+    ContractPersistenceError,
+    ContractRegistry,
+    DataContract,
+)
 from opendqv.core.rule_parser import ContractStatus
 
 
@@ -94,6 +100,58 @@ class TestStatusWriteDoesNotCorruptNestedKeys:
         _write(cdir, "c6", {"name": "c6", "version": "1.0", "status": "draft", "rules": []})
         ContractRegistry(cdir).set_status("c6", "1.0", ContractStatus.ACTIVE)
         assert not list(cdir.glob("*.tmp")), "atomic write must not leave a temp file"
+
+
+class TestPersistenceFailureIsReported:
+    """A transition that did not reach disk must not be reported as success —
+    memory/history would say ACTIVE while the next reload reverts it. Found by
+    adversarial review of the first cut of this fix, which logged and continued."""
+
+    def test_legacy_format_transition_persists(self, cdir):
+        """Flat `rules:` list — no `contract:` block. Status/provenance are
+        written at the top level and read back there, so the transition is
+        durable rather than a silent no-op."""
+        (cdir / "legacy_c.yaml").write_text(
+            yaml.safe_dump({"version": "1.0",
+                            "rules": [{"name": "r", "field": "f", "type": "not_empty"}]}),
+            encoding="utf-8",
+        )
+        ContractRegistry(cdir).set_status("legacy_c", "1.0", ContractStatus.DRAFT)
+        assert ContractRegistry(cdir).get("legacy_c").status == ContractStatus.DRAFT
+
+    def test_legacy_format_approval_provenance_persists(self, cdir):
+        (cdir / "legacy_d.yaml").write_text(
+            yaml.safe_dump({"version": "1.0", "status": "draft",
+                            "rules": [{"name": "r", "field": "f", "type": "not_empty"}]}),
+            encoding="utf-8",
+        )
+        reg = ContractRegistry(cdir)
+        reg.submit_for_review("legacy_d", "1.0", "alice")
+        reg.approve_contract("legacy_d", "1.0", "bob")
+        reloaded = ContractRegistry(cdir).get("legacy_d")
+        assert reloaded.status == ContractStatus.ACTIVE
+        assert reloaded.approved_by == "bob"
+
+    def test_write_failure_raises(self, cdir):
+        _write(cdir, "c8", {"name": "c8", "version": "1.0", "status": "draft", "rules": []})
+        reg = ContractRegistry(cdir)
+        reg.submit_for_review("c8", "1.0", "alice")
+        os.chmod(cdir, 0o500)  # read-only directory → the YAML write fails
+        try:
+            with pytest.raises(ContractPersistenceError):
+                reg.approve_contract("c8", "1.0", "bob")
+        finally:
+            os.chmod(cdir, 0o700)
+
+    def test_in_memory_contract_without_yaml_is_silent(self, cdir):
+        """A contract with no file on disk has nothing to persist to — that is a
+        legitimate state and must NOT raise."""
+        reg = ContractRegistry(cdir)
+        reg._contracts["mem"] = {
+            "1.0": DataContract(name="mem", version="1.0",
+                                status=ContractStatus.DRAFT, rules=[])
+        }
+        reg.set_status("mem", "1.0", ContractStatus.ACTIVE)  # must not raise
 
 
 class TestSerializerReaderSymmetry:

--- a/tests/test_crt177_persistence.py
+++ b/tests/test_crt177_persistence.py
@@ -1,0 +1,115 @@
+"""
+CRT177 Tier 2 — contract state durability recurrence tests (Protocol 32).
+
+The YAML serializer wrote only `rules` and `version`, so lifecycle state and
+provenance never reached disk:
+
+  * `submit_for_review` / `approve_contract` / `reject_contract` updated memory
+    and history but never wrote back — **an approval reverted to the on-disk
+    status on the next restart or `/contracts/reload`** while history claimed
+    ACTIVE. `set_status` (the *ungoverned* demote/archive path) did persist, so
+    the durability guarantee was exactly inverted.
+  * `set_status` persisted via an unanchored ``^( +status: )\\S+`` regex that
+    rewrote EVERY indented ``status:`` line in the file — corrupting any nested
+    ``status`` key (a rule field named `status`, a context override) — and wrote
+    non-atomically.
+
+Both are fixed by serialising status + provenance structurally through the
+shared atomic writer.
+"""
+import yaml
+
+import pytest
+
+from opendqv.core.contracts import ContractRegistry
+from opendqv.core.rule_parser import ContractStatus
+
+
+def _write(dirpath, name, body):
+    (dirpath / f"{name}.yaml").write_text(
+        yaml.safe_dump({"contract": body}), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def cdir(tmp_path):
+    return tmp_path
+
+
+class TestLifecycleTransitionsPersist:
+    def test_approval_survives_reload(self, cdir):
+        _write(cdir, "c1", {"name": "c1", "version": "1.0", "status": "draft", "rules": []})
+        reg = ContractRegistry(cdir)
+        reg.submit_for_review("c1", "1.0", "alice")
+        reg.approve_contract("c1", "1.0", "bob")
+        assert reg.get("c1").status == ContractStatus.ACTIVE
+
+        # The regression: a fresh registry reads from disk.
+        reloaded = ContractRegistry(cdir).get("c1")
+        assert reloaded.status == ContractStatus.ACTIVE, "approval must survive reload"
+        assert reloaded.approved_by == "bob"
+        assert reloaded.proposed_by == "alice"
+
+    def test_submit_for_review_survives_reload(self, cdir):
+        _write(cdir, "c2", {"name": "c2", "version": "1.0", "status": "draft", "rules": []})
+        ContractRegistry(cdir).submit_for_review("c2", "1.0", "alice")
+        reloaded = ContractRegistry(cdir).get("c2")
+        assert reloaded.status == ContractStatus.REVIEW
+        assert reloaded.proposed_by == "alice"
+
+    def test_rejection_and_reason_survive_reload(self, cdir):
+        _write(cdir, "c3", {"name": "c3", "version": "1.0", "status": "draft", "rules": []})
+        reg = ContractRegistry(cdir)
+        reg.submit_for_review("c3", "1.0", "alice")
+        reg.reject_contract("c3", "1.0", "bob", "insufficient coverage")
+        reloaded = ContractRegistry(cdir).get("c3")
+        assert reloaded.status == ContractStatus.DRAFT
+        assert reloaded.rejected_by == "bob"
+        assert reloaded.rejection_reason == "insufficient coverage"
+
+    def test_set_status_still_persists(self, cdir):
+        # set_status already persisted; it must keep doing so after the
+        # regex → structured-serialisation swap.
+        _write(cdir, "c4", {"name": "c4", "version": "1.0", "status": "active", "rules": []})
+        ContractRegistry(cdir).set_status("c4", "1.0", ContractStatus.ARCHIVED)
+        assert ContractRegistry(cdir).get("c4").status == ContractStatus.ARCHIVED
+
+
+class TestStatusWriteDoesNotCorruptNestedKeys:
+    def test_nested_status_key_not_clobbered(self, cdir):
+        """The old regex rewrote every indented `status:` line in the file."""
+        _write(cdir, "c5", {
+            "name": "c5", "version": "1.0", "status": "active",
+            "rules": [{"name": "r1", "field": "status", "type": "not_empty"}],
+            "contexts": {"eu": [{"name": "r2", "field": "status", "type": "not_empty"}]},
+        })
+        ContractRegistry(cdir).set_status("c5", "1.0", ContractStatus.ARCHIVED)
+
+        raw = yaml.safe_load((cdir / "c5.yaml").read_text(encoding="utf-8"))["contract"]
+        assert raw["status"] == "archived"                       # lifecycle status changed
+        assert raw["rules"][0]["field"] == "status"              # rule field untouched
+        assert raw["contexts"]["eu"][0]["field"] == "status"     # context override untouched
+
+    def test_write_is_atomic_no_tmp_left_behind(self, cdir):
+        _write(cdir, "c6", {"name": "c6", "version": "1.0", "status": "draft", "rules": []})
+        ContractRegistry(cdir).set_status("c6", "1.0", ContractStatus.ACTIVE)
+        assert not list(cdir.glob("*.tmp")), "atomic write must not leave a temp file"
+
+
+class TestSerializerReaderSymmetry:
+    def test_every_persisted_field_is_read_back(self, cdir):
+        """A field written but not read by _parse_contract_format is lost
+        silently on reload — this guards that pairing."""
+        _write(cdir, "c7", {"name": "c7", "version": "1.0", "status": "draft", "rules": []})
+        reg = ContractRegistry(cdir)
+        c = reg.get("c7")
+        for field in ContractRegistry._PERSISTED_META_FIELDS:
+            setattr(c, field, f"val-{field}")
+        reg._persist_contract_meta("c7", c)
+
+        reloaded = ContractRegistry(cdir).get("c7")
+        for field in ContractRegistry._PERSISTED_META_FIELDS:
+            assert getattr(reloaded, field) == f"val-{field}", (
+                f"{field!r} is in _PERSISTED_META_FIELDS but _parse_contract_format "
+                f"does not read it back — it will be lost on reload"
+            )

--- a/tests/test_import_api_save.py
+++ b/tests/test_import_api_save.py
@@ -267,8 +267,13 @@ class TestODCSImportAPI:
         assert "contract" in body
 
     def test_import_odcs_save_true(self, client, editor_headers):
+        # CRT177 Tier 2: pass an explicit contract_name (as every sibling import
+        # test does). Without one the ODCS importer falls back to the generic
+        # default `imported_contract`, which another test in the suite creates
+        # and promotes to ACTIVE — and an import must not overwrite a governed
+        # contract, so this correctly 409s depending on test order.
         r = client.post(
-            "/api/v1/import/odcs?save=true",
+            "/api/v1/import/odcs?save=true&contract_name=test_odcs_saved",
             json=self.ODCS_CONTRACT,
             headers=editor_headers,
         )

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -24,11 +24,14 @@ class TestContractStatus:
 class TestStatusChange:
     """Test changing contract lifecycle status."""
 
-    def test_change_to_draft(self, client, auth_headers, approver_headers):
+    def test_change_to_draft(self, client, approver_headers):
+        # CRT177 Tier 2: demoting an ACTIVE contract requires approver/admin —
+        # DRAFT unlocks rule mutation, so demote carries the same weight as
+        # promote. This previously passed with a `validator` token.
         r = client.post(
             "/api/v1/contracts/customer/status",
             params={"status": "draft"},
-            headers=auth_headers,
+            headers=approver_headers,
         )
         assert r.status_code == 200
         assert r.json()["status"] == "draft"
@@ -71,7 +74,7 @@ class TestDraftBlocking:
 
     def test_draft_blocks_validate(self, client, auth_headers, approver_headers):
         # Set to draft
-        client.post("/api/v1/contracts/customer/status", params={"status": "draft"}, headers=auth_headers)
+        client.post("/api/v1/contracts/customer/status", params={"status": "draft"}, headers=approver_headers)
 
         body = {"record": {"email": "test@example.com"}, "contract": "customer"}
         r = client.post("/api/v1/validate", json=body, headers=auth_headers)
@@ -82,7 +85,7 @@ class TestDraftBlocking:
         client.post("/api/v1/contracts/customer/status", params={"status": "active"}, headers=approver_headers)
 
     def test_draft_allowed_with_flag(self, client, auth_headers, approver_headers):
-        client.post("/api/v1/contracts/customer/status", params={"status": "draft"}, headers=auth_headers)
+        client.post("/api/v1/contracts/customer/status", params={"status": "draft"}, headers=approver_headers)
 
         body = {
             "record": {
@@ -228,7 +231,7 @@ class TestRuleMutationOnDraft:
             pytest.skip("No active contracts available")
         contract_name = active[0]["name"]
 
-        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=auth_headers)
+        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=approver_headers)
         try:
             r = client.post(f"/api/v1/contracts/{contract_name}/rules", json=self._RULE, headers=editor_headers)
             assert r.status_code == 200
@@ -248,7 +251,7 @@ class TestRuleMutationOnDraft:
             pytest.skip("No active contracts available")
         contract_name = active[0]["name"]
 
-        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=auth_headers)
+        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=approver_headers)
         try:
             rule_a = dict(self._RULE, name="act047_counter_rule_a")
             rule_b = dict(self._RULE, name="act047_counter_rule_b")
@@ -281,7 +284,7 @@ class TestRuleMutationOnDraft:
             pytest.skip("No active contracts available")
         contract_name = active[0]["name"]
 
-        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=auth_headers)
+        client.post(f"/api/v1/contracts/{contract_name}/status", params={"status": "draft"}, headers=approver_headers)
         try:
             # Add a rule first so we have something to delete
             r = client.post(f"/api/v1/contracts/{contract_name}/rules", json=self._RULE, headers=editor_headers)


### PR DESCRIPTION
## CRT177 Tier 2 — contract-governance patch tier (v2.3.30)

Closes five paths that bypassed ACTIVE-contract immutability, the maker-checker approval workflow, or both. Design reviewed before implementation; the diff was then adversarially red-teamed, which found three further issues (all fixed here). No public API change, no contract-format change.

**Behaviour change worth noting:** `POST /import/*?save=true` now genuinely persists as `draft`. CSV and ODCS previously landed as `active` because the status stamp went to the wrong level of the YAML document — the route already *documented* and *reported* `draft`, so this aligns disk with the documented contract.

### Security

- **Profiler save was unguarded and destructive.** `POST /profile?save=true` had no role guard (every `/import/*` sibling requires editor/admin per SEC-010) and wrote with a bare `open(name.yaml, "w")` with no existence check. Since the name is caller-supplied, `?contract_name=customer&save=true` **replaced a live ACTIVE contract** and reloaded it. Now editor/admin, and `409` rather than overwriting any non-DRAFT contract.
- **Imports could overwrite a live ACTIVE contract** — same hole, same cause. Verified: the bundled ACTIVE `customer` went from 12 rules to 1 via `/import/gx?save=true`. Since imports now correctly land as DRAFT, this *also* demoted the contract — precisely what the status guard below restricts to approver/admin. Both bulk-write surfaces now share one guard, matched **case-insensitively** (on Windows/macOS `Customer.yaml` and `customer.yaml` are the same inode, so a case variant would have slipped past).
- **Status changes were authorized only when promoting to ACTIVE**, so `reader`/`auditor`/`validator` could archive or demote a production contract. Archiving a live contract is a validation outage; demoting unlocks rule mutation, so demote-then-edit defeated maker-checker. Any transition **to** or **out of** ACTIVE now requires approver/admin; others require editor/admin.
- **Imports could persist as ACTIVE, skipping approval** — the status/provenance stamp was written to the top level of the YAML while the loader reads the nested `contract:` block, so every stamp was a silent no-op. Provenance is now recorded on all eight importers.

### Fixed

- **Lifecycle state did not survive a reload.** The serializer wrote only `rules`+`version`, so submit/approve/reject never reached disk — an approval reverted on restart while history claimed ACTIVE. Because `set_status` *did* persist, durability was inverted: the ungoverned transition was durable, the governed one was not. Now serialized structurally on every transition, including the legacy/onboarding formats (written and read at the top level).
- **A failed state write is no longer silent** — raises `ContractPersistenceError` rather than returning `200` and firing the approval webhook for a change that never landed.
- **Status write-back could corrupt a contract** — `set_status` used an unanchored `^( +status: )\S+` regex that rewrote *every* indented `status:` line (a rule field named `status`, a context override) and wrote non-atomically. Replaced with structured serialization through the shared atomic writer.

### Tests
New `tests/test_crt177_persistence.py`, `test_crt177_governance.py`, `test_crt177_imports.py`. Also fixes two test-isolation problems this work exposed: the governance tests no longer drive the shared `customer` contract through the rate-limited status endpoint (a 429 on the restore call left it demoted for downstream tests), and the ODCS save test now passes an explicit name instead of relying on the importer's generic default.

**Full suite: 4321 passed, 23 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)