### PR TITLE
CRT179 — v2.4.0: ODCS v3.1.0 export/import made schema-valid (breaking wire format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ semantic caveats (e.g. `required` → `not_empty` is stricter). The clean CSV
 fixture passes all 20 checks the reference implementation generates from the
 projection; the bad fixture fails exactly the 8 planted fields.
 
+**Ultrareview findings (2026-09-02, all three confirmed and fixed).** (1) Native
+projection ignored rule qualifiers: a rule with `condition:` (19 bundled
+error-severity rules), `regex` with `negate: true`, or `unique` with `group_by`
+projected as an unconditional / inverted / stricter native constraint —
+`datacontract test` would have rejected rows the OpenDQV engine legitimately
+passes. Qualified rules now stay custom-only; a ledger-guard test proves every
+projected native constraint on every bundled contract traces to an
+unconditional, un-negated, ungrouped error rule. (2) JDK date patterns now quote
+literal text (`yyyy-MM-dd'T'HH:mm:ss`), which Java consumers require, and the
+importer un-quotes it. (3) `severity_floor` leaked as a `!!python/object` YAML
+tag that `yaml.safe_load` rejects; the exporter now dumps in JSON mode and strips
+the engine-stamped federation/credential fields the importer refuses, so a
+federated rule round-trips.
+
 Docs: `importers.md` (full export/import mapping tables, loss ledger,
 verification recipe), `cli.md`, `api_reference.md`, `troubleshooting.md`, UI
 import placeholder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to OpenDQV are documented here.
 
+## [2.4.0] - 2026-09-02
+
+ODCS compliance release (CRT179, minor tier — **breaking wire-format change**
+on `export-odcs` / `GET /export/odcs/{name}` and `import-odcs` / `POST /import/odcs`).
+
+**What was wrong.** Since v1.0 the ODCS importer/exporter claimed "ODCS 3.1" but
+emitted and consumed an invented shape: an `info:` block (ODCS 3 has none —
+`id`, `version`, `status` are required top-level fields), quality entries typed
+`not_null` / `regex` / `min` / … (the ODCS enum is `text | library | sql | custom`)
+and a `mustBeSatisfied` flag that does not exist in the standard. Verified against
+the official ODCS v3.1.0 JSON schema and `datacontract lint` (datacontract-cli
+1.1.2): every export failed on the first check, and a real ODCS document imported
+as an empty contract named `imported_contract`.
+
+**Export (now ODCS v3.1.0, schema-valid).** Top-level `id`/`name`/`version`/`status`
+(lifecycle mapped to the ODCS vocabulary, original kept in
+`customProperties[opendqv.status]`), `description.purpose`, `team` for owner.
+Every rule is carried losslessly as a `quality` entry of `type: custom, engine:
+opendqv` (severity, error_message and all cross-field parameters survive a round
+trip). Error-severity rules are additionally projected onto the native fields
+other tools read — `required`, `unique`, `logicalTypeOptions` (`pattern`,
+`minLength`/`maxLength`, `minimum`/`maximum`, JDK date `format`) and a
+`library invalidValues` metric for `allowed_values` lookups. Warning-severity
+rules are deliberately never projected: a native ODCS constraint is a hard
+constraint to every downstream consumer. One `logicalType` per field (numeric >
+date > string); incompatible rules stay custom-only so the document remains valid.
+
+**Import (ODCS v3.0.x / v3.1.0).** Reads real ODCS: top-level fields, `team` (3.1
+object or 3.0 member list), `required`/`unique`, `logicalTypeOptions`, record-level
+library metrics (`nullValues` / `duplicateValues` / `invalidValues` with `mustBe: 0`,
+deprecated `rule:` spelling accepted) and `custom/opendqv` entries (authoritative —
+native projections on that property are ignored). Everything dataset-level or
+inexpressible (`text`, `sql`, other engines, object-level checks, `rowCount`,
+percentage thresholds, `multipleOf`, date bounds, exclusive bounds treated as
+inclusive, duplicate fields across flattened schema objects) is reported in
+`skipped_checks` — nothing is dropped silently. Non-ODCS-3 documents (including
+the old invented shape) and invalid rules return **HTTP 422** instead of 200/500.
+
+**Import safety (Sonnet pre-implementation review).** A `custom/opendqv`
+implementation is allow-listed against the `Rule` model and may not set
+`inherited`, `federation_tier`, `provenance`, `severity_floor` or
+`lookup_auth_header` — an import must not mint federation authority, audit
+provenance or outbound-credential intent. Invalid rules fail the whole import.
+
+**Verification gate (new, permanent).** `tests/test_odcs_import.py` validates every
+bundled contract's export against the vendored official schema
+(`tests/fixtures/odcs-json-schema-v3.1.0.json`), proves export → import → export
+is idempotent on all 41 bundled contracts with zero skipped checks, imports the
+spec's own `full-example.odcs.yaml`, and — when `datacontract` is on PATH or
+`OPENDQV_DATACONTRACT_BIN` is set — runs `datacontract lint` on the output.
+
+Docs: `importers.md` (full export/import mapping tables), `cli.md`,
+`api_reference.md`, `troubleshooting.md`, UI import placeholder.
+
 ## [2.3.30] - 2026-08-06
 
 Contract-governance release (CRT177 Tier 2, patch tier). Closes four paths that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,23 @@ is idempotent on all 41 bundled contracts with zero skipped checks, imports the
 spec's own `full-example.odcs.yaml`, and — when `datacontract` is on PATH or
 `OPENDQV_DATACONTRACT_BIN` is set — runs `datacontract lint` on the output.
 
-Docs: `importers.md` (full export/import mapping tables), `cli.md`,
-`api_reference.md`, `troubleshooting.md`, UI import placeholder.
+**Reference-implementation hardening (Mac Claude review, verified with
+`datacontract test` on CSV fixtures).** Regex patterns with lookaround /
+backreferences are not projected natively (RE2 consumers abort); built-in
+pattern aliases are expanded; `allowed_values` (a distinct rule type the old
+exporter never mapped) → `library invalidValues` with string-quoted values;
+datetime formats → `logicalType: timestamp`; `unique` + `group_by` →
+object-level `duplicateValues`; exclusive bounds are skipped rather than
+loosened; `missingValues [null, '']` → `not_empty`; `text` entries carrying a
+metric are executed as library; native-derived rules are validated through the
+`Rule` model so a non-compiling pattern fails the import; `import_notes` reports
+semantic caveats (e.g. `required` → `not_empty` is stricter). The clean CSV
+fixture passes all 20 checks the reference implementation generates from the
+projection; the bad fixture fails exactly the 8 planted fields.
+
+Docs: `importers.md` (full export/import mapping tables, loss ledger,
+verification recipe), `cli.md`, `api_reference.md`, `troubleshooting.md`, UI
+import placeholder.
 
 ## [2.3.30] - 2026-08-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ It validates records against YAML data contracts at the point of write — befor
 data enters the pipeline ("shift-left"). It is **not** a pipeline monitoring tool
 (that's Monte Carlo) or a pipeline test framework (that's dbt/Soda).
 
-**Version:** 2.3.26
+**Version:** 2.4.0
 **Stack:** FastAPI + Gunicorn/Uvicorn, Streamlit UI, SQLite/PostgreSQL, DuckDB (batch), MCP
 
 ---

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -42,11 +42,11 @@ Full interactive docs at `/docs` (Swagger) and `/redoc` (ReDoc) when the server 
 | `POST` | `/api/v1/import/dbt` | Yes (editor+) | Import dbt schema.yml |
 | `POST` | `/api/v1/import/soda` | Yes (editor+) | Import Soda Core checks YAML |
 | `POST` | `/api/v1/import/csv` | Yes (editor+) | Import CSV rule definitions |
-| `POST` | `/api/v1/import/odcs` | Yes (editor+) | Import ODCS 3.1 contract |
+| `POST` | `/api/v1/import/odcs` | Yes (editor+) | Import ODCS v3.x contract (422 if not ODCS v3) |
 | `POST` | `/api/v1/import/csvw` | Yes (editor+) | Import CSV on the Web metadata |
 | `POST` | `/api/v1/import/otel` | Yes (editor+) | Import OpenTelemetry semantic conventions |
 | `POST` | `/api/v1/import/ndc` | Yes (editor+) | Import NDC format |
-| `GET` | `/api/v1/export/odcs/{contract}` | No | Export contract as ODCS 3.1 YAML |
+| `GET` | `/api/v1/export/odcs/{contract}` | No | Export contract as ODCS v3.1.0 YAML |
 | `GET` | `/api/v1/trace/verify` | Yes (auditor+) | Verify trace log hash-chain integrity |
 | `GET` | `/api/v1/registry` | No | Schema registry — list all contracts as versioned schemas |
 | `GET` | `/api/v1/registry/{name}` | No | Schema registry — get specific schema |
@@ -143,7 +143,7 @@ All importers return stats (total, imported, skipped) and a list of skipped item
 Pass `?save=true` to the API to persist contracts to disk and trigger a reload.
 CLI import commands always save by default.
 
-Export: `GET /api/v1/export/odcs/{contract}` — export a contract as ODCS 3.1 YAML.
+Export: `GET /api/v1/export/odcs/{contract}` — export a contract as ODCS v3.1.0 YAML (schema-valid; passes `datacontract lint`).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,8 +54,8 @@ opendqv --version
 | `import-dbt` | `<file>` | — | Import a dbt `schema.yml` and save as one or more YAML contracts |
 | `import-soda` | `<file>` | — | Import a Soda Core checks YAML and save as one or more YAML contracts |
 | `import-csv` | `<file>` | `--name` | Import a CSV rules file and save as a YAML contract |
-| `import-odcs` | `<file>` | `--name` | Import an ODCS 3.1 contract (YAML or JSON) and save as an OpenDQV contract |
-| `export-odcs` | `<contract>` | `--context`, `--output`/`-o` | Export contract as ODCS 3.1 YAML |
+| `import-odcs` | `<file>` | `--name` | Import an ODCS v3.x contract (YAML or JSON) and save as an OpenDQV contract |
+| `export-odcs` | `<contract>` | `--context`, `--output`/`-o` | Export contract as ODCS v3.1.0 YAML (validates with `datacontract lint`) |
 | `export-dbt` | `<contract>` | `--context`, `--output`/`-o` | Export contract as a dbt `schema.yml` |
 | `generate` | `<contract> <target>` | `--context` | Generate push-down validation code for `salesforce`, `js`, or `snowflake` |
 | `onboard` | — | — | Launch the interactive setup wizard; first validation in ~90 seconds |
@@ -191,7 +191,7 @@ opendqv import-csv rules/customer_rules.csv --name customer_v2
 
 ### `import-odcs <file>`
 
-Reads an Open Data Contract Standard (ODCS 3.1) contract — YAML or JSON — and converts it to an OpenDQV YAML contract. The contract name is taken from `info.title` unless `--name` is provided.
+Reads an Open Data Contract Standard (ODCS v3.0.x or v3.1.0) contract — YAML or JSON — and converts it to an OpenDQV YAML contract. The contract name is taken from the top-level `name` (falling back to `id`) unless `--name` is provided. Documents that are not ODCS v3.x are rejected.
 
 ```bash
 opendqv import-odcs my_odcs_contract.yaml --name payments
@@ -201,7 +201,7 @@ opendqv import-odcs my_odcs_contract.yaml --name payments
 
 ### `export-odcs <contract>`
 
-Exports a contract as ODCS 3.1 YAML, suitable for sharing with other platforms that consume the standard.
+Exports a contract as ODCS v3.1.0 YAML. The output validates against the official ODCS JSON schema and `datacontract lint`, so it can be handed to any tool that consumes the standard. See [importers.md](importers.md#odcs--open-data-contract-standard) for the exact mapping.
 
 ```bash
 opendqv export-odcs customer --output customer_odcs.yaml

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -107,10 +107,11 @@ the test suite on all bundled contracts.
 | every rule | one `quality` entry: `type: custom`, `engine: opendqv`, `implementation: <rule>`, plus `name`, `severity`, `dimension`, `description` (= `error_message`) |
 | `not_empty` (error) | `required: true` |
 | `unique` (error) | `unique: true` |
-| `regex` / `min_length` / `max_length` (error, string field) | `logicalTypeOptions.pattern` / `minLength` / `maxLength` |
+| `regex` / `min_length` / `max_length` (error, string field) | `logicalTypeOptions.pattern` / `minLength` / `maxLength`. Built-in pattern aliases are expanded. Patterns using lookahead, lookbehind, atomic groups or backreferences are **not** projected (RE2-based consumers abort on them) and travel custom-only |
 | `min` / `max` / `range` (error, numeric field) | `logicalTypeOptions.minimum` / `maximum`; `logicalType: number` |
-| `date_format` (error) | `logicalType: date`, `logicalTypeOptions.format` as a JDK pattern (`yyyy-MM-dd`) |
-| `lookup` with `allowed_values` (error) | `quality: {type: library, metric: invalidValues, arguments.validValues, mustBe: 0}` |
+| `date_format` (error) | `logicalType: date` (or `timestamp` when the format has a time part), `logicalTypeOptions.format` as a JDK pattern (`yyyy-MM-dd`); omitted when the format has no JDK equivalent |
+| `allowed_values` (error) | `quality: {type: library, metric: invalidValues, arguments.validValues, mustBe: 0}` — values emitted as strings (the engine compares `str(value)`; a bare `true`/`1.0` is a CAST error in the reference implementation) |
+| `unique` with `group_by` (error) | object-level `quality: {type: library, metric: duplicateValues, arguments.properties: [field, …group_by]}` — at most one per object |
 
 Two deliberate choices:
 
@@ -121,6 +122,37 @@ Two deliberate choices:
 - **A field has one `logicalType`** (numeric wins over date wins over string). Only rules
   compatible with it are projected natively — the schema forbids e.g. `pattern` on a
   number. Nothing is lost: the `custom` entry always carries the full rule.
+
+### What other tools see (the loss ledger)
+
+The `custom/opendqv` entry is lossless, but only OpenDQV reads it. A native-only consumer
+(datacontract-cli's SodaCL / JSON-schema / dbt exporters, OpenMetadata) sees exactly the
+projected fields and nothing else. Deliberately absent from the native projection:
+
+| OpenDQV rule | Native ODCS | Why |
+|---|---|---|
+| any warning-severity rule | nothing | a native constraint is hard downstream |
+| `regex` with lookaround / backreference | nothing | RE2 consumers abort on the whole object |
+| `regex` on a numeric/date field | nothing | `pattern` is only valid under `logicalType: string` |
+| `not_empty` | `required: true` | ODCS `required` allows empty strings; OpenDQV does not — no double-count with `missingValues` |
+| `min_age` / `max_age` / `age_match` / `date_diff` | `logicalType: date` only | no ODCS calendar arithmetic |
+| `compare`, `required_if`, `forbidden_if`, `conditional_value`, `cross_field_range`, `field_sum`, `ratio_check`, `geospatial_bounds`, `checksum`, `lookup` (file / URL), `conditional_lookup` | nothing | cross-field / reference-data / algorithmic rules have no declarative ODCS form |
+
+`tests/test_odcs_import.py` pins this ledger: changing what projects is a deliberate edit.
+
+### Verification recipe
+
+```bash
+pip install 'datacontract-cli[duckdb]'
+opendqv export-odcs customer -o customer.odcs.yaml
+datacontract lint customer.odcs.yaml            # official schema
+# add  servers: [{server: local, type: local, path: rows.csv, format: csv}]  then:
+datacontract test customer.odcs.yaml            # executes required/unique/lengths/bounds/pattern/library metrics
+```
+
+The test suite runs both automatically when `datacontract` is on PATH (or `OPENDQV_DATACONTRACT_BIN`
+is set): on the bundled `customer` contract, a clean CSV passes all 20 generated checks and a
+CSV with 8 planted violations fails exactly those 8 fields.
 
 ### Import mapping
 
@@ -133,16 +165,20 @@ Two deliberate choices:
 | `quality: {type: custom, engine: opendqv, implementation}` | the rule itself — authoritative; native projections on that property are ignored |
 | `required: true` / `unique: true` | `not_empty` / `unique` (error) |
 | `logicalTypeOptions.pattern` / `minLength` / `maxLength` | `regex` / `min_length` / `max_length` |
-| `logicalTypeOptions.minimum` + `maximum` (number, integer) | `range`; one of them → `min` / `max`. `exclusiveMinimum` / `exclusiveMaximum` are treated as inclusive and reported in `skipped_checks` |
+| `logicalTypeOptions.minimum` + `maximum` (number, integer) | `range`; one of them → `min` / `max`. `exclusiveMinimum` / `exclusiveMaximum` have no strict-bound rule and are **skipped, never loosened** to inclusive (that would pass a value the document rejects) |
 | `logicalTypeOptions.format` (date) | `date_format` (JDK pattern → strftime; unsupported letters are reported) |
 | `library` `nullValues` / `duplicateValues` `mustBe: 0` | `not_empty` / `unique` (severity from the entry) |
-| `library` `invalidValues` + `arguments.validValues` `mustBe: 0` | `lookup` with `allowed_values` |
+| `library` `invalidValues` + `arguments.validValues` (or `arguments.pattern`) `mustBe: 0` | `allowed_values` (or `regex`) |
+| `library` `missingValues` with `arguments.missingValues` ⊆ `[null, '']` `mustBe: 0` | `not_empty`; any other sentinel (e.g. `'N/A'`) cannot be honoured and is skipped |
+| `text` entry carrying a `metric` | treated as `library` (the reference implementation executes it) |
 
 Everything else — `text` and `sql` checks, `custom` checks for other engines, object-level
 checks, `rowCount` / `missingValues`, percentage thresholds, `multipleOf`, date bounds — is
 dataset-level or not expressible at the record boundary and is listed in `skipped_checks`.
 Nothing is dropped silently. Multiple schema objects are flattened into one record contract;
-a field defined twice is reported and the first definition kept.
+a field defined twice is reported and the first definition kept. `import_notes` carries semantic
+caveats that are not skips — e.g. `required: true` becomes `not_empty`, which is stricter than
+ODCS `required` (ODCS allows empty strings). The CLI and UI print both lists.
 
 **Import safety.** A `custom/opendqv` implementation is allow-listed against the `Rule`
 model. It may not set `inherited`, `federation_tier`, `provenance`, `severity_floor` or

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -109,7 +109,7 @@ the test suite on all bundled contracts.
 | `unique` (error) | `unique: true` |
 | `regex` / `min_length` / `max_length` (error, string field) | `logicalTypeOptions.pattern` / `minLength` / `maxLength`. Built-in pattern aliases are expanded. Patterns using lookahead, lookbehind, atomic groups or backreferences are **not** projected (RE2-based consumers abort on them) and travel custom-only |
 | `min` / `max` / `range` (error, numeric field) | `logicalTypeOptions.minimum` / `maximum`; `logicalType: number` |
-| `date_format` (error) | `logicalType: date` (or `timestamp` when the format has a time part), `logicalTypeOptions.format` as a JDK pattern (`yyyy-MM-dd`); omitted when the format has no JDK equivalent |
+| `date_format` (error) | `logicalType: date` (or `timestamp` when the format has a time part), `logicalTypeOptions.format` as a JDK pattern (`yyyy-MM-dd`, literal text quoted: `yyyy-MM-dd'T'HH:mm:ss`); omitted when the format has no JDK equivalent |
 | `allowed_values` (error) | `quality: {type: library, metric: invalidValues, arguments.validValues, mustBe: 0}` — values emitted as strings (the engine compares `str(value)`; a bare `true`/`1.0` is a CAST error in the reference implementation) |
 | `unique` with `group_by` (error) | object-level `quality: {type: library, metric: duplicateValues, arguments.properties: [field, …group_by]}` — at most one per object |
 
@@ -132,6 +132,10 @@ projected fields and nothing else. Deliberately absent from the native projectio
 | OpenDQV rule | Native ODCS | Why |
 |---|---|---|
 | any warning-severity rule | nothing | a native constraint is hard downstream |
+| any rule with `condition:` | nothing | a native constraint is unconditional; 19 bundled error rules are conditional |
+| `regex` with `negate: true` | nothing | `pattern` always means "must match" — projecting would invert the rule |
+| `unique` with `group_by` | object-level `duplicateValues` only | property-level `unique: true` would reject rows the grouped rule accepts |
+| `inherited`, `federation_tier`, `provenance`, `severity_floor`, `lookup_auth_header` | stripped from the `custom` entry too | node-local engine state; refused on import, meaningless elsewhere |
 | `regex` with lookaround / backreference | nothing | RE2 consumers abort on the whole object |
 | `regex` on a numeric/date field | nothing | `pattern` is only valid under `logicalType: string` |
 | `not_empty` | `required: true` | ODCS `required` allows empty strings; OpenDQV does not — no double-count with `missingValues` |

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -83,39 +83,79 @@ be reviewed and activated before it can be used for production validation.
 
 ---
 
-## ODCS — Open Data Contract Standard (schema.quality section)
+## ODCS — Open Data Contract Standard (v3.1.0)
 
-OpenDQV imports and exports the **quality and schema sections** of ODCS 3.1 contracts.
-The following ODCS normative sections are **outside scope** and are silently dropped on
-import unless the contract was produced by OpenDQV itself:
+OpenDQV exports contracts as [ODCS v3.1.0](https://bitol-io.github.io/open-data-contract-standard/latest/)
+and imports ODCS v3.0.x / v3.1.0 documents. Every export validates against the official
+ODCS JSON schema and passes `datacontract lint`
+([datacontract-cli](https://github.com/datacontract/datacontract-cli)); this is enforced by
+the test suite on all bundled contracts.
 
-| ODCS normative section | Status in OpenDQV |
-|------------------------|-------------------|
-| `schema.quality` (not_null, unique, regex, range, min, max, min_length, max_length, date_format) | ✅ Imported and exported |
-| `info` (title, version, status, description, owner) | ✅ Imported and exported |
-| `sla` / `serviceLevel` | ❌ Out of scope — use your observability platform |
-| `semantics` (business meaning, ontology) | ❌ Out of scope — use your data catalog |
-| `infrastructure` (storage system, cloud, throughput) | ❌ Out of scope |
-| `terms_of_use` (licensing, regulatory constraints) | ❌ Out of scope |
-| `lineage` / upstream dependencies | ❌ Out of scope — use your lineage tool |
-| Consumer ownership model | ❌ Out of scope — OpenDQV enforces at the producer boundary |
+> **Before v2.4.0** the ODCS exporter emitted an `info:` block and `mustBeSatisfied`
+> quality checks. That shape was not ODCS 3.x and failed `datacontract lint` on the first
+> check. Re-export any contract exported with an earlier version.
+
+### Export mapping
+
+| OpenDQV | ODCS v3.1.0 |
+|---------|-------------|
+| `name` | `id`, `name`, `schema[0].name` |
+| `version` | `version` |
+| `status` draft / review / active / archived | `status` draft / proposed / active / deprecated (original kept in `customProperties[opendqv.status]`) |
+| `description` | `description.purpose` |
+| `owner`, `owner_email` | `team.name`, `team.members[].username` (role `owner`) |
+| every rule | one `quality` entry: `type: custom`, `engine: opendqv`, `implementation: <rule>`, plus `name`, `severity`, `dimension`, `description` (= `error_message`) |
+| `not_empty` (error) | `required: true` |
+| `unique` (error) | `unique: true` |
+| `regex` / `min_length` / `max_length` (error, string field) | `logicalTypeOptions.pattern` / `minLength` / `maxLength` |
+| `min` / `max` / `range` (error, numeric field) | `logicalTypeOptions.minimum` / `maximum`; `logicalType: number` |
+| `date_format` (error) | `logicalType: date`, `logicalTypeOptions.format` as a JDK pattern (`yyyy-MM-dd`) |
+| `lookup` with `allowed_values` (error) | `quality: {type: library, metric: invalidValues, arguments.validValues, mustBe: 0}` |
+
+Two deliberate choices:
+
+- **Warning-severity rules are never projected onto native ODCS fields.** A native
+  constraint (`required`, `logicalTypeOptions`) is a hard constraint to every other ODCS
+  consumer; a soft OpenDQV warning must not become one downstream. Warnings travel only in
+  the `custom` entry, with `severity: warning`.
+- **A field has one `logicalType`** (numeric wins over date wins over string). Only rules
+  compatible with it are projected natively — the schema forbids e.g. `pattern` on a
+  number. Nothing is lost: the `custom` entry always carries the full rule.
+
+### Import mapping
+
+| ODCS v3.x | OpenDQV |
+|-----------|---------|
+| `name` (else `id`) | contract name (lower-cased, non `[a-z0-9_]` → `_`) |
+| `version`, `status` | `version`; status mapped back (proposed → review, deprecated/retired → archived). The REST import always lands as `draft`. |
+| `description.purpose` (else `usage`) | `description` |
+| `team.name` / `team.members[0].username` (or the v3.0 member list) | `owner` / `owner_email` |
+| `quality: {type: custom, engine: opendqv, implementation}` | the rule itself — authoritative; native projections on that property are ignored |
+| `required: true` / `unique: true` | `not_empty` / `unique` (error) |
+| `logicalTypeOptions.pattern` / `minLength` / `maxLength` | `regex` / `min_length` / `max_length` |
+| `logicalTypeOptions.minimum` + `maximum` (number, integer) | `range`; one of them → `min` / `max`. `exclusiveMinimum` / `exclusiveMaximum` are treated as inclusive and reported in `skipped_checks` |
+| `logicalTypeOptions.format` (date) | `date_format` (JDK pattern → strftime; unsupported letters are reported) |
+| `library` `nullValues` / `duplicateValues` `mustBe: 0` | `not_empty` / `unique` (severity from the entry) |
+| `library` `invalidValues` + `arguments.validValues` `mustBe: 0` | `lookup` with `allowed_values` |
+
+Everything else — `text` and `sql` checks, `custom` checks for other engines, object-level
+checks, `rowCount` / `missingValues`, percentage thresholds, `multipleOf`, date bounds — is
+dataset-level or not expressible at the record boundary and is listed in `skipped_checks`.
+Nothing is dropped silently. Multiple schema objects are flattened into one record contract;
+a field defined twice is reported and the first definition kept.
+
+**Import safety.** A `custom/opendqv` implementation is allow-listed against the `Rule`
+model. It may not set `inherited`, `federation_tier`, `provenance`, `severity_floor` or
+`lookup_auth_header` — those are engine-stamped authority and credential fields — and an
+invalid rule fails the whole import with HTTP 422 rather than loading partially.
+
+Other ODCS sections (`servers`, `slaProperties`, `roles`, `support`, `price`, `tags`,
+`domain`, `tenant`) are outside OpenDQV's scope. They are returned as `_odcs_metadata` in
+the API response for the caller's use and are not persisted.
 
 > **Vocabulary note:** In ODCS and Data Mesh terminology, OpenDQV's "source system" is
 > the **data producer** and each calling service is a **data consumer**. OpenDQV enforces
 > quality rules at the producer boundary — before data leaves the source.
-
-> **Status on import:** Unlike GX and Soda importers (which always import as `draft`),
-> the ODCS importer preserves the source contract's `status` field (defaulting to `active`
-> if absent). This is intentional — ODCS carries explicit lifecycle status. Review the
-> imported contract before activating it for production validation.
-
-**Unsupported ODCS quality types (skipped with warning):**
-
-| ODCS type | Reason |
-|-----------|--------|
-| `custom` | No standard mapping |
-| `values` (enumerated) | No inline value set support; convert to `regex` manually |
-| `freshness` | Dataset-level time check — no record-level equivalent |
 
 ---
 
@@ -327,6 +367,6 @@ OpenDQV can also export contracts back to external schema formats:
 | Target format | CLI command | Notes |
 |---------------|-------------|-------|
 | dbt `schema.yml` | `export-dbt <contract>` | Produces dbt v2 column tests; use `--output` to write a file |
-| ODCS 3.1 | `export-odcs <contract>` | Open Data Contract Standard JSON/YAML |
+| ODCS v3.1.0 | `export-odcs <contract>` | Open Data Contract Standard YAML (schema-valid) |
 
 See [dbt Integration](dbt_integration.md) for the full rule-to-test mapping and required dbt packages.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,7 +105,7 @@ python -c "import yaml; yaml.safe_load(open('contracts/mycontract.yaml'))"
 - The input file contains a rule type the importer does not recognise
 - The YAML/JSON is structurally valid but semantically incomplete
 
-**Fix:** Inspect the error message — it will name the specific field or issue. For GX suites: GX 0.x suites use `expectation_suite_name`; GX 1.x suites use `name`. Both are accepted on import. The export endpoint emits GX 1.x format (`name`). For dbt schemas, ensure at least one model has `columns:` defined. For ODCS, ensure `apiVersion` and `kind` are present.
+**Fix:** Inspect the error message — it will name the specific field or issue. For GX suites: GX 0.x suites use `expectation_suite_name`; GX 1.x suites use `name`. Both are accepted on import. The export endpoint emits GX 1.x format (`name`). For dbt schemas, ensure at least one model has `columns:` defined. For ODCS, the document must be ODCS v3.x: `apiVersion` (v3.0.0–v3.1.0), `kind: DataContract`, `id`, `version`, `status` and a `schema` list. The pre-v2.4.0 `info:` / `mustBeSatisfied` shape is not ODCS and is rejected with 422.
 
 ---
 

--- a/opendqv/api/routes_imports.py
+++ b/opendqv/api/routes_imports.py
@@ -235,27 +235,33 @@ async def import_csv(
 async def import_odcs_contract(
     request: Request,
     response: Response,
-    contract_data: dict = Body(..., description="ODCS 3.1 contract as JSON dict"),
+    contract_data: dict = Body(..., description="ODCS v3.x contract as JSON dict"),
     save: bool = Query(False, description="Save as YAML contract to disk and reload registry"),
-    contract_name: str = Query("", description="Override contract name (default: from info.title)"),
+    contract_name: str = Query("", description="Override contract name (default: top-level name, else id)"),
     created_by: str = Query("", description="Identity of the caller creating this contract"),
     user=Depends(get_current_user),
     role: str = Depends(get_current_role),
 ):
     """
-    Import an Open Data Contract Standard (ODCS) 3.1 contract and convert to OpenDQV.
+    Import an Open Data Contract Standard (ODCS) v3.x contract and convert to OpenDQV.
 
-    Accepts ODCS 3.1 dict with apiVersion, kind, info, and schema sections.
-    Maps quality checks (not_null, unique, regex, range, min, max, min_length,
-    max_length, date_format) and field-level shortcuts (required, unique,
-    minLength, maxLength) to OpenDQV rules.
+    Accepts an ODCS v3.0.x / v3.1.0 document (apiVersion, kind, id, version,
+    status, schema). Maps property flags (required, unique), logicalTypeOptions
+    (pattern, minLength, maxLength, minimum, maximum, date format), record-level
+    library metrics (nullValues / duplicateValues / invalidValues with mustBe: 0)
+    and `custom` quality entries with `engine: opendqv` to OpenDQV rules.
+    Everything else is listed in `skipped_checks`. Documents that are not ODCS
+    v3.x, or that carry an invalid or forbidden rule definition, return 422.
 
     Pass ?save=true to write the contract YAML to the contracts/ directory and
     reload the registry, making it immediately available for validation.
     """
     if role not in ("editor", "admin"):
         raise HTTPException(status_code=403, detail=f"Role '{role}' is not permitted. Required: editor or admin.")
-    result = import_odcs(contract_data)
+    try:
+        result = import_odcs(contract_data)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"ODCS import failed: {exc}") from exc
     result["contract"]["source"] = "import"
     result["contract"]["status"] = "draft"
 
@@ -472,11 +478,12 @@ async def export_to_odcs(
     user=Depends(get_current_user),
 ):
     """
-    Export an OpenDQV contract as an ODCS 3.1 data contract YAML.
+    Export an OpenDQV contract as an ODCS v3.1.0 data contract YAML.
 
-    Returns ODCS 3.1 YAML (apiVersion: v3.1.0, kind: DataContract) with quality
-    checks mapped from OpenDQV rules. Suitable for use with OpenMetadata, Soda,
-    Monte Carlo, and the Data Contract CLI.
+    The output validates against the official ODCS v3.1.0 JSON schema and
+    `datacontract lint`. Error-severity rules are projected onto native ODCS
+    fields (required, unique, logicalTypeOptions); every rule is also carried
+    losslessly as a `custom` quality entry with `engine: opendqv`.
     """
     contract = _d._get_contract_versioned_or_404(contract_name, version)
 
@@ -491,6 +498,7 @@ async def export_to_odcs(
         status=contract.status.value if hasattr(contract.status, "value") else str(contract.status),
         description=getattr(contract, "description", "") or "",
         owner=getattr(contract, "owner", "") or "",
+        owner_email=getattr(contract, "owner_email", None),
     )
     from fastapi.responses import Response
     return Response(content=yaml_str, media_type="application/yaml")

--- a/opendqv/cli.py
+++ b/opendqv/cli.py
@@ -18,8 +18,8 @@ Commands:
     import-dbt <file>              Import dbt schema.yml and save as YAML contract(s)
     import-soda <file>             Import Soda Core checks YAML and save as YAML contract(s)
     import-csv <file>              Import CSV rules and save as YAML contract
-    import-odcs <file>             Import ODCS 3.1 contract (YAML/JSON) and save as OpenDQV contract
-    export-odcs <contract>         Export contract as ODCS 3.1 YAML
+    import-odcs <file>             Import ODCS v3.x contract (YAML/JSON) and save as OpenDQV contract
+    export-odcs <contract>         Export contract as ODCS v3.1.0 YAML
     export-dbt <contract>          Export contract as dbt schema.yml
     generate <contract> <target>   Generate validation code (salesforce/js/snowflake/spark/bigquery)
     onboard                        Interactive setup wizard — first validation in 90 seconds
@@ -427,7 +427,7 @@ def cmd_import_csv(args):
 
 
 def cmd_import_odcs(args):
-    """Import ODCS 3.1 contract (YAML or JSON) and save as OpenDQV contract YAML."""
+    """Import ODCS v3.x contract (YAML or JSON) and save as OpenDQV contract YAML."""
     import yaml as _yaml
 
     path = Path(args.file)
@@ -466,7 +466,7 @@ def cmd_import_odcs(args):
 
 
 def cmd_export_odcs(args):
-    """Export a contract as ODCS 3.1 YAML."""
+    """Export a contract as ODCS v3.1.0 YAML."""
 
     registry = get_registry()
     contract = registry.get(args.contract)
@@ -483,6 +483,7 @@ def cmd_export_odcs(args):
         status=status_val,
         description=getattr(contract, "description", "") or "",
         owner=getattr(contract, "owner", "") or "",
+        owner_email=getattr(contract, "owner_email", None),
     )
 
     if args.output:
@@ -1053,12 +1054,12 @@ def main():
     p_import_csv.add_argument("--name", default=None, help="Contract name (default: CSV filename stem)")
 
     # import-odcs
-    p_import_odcs = subparsers.add_parser("import-odcs", help="Import ODCS 3.1 contract and save as OpenDQV contract")
-    p_import_odcs.add_argument("file", help="Path to ODCS 3.1 YAML or JSON file")
+    p_import_odcs = subparsers.add_parser("import-odcs", help="Import ODCS v3.x contract and save as OpenDQV contract")
+    p_import_odcs.add_argument("file", help="Path to ODCS v3.x YAML or JSON file")
     p_import_odcs.add_argument("--name", default=None, help="Contract name override (default: from info.title)")
 
     # export-odcs
-    p_export_odcs = subparsers.add_parser("export-odcs", help="Export contract as ODCS 3.1 YAML")
+    p_export_odcs = subparsers.add_parser("export-odcs", help="Export contract as ODCS v3.1.0 YAML")
     p_export_odcs.add_argument("contract", help="Contract name")
     p_export_odcs.add_argument("--context", default=None, help="Context to apply before export")
     p_export_odcs.add_argument("--output", "-o", default=None, help="Write output to file instead of stdout")

--- a/opendqv/cli.py
+++ b/opendqv/cli.py
@@ -451,6 +451,7 @@ def cmd_import_odcs(args):
     _validate_contract_name(contract_name)
     rule_count = result["rule_count"]
     skipped = result["skipped_checks"]
+    notes = result.get("import_notes", [])
 
     CONTRACTS_DIR.mkdir(parents=True, exist_ok=True)
     out_path = CONTRACTS_DIR / f"{contract_name}.yaml"
@@ -463,6 +464,10 @@ def cmd_import_odcs(args):
         print(f"Skipped checks: {len(skipped)}")
         for s in skipped:
             print(f"  - {s}")
+    if notes:
+        print(f"Notes: {len(notes)}")
+        for n in notes:
+            print(f"  - {n}")
 
 
 def cmd_export_odcs(args):

--- a/opendqv/core/importers/odcs.py
+++ b/opendqv/core/importers/odcs.py
@@ -1,328 +1,584 @@
 """
-Open Data Contract Standard (ODCS) 3.1 importer and exporter.
+Open Data Contract Standard (ODCS) v3.1.0 importer and exporter.
 
-ODCS 3.1 is the emerging universal standard for data contracts, supported by:
-  - OpenMetadata v1.8+ (DataContract entity, import/export)
-  - Soda (quality checks alignment)
-  - Monte Carlo (contract metadata)
-  - Data Contract CLI (bitol-io/data-contract-cli)
+Reference: https://bitol-io.github.io/open-data-contract-standard/latest/
+Schema:    schema/odcs-json-schema-v3.1.0.json in the bitol-io repository.
 
 This module provides bidirectional conversion:
-  import_odcs(contract_data)     → OpenDQV contract dict
-  odcs_to_yaml(contract_data)    → (contract_name, YAML string)
-  export_odcs(name, rules, ...)  → ODCS 3.1 dict
-  contract_to_odcs_yaml(...)     → ODCS 3.1 YAML string
+  import_odcs(contract_data)     → OpenDQV contract dict (+ skipped_checks)
+  odcs_to_yaml(contract_data)    → (contract_name, OpenDQV YAML string)
+  export_odcs(name, rules, ...)  → ODCS 3.1.0 dict
+  contract_to_odcs_yaml(...)     → ODCS 3.1.0 YAML string
 
-ODCS 3.1 top-level structure (canonical):
-  apiVersion: v3.0.0 | v3.1.0
-  kind: DataContract
-  info:
-    title: <str>         → contract name
-    version: <str>       → contract version
-    status: active | draft | archived
-    description: <str>
-    owner: <str>
+ODCS 3.1.0 shape (the parts OpenDQV reads and writes):
+
+  apiVersion: v3.1.0            # required; v3.0.x accepted on import
+  kind: DataContract            # required
+  id: <str>                     # required — OpenDQV uses the contract name
+  name: <str>
+  version: <str>                # required
+  status: <str>                 # required — draft | proposed | active | deprecated | retired
+  description: {purpose, usage, limitations}
+  team: {name, members: [{username, role}]}
+  customProperties: [{property, value}]
   schema:
-    - name: <table/entity>
+    - name: <object>
+      logicalType: object
       properties:
         - name: <field>
-          required: true           → not_empty rule (error)
-          unique: true             → unique rule (error)
-          minLength: N             → min_length rule
-          maxLength: N             → max_length rule
+          logicalType: string | number | integer | date | ...
+          required: <bool>
+          unique: <bool>
+          logicalTypeOptions:   # keys depend on logicalType (schema-enforced)
+            pattern / minLength / maxLength / format      (string)
+            minimum / maximum / exclusiveMinimum / ...    (number, integer)
+            format / minimum / maximum                    (date)
           quality:
-            - type: not_null | notNull   → not_empty
-            - type: unique               → unique
-            - type: regex
-              pattern: <str>
-              mustBeSatisfied: <bool>    → error if true, warning if false
-            - type: range
-              min: N
-              max: N
-              mustBeSatisfied: <bool>
-            - type: min
-              min: N
-            - type: max
-              max: N
-            - type: min_length | minLength
-              minLength: N
-            - type: max_length | maxLength
-              maxLength: N
-            - type: date_format | dateFormat
-              format: <str>
+            - type: library     # metric: nullValues | duplicateValues | invalidValues | ...
+              metric: <str>
+              mustBe: <n>       # exactly one mustBe* operator
+            - type: custom      # engine + implementation are required
+              engine: opendqv
+              implementation: {<OpenDQV rule dict>}
 
-mustBeSatisfied absent / false → severity: warning
-mustBeSatisfied true            → severity: error
+Export strategy (lossless + interoperable):
+  * Every OpenDQV rule is emitted as a ``type: custom, engine: opendqv`` quality
+    entry whose ``implementation`` is the rule itself. That is the authoritative
+    form and round-trips exactly (severity, error_message, cross-field params).
+  * Rules with severity ``error`` are ALSO projected onto the native ODCS
+    fields other tools understand (``required``, ``unique``,
+    ``logicalTypeOptions``). Warning-severity rules are never projected —
+    a native ODCS constraint is a hard constraint to every other consumer.
+  * A field has exactly one ``logicalType``; only rules compatible with it are
+    projected natively (the schema forbids e.g. ``pattern`` on a number).
+
+Import strategy:
+  * If a property carries ``custom/opendqv`` entries, rules come from those and
+    the native projections on that property are ignored (they are echoes).
+  * Otherwise rules are derived from ``required``/``unique``/``logicalTypeOptions``
+    and from record-level library metrics (``nullValues``/``duplicateValues``/
+    ``invalidValues`` with ``mustBe: 0``). Everything else is dataset-level or
+    not expressible and is reported in ``skipped_checks`` — never dropped silently.
 """
 
 from __future__ import annotations
 
-from collections import defaultdict
+import re
+from collections import OrderedDict
 from typing import Any, Optional
 
 import yaml
+from pydantic import ValidationError
+
+from opendqv.core.rule_parser import Rule
+
+ODCS_API_VERSION = "v3.1.0"
+ODCS_ENGINE = "opendqv"
+_SUPPORTED_API_VERSIONS = {"v3.0.0", "v3.0.1", "v3.0.2", "v3.1.0"}
 
 # ---------------------------------------------------------------------------
-# ODCS quality type → OpenDQV type normalisation
+# Status mapping  (OpenDQV lifecycle ⇄ ODCS status vocabulary)
 # ---------------------------------------------------------------------------
 
-_TYPE_MAP: dict[str, str] = {
-    "not_null":   "not_empty",
-    "notnull":    "not_empty",
-    "not_empty":  "not_empty",
-    "unique":     "unique",
-    "regex":      "regex",
-    "range":      "range",
-    "min":        "min",
-    "max":        "max",
-    "min_length": "min_length",
-    "minlength":  "min_length",
-    "max_length": "max_length",
-    "maxlength":  "max_length",
-    "date_format":"date_format",
-    "dateformat": "date_format",
+_STATUS_TO_ODCS = {
+    "draft": "draft",
+    "review": "proposed",
+    "active": "active",
+    "archived": "deprecated",
+}
+_STATUS_FROM_ODCS = {
+    "draft": "draft",
+    "proposed": "review",
+    "active": "active",
+    "deprecated": "archived",
+    "retired": "archived",
 }
 
-# OpenDQV type → canonical ODCS 3.1 type string
-_ODCS_TYPE_MAP: dict[str, str] = {
-    "not_empty":  "not_null",
-    "unique":     "unique",
-    "regex":      "regex",
-    "range":      "range",
-    "min":        "min",
-    "max":        "max",
-    "min_length": "min_length",
-    "max_length": "max_length",
-    "date_format":"date_format",
-    "min_age":    "range",   # export as range with min constraint
-    "max_age":    "range",   # export as range with max constraint
+# ---------------------------------------------------------------------------
+# Rule-type → ODCS dimension / logicalType inference
+# ---------------------------------------------------------------------------
+
+_DIMENSION: dict[str, str] = {
+    "not_empty": "completeness",
+    "required_if": "completeness",
+    "unique": "uniqueness",
+    "regex": "conformity",
+    "min_length": "conformity",
+    "max_length": "conformity",
+    "date_format": "conformity",
+    "checksum": "conformity",
+    "lookup": "conformity",
+    "min": "accuracy",
+    "max": "accuracy",
+    "range": "accuracy",
+    "min_age": "accuracy",
+    "max_age": "accuracy",
+    "geospatial_bounds": "accuracy",
 }
+_DEFAULT_DIMENSION = "consistency"   # cross-field / conditional rules
+
+# Precedence when rules on one field imply different logical types.
+# Numeric wins over date wins over string so that min/max projections survive;
+# a field that is both "date_format" and "min" is a modelling error upstream.
+_NUMERIC_TYPES = {"min", "max", "range", "cross_field_range", "field_sum", "ratio_check", "geospatial_bounds"}
+_DATE_TYPES = {"date_format", "min_age", "max_age", "age_match", "date_diff"}
 
 
-def _severity(must_be_satisfied) -> str:
-    """Convert ODCS mustBeSatisfied → OpenDQV severity string."""
-    if must_be_satisfied is True:
-        return "error"
-    return "warning"
-
-
-def _normalize_type(odcs_type: str) -> Optional[str]:
-    return _TYPE_MAP.get(odcs_type.lower().replace("-", "_"))
-
-
-# ---------------------------------------------------------------------------
-# Per-quality-check converter
-# ---------------------------------------------------------------------------
-
-def _quality_to_rule(field: str, q: dict, rule_idx: int) -> Optional[dict]:
-    """Convert one ODCS quality check dict to an OpenDQV rule dict, or None to skip."""
-    odcs_type = q.get("type", "")
-    dqr_type = _normalize_type(odcs_type)
-    if not dqr_type:
-        return None  # unsupported type — skip
-
-    severity = _severity(q.get("mustBeSatisfied"))
-    rule_name = f"{field}_{dqr_type}_{rule_idx}"
-    rule: dict[str, Any] = {
-        "name": rule_name,
-        "type": dqr_type,
-        "field": field,
-        "severity": severity,
-        "error_message": q.get("description") or f"{field}: {odcs_type} check failed",
-    }
-
-    if dqr_type == "regex":
-        pattern = q.get("pattern") or q.get("regex", "")
-        if not pattern:
-            return None
-        rule["pattern"] = pattern
-
-    elif dqr_type == "range":
-        min_val = q.get("min") if q.get("min") is not None else q.get("minValue")
-        max_val = q.get("max") if q.get("max") is not None else q.get("maxValue")
-        if min_val is not None:
-            rule["min_value"] = float(min_val)
-        if max_val is not None:
-            rule["max_value"] = float(max_val)
-
-    elif dqr_type == "min":
-        val = q.get("min") if q.get("min") is not None else q.get("minValue")
-        if val is None:
-            return None
-        rule["min_value"] = float(val)
-
-    elif dqr_type == "max":
-        val = q.get("max") if q.get("max") is not None else q.get("maxValue")
-        if val is None:
-            return None
-        rule["max_value"] = float(val)
-
-    elif dqr_type == "min_length":
-        val = q.get("minLength") or q.get("min_length") or q.get("min")
-        if val is None:
-            return None
-        rule["min_length"] = int(val)
-
-    elif dqr_type == "max_length":
-        val = q.get("maxLength") or q.get("max_length") or q.get("max")
-        if val is None:
-            return None
-        rule["max_length"] = int(val)
-
-    elif dqr_type == "date_format":
-        fmt = q.get("format", "%Y-%m-%d")
-        rule["format"] = fmt
-
-    return rule
+def _infer_logical_type(rule_types: set[str]) -> str:
+    if rule_types & _NUMERIC_TYPES:
+        return "number"
+    if rule_types & _DATE_TYPES:
+        return "date"
+    return "string"
 
 
 # ---------------------------------------------------------------------------
-# Field-level shortcut attributes → rules
+# Date-format conversion  (strftime / human ⇄ JDK DateTimeFormatter)
 # ---------------------------------------------------------------------------
 
-def _field_shortcuts_to_rules(field: str, prop: dict) -> list[dict]:
-    """Convert field-level ODCS shortcuts (required, unique, minLength, maxLength) to rules."""
-    rules = []
-    if prop.get("required") is True:
-        rules.append({
-            "name": f"{field}_not_empty",
-            "type": "not_empty",
-            "field": field,
-            "severity": "error",
-            "error_message": f"{field} is required",
-        })
-    if prop.get("unique") is True:
-        rules.append({
-            "name": f"{field}_unique",
-            "type": "unique",
-            "field": field,
-            "severity": "error",
-            "error_message": f"{field} must be unique",
-        })
-    if prop.get("minLength") is not None:
-        rules.append({
-            "name": f"{field}_min_length",
-            "type": "min_length",
-            "field": field,
-            "severity": "error",
-            "min_length": int(prop["minLength"]),
-            "error_message": f"{field} must be at least {prop['minLength']} characters",
-        })
-    if prop.get("maxLength") is not None:
-        rules.append({
-            "name": f"{field}_max_length",
-            "type": "max_length",
-            "field": field,
-            "severity": "error",
-            "max_length": int(prop["maxLength"]),
-            "error_message": f"{field} must be at most {prop['maxLength']} characters",
-        })
-    return rules
+_STRFTIME_TO_JDK = {
+    "%Y": "yyyy", "%y": "yy", "%m": "MM", "%d": "dd",
+    "%H": "HH", "%M": "mm", "%S": "ss", "%f": "SSSSSS", "%%": "%",
+}
+_HUMAN_TO_JDK = {"YYYY": "yyyy", "YY": "yy", "DD": "dd", "HH": "HH", "SS": "ss"}
+
+
+def _to_jdk_format(fmt: str) -> Optional[str]:
+    """Convert an OpenDQV date format to a JDK pattern; None if not representable."""
+    if not fmt:
+        return None
+    if "%" in fmt:
+        out, i = [], 0
+        while i < len(fmt):
+            if fmt[i] == "%":
+                code = fmt[i:i + 2]
+                if code not in _STRFTIME_TO_JDK:
+                    return None
+                out.append(_STRFTIME_TO_JDK[code])
+                i += 2
+            else:
+                out.append(fmt[i])
+                i += 1
+        return "".join(out)
+    # Human form: YYYY-MM-DD / YYYY-MM-DD HH:MM:SS — MM is minutes after HH.
+    out, i, seen_h = [], 0, False
+    while i < len(fmt):
+        if fmt[i:i + 4] == "YYYY":
+            out.append("yyyy")
+            i += 4
+        elif fmt[i:i + 2] in ("YY", "DD", "HH", "SS"):
+            out.append(_HUMAN_TO_JDK[fmt[i:i + 2]])
+            seen_h = seen_h or fmt[i:i + 2] == "HH"
+            i += 2
+        elif fmt[i:i + 2] == "MM":
+            out.append("mm" if seen_h else "MM")
+            i += 2
+        else:
+            out.append(fmt[i])
+            i += 1
+    return "".join(out)
+
+
+_JDK_TOKENS = [("yyyy", "%Y"), ("yy", "%y"), ("MM", "%m"), ("dd", "%d"),
+               ("HH", "%H"), ("mm", "%M"), ("ss", "%S"), ("SSSSSS", "%f")]
+
+
+def _from_jdk_format(fmt: str) -> Optional[str]:
+    """Convert a JDK DateTimeFormatter pattern to strftime; None if unsupported."""
+    if not fmt:
+        return None
+    out, i = [], 0
+    while i < len(fmt):
+        for tok, code in _JDK_TOKENS:
+            if fmt.startswith(tok, i):
+                out.append(code)
+                i += len(tok)
+                break
+        else:
+            ch = fmt[i]
+            if ch.isalpha():
+                return None   # unknown pattern letter (e.g. 'a', 'z', 'E')
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Rule dict hygiene
+# ---------------------------------------------------------------------------
+
+# Fields an ODCS import may never set. They carry federation authority, audit
+# provenance, or outbound-credential intent and are stamped by the engine, not
+# by whoever hands us a document (Sonnet pre-implementation finding #1).
+_IMPORT_DENIED_FIELDS = frozenset({
+    "inherited", "federation_tier", "provenance", "severity_floor",
+    "lookup_auth_header",
+})
+_ALLOWED_RULE_FIELDS = frozenset(Rule.model_fields.keys()) - _IMPORT_DENIED_FIELDS
+_ALIAS_TO_FIELD = {"min": "min_value", "max": "max_value"}
+
+_NAME_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def _sanitise_name(raw: str) -> str:
+    name = _NAME_RE.sub("_", str(raw).strip().lower()).strip("_")
+    return name or "imported_contract"
+
+
+def _rule_to_dict(rule: Any) -> dict:
+    """Rule object or dict → plain dict with canonical field names, defaults dropped."""
+    if isinstance(rule, Rule):
+        d = rule.model_dump(exclude_none=True, exclude_defaults=True, by_alias=False)
+        # exclude_defaults drops severity=error / description="" — keep what matters
+        d["type"] = rule.type
+        d["field"] = rule.field
+        d["name"] = rule.name
+        d["severity"] = rule.severity.value if hasattr(rule.severity, "value") else str(rule.severity)
+        d["error_message"] = rule.error_message
+    else:
+        d = {}
+        for k, v in dict(rule).items():
+            if v is None:
+                continue
+            d[_ALIAS_TO_FIELD.get(k, k)] = v
+        sev = d.get("severity", "error")
+        d["severity"] = sev.value if hasattr(sev, "value") else str(sev)
+    if d.get("inherited") is False:
+        d.pop("inherited")
+    # Deterministic key order: identity first, then the rest alphabetically.
+    head = ["name", "type", "field", "severity", "error_message", "description"]
+    ordered: dict[str, Any] = OrderedDict()
+    for k in head:
+        if k in d and d[k] not in ("", None):
+            ordered[k] = d[k]
+    for k in sorted(d):
+        if k not in ordered and k not in head:
+            ordered[k] = d[k]
+    return dict(ordered)
+
+
+def _sanitise_rule_dict(field: str, impl: dict) -> dict:
+    """Allowlist a caller-supplied rule dict and validate it through the Rule model."""
+    if not isinstance(impl, dict):
+        raise ValueError(f"{field}: custom/opendqv implementation must be an object")
+    clean: dict[str, Any] = {}
+    for k, v in impl.items():
+        canon = _ALIAS_TO_FIELD.get(k, k)
+        if canon in _IMPORT_DENIED_FIELDS:
+            raise ValueError(f"{field}: field '{k}' may not be set by an ODCS import")
+        if canon not in _ALLOWED_RULE_FIELDS:
+            raise ValueError(f"{field}: unknown rule field '{k}'")
+        clean[canon] = v
+    clean.setdefault("field", field)
+    clean.setdefault("name", f"{field}_{clean.get('type', 'rule')}")
+    try:
+        validated = Rule(**clean)
+    except ValidationError as exc:
+        # One line per error, no stack detail — this reaches API clients as 422.
+        msgs = "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors())
+        raise ValueError(f"{field}: invalid rule — {msgs}") from None
+    return _rule_to_dict(validated)
 
 
 # ---------------------------------------------------------------------------
 # Importer
 # ---------------------------------------------------------------------------
 
+def _num(v: Any) -> Optional[float]:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _rule(field: str, rtype: str, severity: str = "error", message: str = "", **params) -> dict:
+    d = {"name": f"{field}_{rtype}", "type": rtype, "field": field, "severity": severity,
+         "error_message": message or f"{field}: {rtype} check failed"}
+    d.update({k: v for k, v in params.items() if v is not None})
+    return d
+
+
+def _native_rules(field: str, prop: dict, skipped: list[str]) -> list[dict]:
+    """Rules from required / unique / logicalTypeOptions."""
+    rules: list[dict] = []
+    if prop.get("required") is True:
+        rules.append(_rule(field, "not_empty", message=f"{field} is required"))
+    if prop.get("unique") is True:
+        rules.append(_rule(field, "unique", message=f"{field} must be unique"))
+
+    opts = prop.get("logicalTypeOptions") or {}
+    if not isinstance(opts, dict):
+        return rules
+    ltype = str(prop.get("logicalType") or "string").lower()
+
+    if opts.get("pattern"):
+        rules.append(_rule(field, "regex", message=f"{field} must match pattern", pattern=str(opts["pattern"])))
+    if opts.get("minLength") is not None:
+        rules.append(_rule(field, "min_length", message=f"{field} must be at least {opts['minLength']} characters",
+                           min_length=int(opts["minLength"])))
+    if opts.get("maxLength") is not None:
+        rules.append(_rule(field, "max_length", message=f"{field} must be at most {opts['maxLength']} characters",
+                           max_length=int(opts["maxLength"])))
+
+    if ltype in ("number", "integer"):
+        lo = _num(opts.get("minimum"))
+        hi = _num(opts.get("maximum"))
+        if opts.get("exclusiveMinimum") is not None and lo is None:
+            lo = _num(opts["exclusiveMinimum"])
+            skipped.append(f"{field}.exclusiveMinimum (treated as inclusive minimum)")
+        if opts.get("exclusiveMaximum") is not None and hi is None:
+            hi = _num(opts["exclusiveMaximum"])
+            skipped.append(f"{field}.exclusiveMaximum (treated as inclusive maximum)")
+        if lo is not None and hi is not None:
+            rules.append(_rule(field, "range", message=f"{field} must be between {lo:g} and {hi:g}",
+                               min_value=lo, max_value=hi))
+        elif lo is not None:
+            rules.append(_rule(field, "min", message=f"{field} must be >= {lo:g}", min_value=lo))
+        elif hi is not None:
+            rules.append(_rule(field, "max", message=f"{field} must be <= {hi:g}", max_value=hi))
+        if opts.get("multipleOf") is not None:
+            skipped.append(f"{field}.multipleOf (no OpenDQV equivalent)")
+
+    if ltype in ("date", "timestamp", "time"):
+        fmt = opts.get("format")
+        if fmt:
+            strf = _from_jdk_format(str(fmt))
+            if strf:
+                rules.append(_rule(field, "date_format", message=f"{field} must match date format {fmt}", format=strf))
+            else:
+                skipped.append(f"{field}.format '{fmt}' (unsupported date pattern)")
+        for k in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"):
+            if opts.get(k) is not None:
+                skipped.append(f"{field}.{k} (date bounds not supported)")
+    return rules
+
+
+def _library_rule(field: str, q: dict, skipped: list[str]) -> Optional[dict]:
+    """Record-level reading of an ODCS library metric, or None (reason appended to skipped)."""
+    metric = q.get("metric") or q.get("rule")   # `rule` is the deprecated 3.0 spelling
+    severity = "warning" if str(q.get("severity", "error")).lower() in ("warning", "warn", "info") else "error"
+    message = q.get("description") or ""
+    must_be_zero = q.get("mustBe") in (0, 0.0, "0")
+    if metric == "nullValues" and must_be_zero:
+        return _rule(field, "not_empty", severity, message or f"{field} must not be null")
+    if metric == "duplicateValues" and must_be_zero:
+        return _rule(field, "unique", severity, message or f"{field} must be unique")
+    if metric == "invalidValues" and must_be_zero:
+        args = q.get("arguments") or {}
+        values = args.get("validValues") if isinstance(args, dict) else None
+        if isinstance(values, list) and values:
+            return _rule(field, "lookup", severity, message or f"{field} must be one of the valid values",
+                         allowed_values=[str(v) for v in values])
+        skipped.append(f"{field}.invalidValues (no validValues argument)")
+        return None
+    skipped.append(f"{field}.{metric or '?'} (dataset-level metric, no record-level equivalent)")
+    return None
+
+
+def _quality_rules(field: str, quality: list, skipped: list[str]) -> tuple[list[dict], bool]:
+    """Return (rules, had_opendqv_custom). Custom/opendqv entries take precedence."""
+    custom: list[dict] = []
+    other: list[dict] = []
+    for q in quality or []:
+        if not isinstance(q, dict):
+            continue
+        qtype = str(q.get("type", "")).lower()
+        if qtype == "custom":
+            if str(q.get("engine", "")).lower() == ODCS_ENGINE:
+                custom.append(_sanitise_rule_dict(field, q.get("implementation")))
+            else:
+                skipped.append(f"{field}.custom (engine '{q.get('engine', '?')}')")
+        elif qtype == "library" or q.get("metric") or q.get("rule"):
+            r = _library_rule(field, q, skipped)
+            if r:
+                other.append(r)
+        elif qtype in ("text", "sql"):
+            skipped.append(f"{field}.{qtype} (not executable at record level)")
+        else:
+            skipped.append(f"{field}.{q.get('type') or '?'} (unknown quality type)")
+    if custom:
+        return custom, True
+    return other, False
+
+
+def _team_owner(team: Any) -> tuple[str, Optional[str]]:
+    """(owner, owner_email) from ODCS 3.1 team object or 3.0 member list."""
+    if isinstance(team, dict):
+        members = team.get("members") or []
+        first = next((m for m in members if isinstance(m, dict)), {})
+        return str(team.get("name") or first.get("username") or ""), (first.get("username") or None)
+    if isinstance(team, list):
+        first = next((m for m in team if isinstance(m, dict)), {})
+        return str(first.get("username") or first.get("name") or ""), (first.get("username") or None)
+    return "", None
+
+
+def _custom_property(doc: dict, key: str) -> Optional[Any]:
+    for cp in doc.get("customProperties") or []:
+        if isinstance(cp, dict) and cp.get("property") == key:
+            return cp.get("value")
+    return None
+
+
 def import_odcs(contract_data: dict) -> dict:
     """
-    Convert an ODCS 3.1 contract dict to an OpenDQV contract dict.
+    Convert an ODCS 3.x contract dict to an OpenDQV contract dict.
 
-    Args:
-        contract_data: Parsed ODCS 3.1 dict (from YAML or JSON).
-
-    Returns:
-        OpenDQV contract dict with keys: contract (name, version, status,
-        description, owner, rules).
+    Raises ValueError for documents that are not ODCS 3.x or carry an invalid
+    or forbidden rule definition (callers map this to HTTP 422).
     """
-    _KNOWN_ODCS_KEYS = {"apiVersion", "kind", "info", "schema"}
-    odcs_metadata = {
-        k: v for k, v in contract_data.items()
-        if k not in _KNOWN_ODCS_KEYS
-    }
+    if not isinstance(contract_data, dict):
+        raise ValueError("ODCS document must be a mapping")
+    api_version = str(contract_data.get("apiVersion", "")).strip()
+    if api_version not in _SUPPORTED_API_VERSIONS:
+        raise ValueError(
+            f"Unsupported apiVersion '{api_version or '<missing>'}' — "
+            f"OpenDQV reads ODCS {', '.join(sorted(_SUPPORTED_API_VERSIONS))}"
+        )
+    if str(contract_data.get("kind", "")) != "DataContract":
+        raise ValueError("ODCS kind must be 'DataContract'")
 
-    info = contract_data.get("info", {})
-    name = info.get("title", "imported_contract")
-    # Sanitise name: lowercase, replace spaces/hyphens with underscores
-    name = name.lower().replace(" ", "_").replace("-", "_")
-    version = str(info.get("version", "1.0"))
-    status = info.get("status", "active")
-    description = info.get("description", "")
-    owner = info.get("owner", "")
+    name = _sanitise_name(contract_data.get("name") or contract_data.get("id") or "imported_contract")
+    version = str(contract_data.get("version", "1.0"))
+    odcs_status = str(contract_data.get("status", "draft")).lower()
+    status = _custom_property(contract_data, "opendqv.status") or _STATUS_FROM_ODCS.get(odcs_status, "draft")
+
+    desc = contract_data.get("description")
+    if isinstance(desc, dict):
+        description = str(desc.get("purpose") or desc.get("usage") or "")
+    else:
+        description = str(desc or "")
+    owner, owner_email = _team_owner(contract_data.get("team"))
 
     rules: list[dict] = []
     skipped: list[str] = []
+    seen_fields: dict[str, str] = {}
 
-    schema = contract_data.get("schema", [])
-    for table in schema:
-        properties = table.get("properties", [])
-        for prop in properties:
-            field = prop.get("name", "")
-            if not field:
+    schema = contract_data.get("schema") or []
+    if not isinstance(schema, list):
+        raise ValueError("ODCS schema must be a list of objects")
+    for obj in schema:
+        if not isinstance(obj, dict):
+            continue
+        obj_name = str(obj.get("name", "?"))
+        for q in obj.get("quality") or []:
+            if isinstance(q, dict):
+                skipped.append(f"{obj_name}.{q.get('metric') or q.get('type') or '?'} (object-level check)")
+        for prop in obj.get("properties") or []:
+            if not isinstance(prop, dict) or not prop.get("name"):
                 continue
+            field = str(prop["name"])
+            if field in seen_fields:
+                skipped.append(f"{obj_name}.{field} (duplicate of {seen_fields[field]}.{field}; first definition kept)")
+                continue
+            seen_fields[field] = obj_name
+            q_rules, from_custom = _quality_rules(field, prop.get("quality"), skipped)
+            if from_custom:
+                rules.extend(q_rules)          # authoritative; native projections are echoes
+                continue
+            # Native-derived rules: one per (type) per field — `required: true`
+            # and a `nullValues mustBe 0` entry describe the same constraint.
+            seen_types: set[str] = set()
+            for r in _native_rules(field, prop, skipped) + q_rules:
+                if r["type"] in seen_types:
+                    continue
+                seen_types.add(r["type"])
+                rules.append(r)
 
-            # Field-level shortcuts first
-            rules.extend(_field_shortcuts_to_rules(field, prop))
+    deduped = rules
+    # Rule names must be unique within a contract.
+    used: set[str] = set()
+    for r in deduped:
+        base = r["name"]
+        n, i = base, 2
+        while n in used:
+            n = f"{base}_{i}"
+            i += 1
+        r["name"] = n
+        used.add(n)
 
-            # Inline quality checks
-            for idx, q in enumerate(prop.get("quality", [])):
-                rule = _quality_to_rule(field, q, idx)
-                if rule:
-                    rules.append(rule)
-                else:
-                    skipped.append(f"{field}.{q.get('type', '?')}")
+    passthrough = {
+        k: v for k, v in contract_data.items()
+        if k in ("servers", "slaProperties", "slaDefaultElement", "roles", "support",
+                 "price", "tags", "domain", "tenant", "dataProduct", "authoritativeDefinitions",
+                 "contractCreatedTs")
+    }
 
-    # Deduplicate by (type, field) — shortcuts take priority (added first).
-    # Using name as part of the key never deduplicates because names are unique.
-    seen_keys: set[tuple] = set()
-    deduped: list[dict] = []
-    for rule in rules:
-        key = (rule["type"], rule["field"])
-        if key not in seen_keys:
-            seen_keys.add(key)
-            deduped.append(rule)
+    contract: dict[str, Any] = {
+        "name": name,
+        "version": version,
+        "status": status,
+        "description": description,
+        "owner": owner,
+        "rules": deduped,
+    }
+    if owner_email:
+        contract["owner_email"] = owner_email
 
     return {
-        "contract": {
-            "name": name,
-            "version": version,
-            "status": status,
-            "description": description,
-            "owner": owner,
-            "rules": deduped,
-        },
+        "contract": contract,
         "skipped_checks": skipped,
         "rule_count": len(deduped),
-        "_odcs_metadata": odcs_metadata,   # sla, semantics, lineage, etc. — preserved, not evaluated
+        "_odcs_metadata": passthrough,   # preserved for the API response, not evaluated
     }
 
 
 def odcs_to_yaml(contract_data: dict, contract_name: Optional[str] = None) -> tuple[str, str]:
-    """
-    Import ODCS 3.1 and return (contract_name, OpenDQV YAML string).
-
-    Args:
-        contract_data: Parsed ODCS 3.1 dict.
-        contract_name: Override the contract name (default: from info.title).
-
-    Returns:
-        (contract_name, yaml_string) tuple.
-    """
+    """Import ODCS 3.x and return (contract_name, OpenDQV YAML string)."""
     result = import_odcs(contract_data)
     name = contract_name or result["contract"]["name"]
     result["contract"]["name"] = name
-    yaml_str = yaml.dump(
-        {"contract": result["contract"]},
-        default_flow_style=False,
-        sort_keys=False,
-        allow_unicode=True,
-    )
+    yaml_str = yaml.dump({"contract": result["contract"]}, default_flow_style=False,
+                         sort_keys=False, allow_unicode=True)
     return name, yaml_str
 
 
 # ---------------------------------------------------------------------------
 # Exporter
 # ---------------------------------------------------------------------------
+
+def _project_native(prop: dict, ltype: str, rule: dict) -> None:
+    """Project an error-severity rule onto native ODCS fields when compatible."""
+    rtype = rule["type"]
+    opts: dict = prop.setdefault("logicalTypeOptions", {})
+    if rtype == "not_empty":
+        prop["required"] = True
+    elif rtype == "unique":
+        prop["unique"] = True
+    elif ltype == "string":
+        if rtype == "regex" and rule.get("pattern"):
+            opts["pattern"] = rule["pattern"]
+        elif rtype == "min_length" and rule.get("min_length") is not None:
+            opts["minLength"] = int(rule["min_length"])
+        elif rtype == "max_length" and rule.get("max_length") is not None:
+            opts["maxLength"] = int(rule["max_length"])
+    elif ltype == "number":
+        if rtype in ("min", "range") and rule.get("min_value") is not None:
+            opts["minimum"] = rule["min_value"]
+        if rtype in ("max", "range") and rule.get("max_value") is not None:
+            opts["maximum"] = rule["max_value"]
+    elif ltype == "date":
+        if rtype == "date_format":
+            jdk = _to_jdk_format(rule.get("format") or "%Y-%m-%d")
+            if jdk:
+                opts["format"] = jdk
+    if not opts:
+        prop.pop("logicalTypeOptions", None)
+
+
+def _custom_entry(rule: dict) -> dict:
+    entry: dict[str, Any] = {
+        "type": "custom",
+        "engine": ODCS_ENGINE,
+        "name": rule["name"],
+        "severity": rule.get("severity", "error"),
+        "dimension": _DIMENSION.get(rule["type"], _DEFAULT_DIMENSION),
+    }
+    if rule.get("error_message"):
+        entry["description"] = rule["error_message"]
+    entry["implementation"] = rule
+    return entry
+
 
 def export_odcs(
     contract_name: str,
@@ -331,106 +587,59 @@ def export_odcs(
     status: str = "active",
     description: str = "",
     owner: str = "",
+    owner_email: Optional[str] = None,
     odcs_metadata: Optional[dict] = None,
 ) -> dict:
-    """
-    Export OpenDQV rules to an ODCS 3.1 contract dict.
+    """Export OpenDQV rules to an ODCS v3.1.0 contract dict (schema-valid)."""
+    by_field: "OrderedDict[str, list[dict]]" = OrderedDict()
+    for raw in rules:
+        r = _rule_to_dict(raw)
+        by_field.setdefault(r["field"], []).append(r)
 
-    Args:
-        contract_name: The contract name (becomes info.title).
-        rules:         List of Rule objects or rule dicts.
-        version:       Contract version string.
-        status:        Contract status (active/draft/archived).
-        description:   Human-readable description.
-        owner:         Owning team or person.
-
-    Returns:
-        ODCS 3.1 dict ready for yaml.dump().
-    """
-    # Group rules by field
-    by_field: dict[str, list] = defaultdict(list)
-    for rule in rules:
-        field = rule.field if hasattr(rule, "field") else rule.get("field", "unknown")
-        by_field[field].append(rule)
-
-    properties = []
+    properties: list[dict] = []
     for field, field_rules in by_field.items():
-        quality = []
-        for rule in field_rules:
-            r_type = rule.type if hasattr(rule, "type") else rule.get("type")
-            r_sev  = (rule.severity.value if hasattr(rule, "severity") and hasattr(rule.severity, "value")
-                      else rule.get("severity", "error"))
-            odcs_type = _ODCS_TYPE_MAP.get(r_type)
-            if not odcs_type:
-                continue
-
-            q: dict[str, Any] = {
-                "type": odcs_type,
-                "mustBeSatisfied": (r_sev == "error"),
-            }
-
-            if r_type == "regex":
-                pattern = rule.pattern if hasattr(rule, "pattern") else rule.get("pattern")
-                if pattern:
-                    q["pattern"] = pattern
-
-            elif r_type in ("range", "min", "min_age"):
-                min_val = (rule.min_value if hasattr(rule, "min_value") else rule.get("min_value"))
-                if min_val is not None:
-                    q["min"] = min_val
-
-            if r_type in ("range", "max", "max_age"):
-                max_val = (rule.max_value if hasattr(rule, "max_value") else rule.get("max_value"))
-                if max_val is not None:
-                    q["max"] = max_val
-
-            elif r_type == "date_format":
-                fmt = rule.format if hasattr(rule, "format") else rule.get("format")
-                if fmt:
-                    q["format"] = fmt
-
-            elif r_type == "min_length":
-                v = rule.min_length if hasattr(rule, "min_length") else rule.get("min_length")
-                if v is not None:
-                    q["minLength"] = v
-
-            elif r_type == "max_length":
-                v = rule.max_length if hasattr(rule, "max_length") else rule.get("max_length")
-                if v is not None:
-                    q["maxLength"] = v
-
-            err_msg = (rule.error_message if hasattr(rule, "error_message")
-                       else rule.get("error_message"))
-            if err_msg:
-                q["description"] = err_msg
-
-            quality.append(q)
-
-        prop: dict[str, Any] = {"name": field}
-        if quality:
-            prop["quality"] = quality
+        ltype = _infer_logical_type({r["type"] for r in field_rules})
+        prop: dict[str, Any] = {"name": field, "logicalType": ltype}
+        quality: list[dict] = []
+        for r in field_rules:
+            if r.get("severity", "error") == "error":
+                _project_native(prop, ltype, r)
+                if r["type"] == "lookup" and r.get("allowed_values"):
+                    quality.append({
+                        "type": "library", "metric": "invalidValues",
+                        "arguments": {"validValues": list(r["allowed_values"])},
+                        "mustBe": 0, "severity": "error", "dimension": "conformity",
+                        **({"description": r["error_message"]} if r.get("error_message") else {}),
+                    })
+            quality.append(_custom_entry(r))
+        prop["quality"] = quality
         properties.append(prop)
 
-    result = {
-        "apiVersion": "v3.1.0",
-        "kind": "DataContract",
-        "info": {
-            "title": contract_name,
-            "version": version,
-            "status": status,
-            "description": description,
-            "owner": owner,
-        },
-        "schema": [
-            {
-                "name": contract_name,
-                "properties": properties,
-            }
-        ],
-    }
+    odcs_status = _STATUS_TO_ODCS.get(str(status).lower(), "draft")
+    doc: dict[str, Any] = OrderedDict()
+    doc["apiVersion"] = ODCS_API_VERSION
+    doc["kind"] = "DataContract"
+    doc["id"] = contract_name
+    doc["name"] = contract_name
+    doc["version"] = str(version)
+    doc["status"] = odcs_status
+    if description:
+        doc["description"] = {"purpose": description}
+    if owner:
+        team: dict[str, Any] = {"name": owner}
+        if owner_email:
+            team["members"] = [{"username": owner_email, "role": "owner"}]
+        doc["team"] = team
+    doc["customProperties"] = [
+        {"property": "opendqv.status", "value": str(status).lower()},
+        {"property": "opendqv.engine", "value": "opendqv"},
+    ]
+    doc["schema"] = [{"name": contract_name, "logicalType": "object", "properties": properties}]
     if odcs_metadata:
-        result.update(odcs_metadata)   # re-emit sla, semantics, lineage, etc.
-    return result
+        for k, v in odcs_metadata.items():
+            if k not in doc:
+                doc[k] = v
+    return dict(doc)
 
 
 def contract_to_odcs_yaml(
@@ -440,16 +649,10 @@ def contract_to_odcs_yaml(
     status: str = "active",
     description: str = "",
     owner: str = "",
+    owner_email: Optional[str] = None,
     odcs_metadata: Optional[dict] = None,
 ) -> str:
-    """Export OpenDQV contract to ODCS 3.1 YAML string."""
-    doc = export_odcs(
-        contract_name=contract_name,
-        rules=rules,
-        version=version,
-        status=status,
-        description=description,
-        owner=owner,
-        odcs_metadata=odcs_metadata,
-    )
+    """Export OpenDQV contract to ODCS v3.1.0 YAML string."""
+    doc = export_odcs(contract_name, rules, version=version, status=status, description=description,
+                      owner=owner, owner_email=owner_email, odcs_metadata=odcs_metadata)
     return yaml.dump(doc, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/opendqv/core/importers/odcs.py
+++ b/opendqv/core/importers/odcs.py
@@ -176,6 +176,14 @@ def _to_jdk_format(fmt: str) -> Optional[str]:
                     return None
                 out.append(_STRFTIME_TO_JDK[code])
                 i += 2
+            elif fmt[i].isalpha():
+                # Every A-Z/a-z is a reserved JDK pattern letter; literal text
+                # (e.g. the ISO 8601 'T') must be single-quoted.
+                j = i
+                while j < len(fmt) and fmt[j].isalpha():
+                    j += 1
+                out.append(f"'{fmt[i:j]}'")
+                i = j
             else:
                 out.append(fmt[i])
                 i += 1
@@ -209,6 +217,14 @@ def _from_jdk_format(fmt: str) -> Optional[str]:
         return None
     out, i = [], 0
     while i < len(fmt):
+        if fmt[i] == "'":
+            end = fmt.find("'", i + 1)
+            if end < 0:
+                return None   # unterminated literal
+            literal = fmt[i + 1:end] or "'"   # '' is an escaped quote in JDK
+            out.append(literal.replace("%", "%%"))
+            i = end + 1
+            continue
         for tok, code in _JDK_TOKENS:
             if fmt.startswith(tok, i):
                 out.append(code)
@@ -234,6 +250,7 @@ _IMPORT_DENIED_FIELDS = frozenset({
     "inherited", "federation_tier", "provenance", "severity_floor",
     "lookup_auth_header",
 })
+_ENGINE_STAMPED_FIELDS = _IMPORT_DENIED_FIELDS
 _ALLOWED_RULE_FIELDS = frozenset(Rule.model_fields.keys()) - _IMPORT_DENIED_FIELDS
 _ALIAS_TO_FIELD = {"min": "min_value", "max": "max_value"}
 
@@ -248,7 +265,9 @@ def _sanitise_name(raw: str) -> str:
 def _rule_to_dict(rule: Any) -> dict:
     """Rule object or dict → plain dict with canonical field names, defaults dropped."""
     if isinstance(rule, Rule):
-        d = rule.model_dump(exclude_none=True, exclude_defaults=True, by_alias=False)
+        # mode="json": enums (severity_floor etc.) become plain strings, so the
+        # YAML never carries a Python-specific !!python/object tag.
+        d = rule.model_dump(mode="json", exclude_none=True, exclude_defaults=True, by_alias=False)
         # exclude_defaults drops severity=error / description="" — keep what matters
         d["type"] = rule.type
         d["field"] = rule.field
@@ -265,6 +284,10 @@ def _rule_to_dict(rule: Any) -> dict:
         d["severity"] = sev.value if hasattr(sev, "value") else str(sev)
     if d.get("inherited") is False:
         d.pop("inherited")
+    # Engine-stamped federation / credential fields are node-local state, are
+    # refused on import, and mean nothing to another system: never export them.
+    for k in _ENGINE_STAMPED_FIELDS:
+        d.pop(k, None)
     # Deterministic key order: identity first, then the rest alphabetically.
     head = ["name", "type", "field", "severity", "error_message", "description"]
     ordered: dict[str, Any] = OrderedDict()
@@ -578,16 +601,30 @@ def odcs_to_yaml(contract_data: dict, contract_name: Optional[str] = None) -> tu
 # Exporter
 # ---------------------------------------------------------------------------
 
+def _is_qualified(rule: dict) -> bool:
+    """True when a rule only applies conditionally — native ODCS has no way to say that."""
+    return bool(rule.get("condition"))
+
+
 def _project_native(prop: dict, ltype: str, rule: dict) -> None:
-    """Project an error-severity rule onto native ODCS fields when compatible."""
+    """Project an error-severity rule onto native ODCS fields when compatible.
+
+    A native ODCS constraint is unconditional and un-negated. Rules qualified
+    by ``condition``, ``negate`` or ``group_by`` would project as something
+    stronger than (or the inverse of) what OpenDQV enforces, so they stay
+    custom-only. (Ultrareview finding, 2026-09-02.)
+    """
+    if _is_qualified(rule):
+        return
     rtype = rule["type"]
     opts: dict = prop.setdefault("logicalTypeOptions", {})
     if rtype == "not_empty":
         prop["required"] = True
     elif rtype == "unique":
-        prop["unique"] = True
+        if not rule.get("group_by"):
+            prop["unique"] = True
     elif ltype == "string":
-        if rtype == "regex" and rule.get("pattern"):
+        if rtype == "regex" and rule.get("pattern") and not rule.get("negate"):
             portable = _portable_pattern(rule["pattern"])
             if portable:
                 opts["pattern"] = portable
@@ -650,7 +687,7 @@ def export_odcs(
         for r in field_rules:
             if r.get("severity", "error") == "error":
                 _project_native(prop, ltype, r)
-                if r["type"] in ("allowed_values", "lookup") and r.get("allowed_values"):
+                if r["type"] in ("allowed_values", "lookup") and r.get("allowed_values") and not _is_qualified(r) and not r.get("negate"):
                     # Values are quoted strings: the engine compares str(value),
                     # and a bare true/1.0 raises a CAST error in the reference implementation.
                     quality.append({
@@ -659,7 +696,7 @@ def export_odcs(
                         "mustBe": 0, "severity": "error", "dimension": "conformity",
                         **({"description": r["error_message"]} if r.get("error_message") else {}),
                     })
-                if r["type"] == "unique" and r.get("group_by") and not object_quality:
+                if r["type"] == "unique" and r.get("group_by") and not _is_qualified(r) and not object_quality:
                     # Compound uniqueness is object-level in ODCS. At most one per
                     # object — the reference implementation mis-reports a second.
                     object_quality.append({

--- a/opendqv/core/importers/odcs.py
+++ b/opendqv/core/importers/odcs.py
@@ -70,7 +70,7 @@ from typing import Any, Optional
 import yaml
 from pydantic import ValidationError
 
-from opendqv.core.rule_parser import Rule
+from opendqv.core.rule_parser import _BUILTIN_PATTERNS, Rule
 
 ODCS_API_VERSION = "v3.1.0"
 ODCS_ENGINE = "opendqv"
@@ -108,6 +108,7 @@ _DIMENSION: dict[str, str] = {
     "date_format": "conformity",
     "checksum": "conformity",
     "lookup": "conformity",
+    "allowed_values": "conformity",
     "min": "accuracy",
     "max": "accuracy",
     "range": "accuracy",
@@ -130,6 +131,25 @@ def _infer_logical_type(rule_types: set[str]) -> str:
     if rule_types & _DATE_TYPES:
         return "date"
     return "string"
+
+
+# Constructs outside RE2 / ECMA-262-portable regex: lookahead, lookbehind,
+# atomic groups, backreferences. The ODCS reference implementation executes
+# `pattern` with RE2 and a single lookahead aborts every check on the object,
+# so such patterns stay custom-only (the OpenDQV engine still enforces them).
+_NON_PORTABLE_RE = re.compile(r"\(\?[=!<>]|\\[1-9]")
+
+
+def _portable_pattern(pattern: str) -> Optional[str]:
+    expanded = _BUILTIN_PATTERNS.get(pattern, pattern)
+    return None if _NON_PORTABLE_RE.search(expanded) else expanded
+
+
+_TIME_MARKERS = ("%H", "%M", "%S", "%f", "HH", "mm", "ss")
+
+
+def _has_time(fmt: Optional[str]) -> bool:
+    return bool(fmt) and any(m in fmt for m in _TIME_MARKERS)
 
 
 # ---------------------------------------------------------------------------
@@ -271,13 +291,19 @@ def _sanitise_rule_dict(field: str, impl: dict) -> dict:
         clean[canon] = v
     clean.setdefault("field", field)
     clean.setdefault("name", f"{field}_{clean.get('type', 'rule')}")
+    return _rule_to_dict(_validate_rule(field, clean))
+
+
+def _validate_rule(field: str, d: dict) -> Rule:
+    """Construct a Rule, converting any failure (schema or regex compile) to a clean ValueError."""
     try:
-        validated = Rule(**clean)
+        return Rule(**d)
     except ValidationError as exc:
         # One line per error, no stack detail — this reaches API clients as 422.
         msgs = "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors())
         raise ValueError(f"{field}: invalid rule — {msgs}") from None
-    return _rule_to_dict(validated)
+    except Exception as exc:  # e.g. regex.error from pattern pre-compile
+        raise ValueError(f"{field}: invalid rule — {type(exc).__name__}: {exc}") from None
 
 
 # ---------------------------------------------------------------------------
@@ -298,11 +324,12 @@ def _rule(field: str, rtype: str, severity: str = "error", message: str = "", **
     return d
 
 
-def _native_rules(field: str, prop: dict, skipped: list[str]) -> list[dict]:
+def _native_rules(field: str, prop: dict, skipped: list[str], notes: list[str]) -> list[dict]:
     """Rules from required / unique / logicalTypeOptions."""
     rules: list[dict] = []
     if prop.get("required") is True:
         rules.append(_rule(field, "not_empty", message=f"{field} is required"))
+        notes.append(f"{field}.required → not_empty (stricter: ODCS `required` allows empty strings)")
     if prop.get("unique") is True:
         rules.append(_rule(field, "unique", message=f"{field} must be unique"))
 
@@ -323,12 +350,11 @@ def _native_rules(field: str, prop: dict, skipped: list[str]) -> list[dict]:
     if ltype in ("number", "integer"):
         lo = _num(opts.get("minimum"))
         hi = _num(opts.get("maximum"))
-        if opts.get("exclusiveMinimum") is not None and lo is None:
-            lo = _num(opts["exclusiveMinimum"])
-            skipped.append(f"{field}.exclusiveMinimum (treated as inclusive minimum)")
-        if opts.get("exclusiveMaximum") is not None and hi is None:
-            hi = _num(opts["exclusiveMaximum"])
-            skipped.append(f"{field}.exclusiveMaximum (treated as inclusive maximum)")
+        # Exclusive bounds have no OpenDQV equivalent. Loosening them to
+        # inclusive would pass a value the document rejects — skip, never loosen.
+        for k in ("exclusiveMinimum", "exclusiveMaximum"):
+            if opts.get(k) is not None:
+                skipped.append(f"{field}.{k} (no strict-bound rule in OpenDQV; not loosened to inclusive)")
         if lo is not None and hi is not None:
             rules.append(_rule(field, "range", message=f"{field} must be between {lo:g} and {hi:g}",
                                min_value=lo, max_value=hi))
@@ -367,15 +393,25 @@ def _library_rule(field: str, q: dict, skipped: list[str]) -> Optional[dict]:
         args = q.get("arguments") or {}
         values = args.get("validValues") if isinstance(args, dict) else None
         if isinstance(values, list) and values:
-            return _rule(field, "lookup", severity, message or f"{field} must be one of the valid values",
+            return _rule(field, "allowed_values", severity, message or f"{field} must be one of the valid values",
                          allowed_values=[str(v) for v in values])
-        skipped.append(f"{field}.invalidValues (no validValues argument)")
+        if isinstance(args, dict) and args.get("pattern"):
+            return _rule(field, "regex", severity, message or f"{field} must match pattern",
+                         pattern=str(args["pattern"]))
+        skipped.append(f"{field}.invalidValues (no validValues / pattern argument)")
+        return None
+    if metric == "missingValues" and must_be_zero:
+        args = q.get("arguments") or {}
+        sentinels = args.get("missingValues") if isinstance(args, dict) else None
+        if isinstance(sentinels, list) and all(v is None or v == "" for v in sentinels):
+            return _rule(field, "not_empty", severity, message or f"{field} must not be null or empty")
+        skipped.append(f"{field}.missingValues (sentinels beyond null/'' cannot be honoured by not_empty)")
         return None
     skipped.append(f"{field}.{metric or '?'} (dataset-level metric, no record-level equivalent)")
     return None
 
 
-def _quality_rules(field: str, quality: list, skipped: list[str]) -> tuple[list[dict], bool]:
+def _quality_rules(field: str, quality: list, skipped: list[str]) -> tuple[list[dict], bool]:  # noqa: D401
     """Return (rules, had_opendqv_custom). Custom/opendqv entries take precedence."""
     custom: list[dict] = []
     other: list[dict] = []
@@ -388,7 +424,9 @@ def _quality_rules(field: str, quality: list, skipped: list[str]) -> tuple[list[
                 custom.append(_sanitise_rule_dict(field, q.get("implementation")))
             else:
                 skipped.append(f"{field}.custom (engine '{q.get('engine', '?')}')")
-        elif qtype == "library" or q.get("metric") or q.get("rule"):
+        elif qtype in ("library", "") or (qtype == "text" and (q.get("metric") or q.get("rule"))):
+            # `library` is the ODCS default type; a `text` entry carrying a metric
+            # is executed by the reference implementation, so treat it as library.
             r = _library_rule(field, q, skipped)
             if r:
                 other.append(r)
@@ -452,6 +490,7 @@ def import_odcs(contract_data: dict) -> dict:
 
     rules: list[dict] = []
     skipped: list[str] = []
+    notes: list[str] = []
     seen_fields: dict[str, str] = {}
 
     schema = contract_data.get("schema") or []
@@ -479,10 +518,11 @@ def import_odcs(contract_data: dict) -> dict:
             # Native-derived rules: one per (type) per field — `required: true`
             # and a `nullValues mustBe 0` entry describe the same constraint.
             seen_types: set[str] = set()
-            for r in _native_rules(field, prop, skipped) + q_rules:
+            for r in _native_rules(field, prop, skipped, notes) + q_rules:
                 if r["type"] in seen_types:
                     continue
                 seen_types.add(r["type"])
+                _validate_rule(field, r)     # fail closed (e.g. a pattern that does not compile)
                 rules.append(r)
 
     deduped = rules
@@ -518,6 +558,7 @@ def import_odcs(contract_data: dict) -> dict:
     return {
         "contract": contract,
         "skipped_checks": skipped,
+        "import_notes": notes,
         "rule_count": len(deduped),
         "_odcs_metadata": passthrough,   # preserved for the API response, not evaluated
     }
@@ -547,7 +588,9 @@ def _project_native(prop: dict, ltype: str, rule: dict) -> None:
         prop["unique"] = True
     elif ltype == "string":
         if rtype == "regex" and rule.get("pattern"):
-            opts["pattern"] = rule["pattern"]
+            portable = _portable_pattern(rule["pattern"])
+            if portable:
+                opts["pattern"] = portable
         elif rtype == "min_length" and rule.get("min_length") is not None:
             opts["minLength"] = int(rule["min_length"])
         elif rtype == "max_length" and rule.get("max_length") is not None:
@@ -557,7 +600,7 @@ def _project_native(prop: dict, ltype: str, rule: dict) -> None:
             opts["minimum"] = rule["min_value"]
         if rtype in ("max", "range") and rule.get("max_value") is not None:
             opts["maximum"] = rule["max_value"]
-    elif ltype == "date":
+    elif ltype in ("date", "timestamp"):
         if rtype == "date_format":
             jdk = _to_jdk_format(rule.get("format") or "%Y-%m-%d")
             if jdk:
@@ -597,18 +640,32 @@ def export_odcs(
         by_field.setdefault(r["field"], []).append(r)
 
     properties: list[dict] = []
+    object_quality: list[dict] = []
     for field, field_rules in by_field.items():
         ltype = _infer_logical_type({r["type"] for r in field_rules})
+        if ltype == "date" and any(r["type"] == "date_format" and _has_time(r.get("format")) for r in field_rules):
+            ltype = "timestamp"
         prop: dict[str, Any] = {"name": field, "logicalType": ltype}
         quality: list[dict] = []
         for r in field_rules:
             if r.get("severity", "error") == "error":
                 _project_native(prop, ltype, r)
-                if r["type"] == "lookup" and r.get("allowed_values"):
+                if r["type"] in ("allowed_values", "lookup") and r.get("allowed_values"):
+                    # Values are quoted strings: the engine compares str(value),
+                    # and a bare true/1.0 raises a CAST error in the reference implementation.
                     quality.append({
                         "type": "library", "metric": "invalidValues",
-                        "arguments": {"validValues": list(r["allowed_values"])},
+                        "arguments": {"validValues": [str(v) for v in r["allowed_values"]]},
                         "mustBe": 0, "severity": "error", "dimension": "conformity",
+                        **({"description": r["error_message"]} if r.get("error_message") else {}),
+                    })
+                if r["type"] == "unique" and r.get("group_by") and not object_quality:
+                    # Compound uniqueness is object-level in ODCS. At most one per
+                    # object — the reference implementation mis-reports a second.
+                    object_quality.append({
+                        "type": "library", "metric": "duplicateValues",
+                        "arguments": {"properties": [field, *[str(g) for g in r["group_by"]]]},
+                        "mustBe": 0, "severity": "error", "dimension": "uniqueness",
                         **({"description": r["error_message"]} if r.get("error_message") else {}),
                     })
             quality.append(_custom_entry(r))
@@ -634,7 +691,10 @@ def export_odcs(
         {"property": "opendqv.status", "value": str(status).lower()},
         {"property": "opendqv.engine", "value": "opendqv"},
     ]
-    doc["schema"] = [{"name": contract_name, "logicalType": "object", "properties": properties}]
+    schema_obj: dict[str, Any] = {"name": contract_name, "logicalType": "object", "properties": properties}
+    if object_quality:
+        schema_obj["quality"] = object_quality
+    doc["schema"] = [schema_obj]
     if odcs_metadata:
         for k, v in odcs_metadata.items():
             if k not in doc:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3444,4 +3444,4 @@ ui = ["streamlit"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "b65a57a91d62f8e301bc11fc385d67f1f00e2354261418c0549326c4cc343b1a"
+content-hash = "c8c9a884b0ed33f3ff9b9a46bccab7f821c5ec5631ed9fde1ae265f0a9dbf5b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opendqv"
-version = "2.3.30"
+version = "2.4.0"
 description = "OpenDQV Core — open-source, contract-driven data quality validation engine for data pipelines and API boundaries"
 authors = ["Sunny Sharma"]
 license = "MIT"
@@ -78,6 +78,7 @@ pytest-cov = ">=4,<8"
 pytest-playwright = ">=0.4,<0.9"
 ruff = ">=0.4,<0.17"
 mcp = ">=1.0.0,<2.0.0"
+jsonschema = ">=4.26,<5"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/fixtures/odcs-full-example-v3.1.0.yaml
+++ b/tests/fixtures/odcs-full-example-v3.1.0.yaml
@@ -1,0 +1,331 @@
+# What's this data contract about?
+domain: seller # Domain
+dataProduct: my quantum # Data product name
+version: 1.1.0 # Version (follows semantic versioning)
+status: active
+id: 53581432-6c55-4ba2-a65f-72344a91553a
+
+authoritativeDefinitions:
+- type: canonical
+  url: https://github.com/bitol-io/open-data-contract-standard/blob/main/docs/examples/all/full-example.odcs.yaml
+  description: Canonical URL to the latest version of the contract.
+  
+# Lots of information
+description:
+  purpose: Views built on top of the seller tables.
+  limitations: Data based on seller perspective, no buyer information
+  usage: Predict sales over time
+  authoritativeDefinitions:
+    - type: privacy-statement
+      url: https://example.com/gdpr.pdf
+tenant: ClimateQuantumInc
+
+kind: DataContract
+apiVersion: v3.1.0 # Standard version (follows semantic versioning)
+
+# Infrastructure & servers
+servers:
+  - server: my-postgres
+    type: postgres
+    host: localhost
+    port: 5432
+    database: pypl-edw
+    schema: pp_access_views
+
+# Dataset, schema, and quality
+schema:
+  - id: tbl_obj
+    name: tbl
+    physicalName: tbl_1
+    physicalType: table
+    businessName: Core Payment Metrics
+    description: Provides core payment metrics
+    authoritativeDefinitions:
+      - url: https://catalog.data.gov/dataset/air-quality
+        type: businessDefinition
+      - url: https://youtu.be/jbY1BKFj9ec
+        type: videoTutorial
+    tags: [ 'finance', 'payments']
+    dataGranularityDescription: Aggregation on columns txn_ref_dt, pmt_txn_id
+    # Schema-level relationships (for composite keys)
+    relationships:
+      - type: foreignKey
+        from:
+          - tbl.rcvr_id
+          - tbl.rcvr_cntry_code
+        to:
+          - receivers.id
+          - receivers.country_code
+        customProperties:
+          - property: description
+            value: "Composite key linking to receivers table"
+          - property: cardinality
+            value: "many-to-one"
+    properties:
+      - id: txn_ref_dt_prop
+        name: transaction_reference_date
+        physicalName: txn_ref_dt
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: transaction reference date
+        logicalType: date
+        physicalType: date
+        required: false
+        description: Reference date for transaction
+        partitioned: true
+        partitionKeyPosition: 1
+        criticalDataElement: false
+        tags: [ ]
+        classification: public
+        transformSourceObjects:
+          - table_name_1
+          - table_name_2
+          - table_name_3
+        transformLogic: sel t1.txn_dt as txn_ref_dt from table_name_1 as t1, table_name_2 as t2, table_name_3 as t3 where t1.txn_dt=date-3
+        transformDescription: defines the logic in business terms; logic for dummies
+        examples:
+          - "2022-10-03"
+          - "2020-01-28"
+        customProperties:
+          - property: anonymizationStrategy
+            value: none
+      - id: rcvr_id_prop
+        name: rcvr_id
+        primaryKey: true
+        primaryKeyPosition: 1
+        businessName: receiver id
+        logicalType: string
+        physicalType: varchar(18)
+        required: false
+        description: A description for column rcvr_id.
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ 'uid' ]
+        classification: restricted
+        # Property-level relationship (from is implicit)
+        relationships:
+          - to: receivers.id
+            type: foreignKey
+            customProperties:
+              - property: description
+                value: "Links to receiver master data"
+      - id: rcvr_cntry_code_prop
+        name: rcvr_cntry_code
+        primaryKey: false
+        primaryKeyPosition: -1
+        businessName: receiver country code
+        logicalType: string
+        physicalType: varchar(2)
+        required: false
+        description: Country code
+        partitioned: false
+        partitionKeyPosition: -1
+        criticalDataElement: false
+        tags: [ ]
+        classification: public
+        authoritativeDefinitions:
+          - url: https://collibra.com/asset/742b358f-71a5-4ab1-bda4-dcdba9418c25
+            type: businessDefinition
+          - url: https://github.com/myorg/myrepo
+            type: transformationImplementation
+          - url: jdbc:postgresql://localhost:5432/adventureworks/tbl_1/rcvr_cntry_code
+            type: implementation
+        encryptedName: rcvr_cntry_code_encrypted
+        quality:
+          - metric: nullValues
+            mustBe: 0
+            description: column should not contain null values
+            dimension: completeness
+            type: library
+            severity: error
+            businessImpact: operational
+            schedule: 0 20 * * *
+            scheduler: cron
+            customProperties:
+              - property: FIELD_NAME
+                value:
+              - property: COMPARE_TO
+                value:
+              - property: COMPARISON_TYPE
+                value: Greater than
+    quality:
+      - metric: rowCount
+        mustBeGreaterThan: 1000000
+        type: library
+        description: Ensure row count is within expected volume range
+        dimension: completeness
+        method: reconciliation
+        severity: error
+        businessImpact: operational
+        schedule: 0 20 * * *
+        scheduler: cron
+    customProperties:
+      - property: business-key
+        value:
+          - txn_ref_dt
+          - rcvr_id
+
+  # Receivers master table
+  - id: receivers_obj
+    name: receivers
+    physicalName: receivers_master
+    physicalType: table
+    businessName: Receivers Master Data
+    description: Master data for all receivers
+    tags: [ 'master-data', 'receivers' ]
+    properties:
+      - id: receiver_id_prop
+        name: id
+        primaryKey: true
+        primaryKeyPosition: 1
+        businessName: receiver identifier
+        logicalType: string
+        physicalType: varchar(18)
+        required: true
+        description: Unique identifier for receiver
+        unique: true
+        classification: restricted
+      - id: country_code_prop
+        name: country_code
+        primaryKey: true
+        primaryKeyPosition: 2
+        businessName: receiver country
+        logicalType: string
+        physicalType: varchar(2)
+        required: true
+        description: Country code of the receiver
+        classification: public
+      - id: receiver_name_prop
+        name: receiver_name
+        businessName: receiver name
+        logicalType: string
+        physicalType: varchar(255)
+        required: true
+        description: Name of the receiver
+        classification: restricted
+      - id: receiver_type_prop
+        name: receiver_type
+        businessName: receiver type
+        logicalType: string
+        physicalType: varchar(20)
+        required: false
+        description: Type of receiver (individual, business, etc.)
+        classification: public
+        # Example of nested reference
+        relationships:
+          - to: receiver_types.type_code
+            customProperties:
+              - property: description
+                value: "Links to receiver type definitions"
+
+
+# Pricing
+price:
+  priceAmount: 9.95
+  priceCurrency: USD
+  priceUnit: megabyte
+
+
+# Team
+team:
+  name: my-team
+  description: The team owning the data contract
+  members:
+    - username: ceastwood
+      role: Data Scientist
+      dateIn: "2022-08-02"
+      dateOut: "2022-10-01"
+      replacedByUsername: mhopper
+    - username: mhopper
+      role: Data Scientist
+      dateIn: "2022-10-01"
+    - username: daustin
+      role: Owner
+      description: Keeper of the grail
+      dateIn: "2022-10-01"
+
+
+# Roles
+roles:
+  - role: microstrategy_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mandolorian'
+  - role: bq_queryman_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: na
+  - role: risk_data_access_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'dathvador'
+  - role: bq_unica_user_opr
+    access: write
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mickey'
+
+# SLA
+slaProperties:
+  - property: latency # Property, see list of values in DP QoS
+    value: 4
+    unit: d # d, day, days for days; y, yr, years for years
+    element: tab1.txn_ref_dt # This would not be needed as it is the same table.column as the default one
+  - property: generalAvailability
+    value: "2022-05-12T09:30:10-08:00"
+  - property: endOfSupport
+    value: "2032-05-12T09:30:10-08:00"
+  - property: endOfLife
+    value: "2042-05-12T09:30:10-08:00"
+  - property: retention
+    value: 3
+    unit: y
+    element: tab1.txn_ref_dt
+  - property: frequency
+    value: 1
+    valueExt: 1
+    unit: d
+    element: tab1.txn_ref_dt
+  - property: timeOfAvailability
+    value: 09:00-08:00
+    element: tab1.txn_ref_dt
+    driver: regulatory # Describes the importance of the SLA: [regulatory|analytics|operational|...]
+  - property: timeOfAvailability
+    value: 08:00-08:00
+    element: tab1.txn_ref_dt
+    driver: analytics
+
+
+# Support
+support:
+  - channel: '#product-help' # Simple Slack communication channel
+    tool: slack
+  - channel: datacontract-ann # Simple distribution list
+    tool: email
+    url: mailto:datacontract-ann@bitol.io
+  - channel: Feedback  # Product Feedback
+    description: General Product Feedback (Public)
+    url: https://product-feedback.com
+  - channel: 'product-issues'
+    tool: teams
+    scope: issues
+    customProperties:
+    - property: servicehours
+      value: 9-5 CET
+
+
+# Tags
+tags:
+  - transactions
+
+
+# Custom properties
+customProperties:
+  - property: refRulesetName
+    value: gcsc.ruleset.name
+  - property: somePropertyName
+    value: property.value
+  - property: dataprocClusterName # Used for specific applications like Elevate
+    value: [ cluster name ]
+
+contractCreatedTs: "2022-11-15T02:59:43+00:00"

--- a/tests/fixtures/odcs-json-schema-v3.1.0.json
+++ b/tests/fixtures/odcs-json-schema-v3.1.0.json
@@ -1,0 +1,2929 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Open Data Contract Standard (ODCS)",
+  "description": "An open data contract specification to establish agreement between data producers and consumers.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Current version of the data contract."
+    },
+    "kind": {
+      "type": "string",
+      "default": "DataContract",
+      "description": "The kind of file this is. Valid value is `DataContract`.",
+      "enum": ["DataContract"]
+    },
+    "apiVersion": {
+      "type": "string",
+      "default": "v3.1.0",
+      "description": "Version of the standard used to build data contract. Default value is v3.1.0.",
+      "enum": ["v3.1.0", "v3.0.2", "v3.0.1", "v3.0.0", "v2.2.2", "v2.2.1", "v2.2.0"]
+    },
+    "id": {
+      "type": "string",
+      "description": "A unique identifier used to reduce the risk of dataset name collisions, such as a UUID."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the data contract."
+    },
+    "tenant": {
+      "type": "string",
+      "description": "Indicates the property the data is primarily associated with. Value is case insensitive."
+    },
+    "tags": {
+      "$ref": "#/$defs/Tags"
+    },
+    "status": {
+      "type": "string",
+      "description": "Current status of the dataset.",
+      "examples": [
+        "proposed", "draft", "active", "deprecated", "retired"
+      ]
+    },
+    "servers": {
+      "type": "array",
+      "description": "List of servers where the datasets reside.",
+      "items": {
+        "$ref": "#/$defs/Server"
+      }
+    },
+    "dataProduct": {
+      "type": "string",
+      "description": "The name of the data product. DEPRECATED since v3.1.0.",
+      "deprecated": true
+    },
+    "description": {
+      "type": "object",
+      "description": "High level description of the dataset.",
+      "properties": {
+        "usage": {
+          "type": "string",
+          "description": "Intended usage of the dataset."
+        },
+        "purpose": {
+          "type": "string",
+          "description": "Purpose of the dataset."
+        },
+        "limitations": {
+          "type": "string",
+          "description": "Limitations of the dataset."
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "domain": {
+      "type": "string",
+      "description": "Name of the logical data domain.",
+      "examples": ["imdb_ds_aggregate", "receiver_profile_out", "transaction_profile_out"]
+    },
+    "schema": {
+      "type": "array",
+      "description": "A list of elements within the schema to be cataloged.",
+      "items": {
+        "$ref": "#/$defs/SchemaObject"
+      }
+    },
+    "support": {
+      "$ref": "#/$defs/Support"
+    },
+    "price": {
+      "$ref": "#/$defs/Pricing"
+    },
+    "team": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Team",
+          "description": "Team information object with members array (v3.1.0+)."
+        },
+        {
+          "type": "array",
+          "description": "DEPRECATED: Array of team members. Use the Team object structure instead. This array format is maintained for backward compatibility with v3.0.2 and earlier versions and will be removed in ODCS 4.0.",
+          "deprecated": true,
+          "items": {
+            "$ref": "#/$defs/TeamMember"
+          }
+        }
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "description": "A list of roles that will provide user access to the dataset.",
+      "items": {
+        "$ref": "#/$defs/Role"
+      }
+    },
+    "slaDefaultElement": {
+      "type": "string",
+      "description": "DEPRECATED SINCE 3.1. WILL BE REMOVED IN ODCS 4.0. Element (using the element path notation) to do the checks on.",
+      "deprecated": true
+    },
+    "slaProperties": {
+      "type": "array",
+      "description": "A list of key/value pairs for SLA specific properties. There is no limit on the type of properties (more details to come).",
+      "items": {
+        "$ref": "#/$defs/ServiceLevelAgreementProperty"
+      }
+    },
+    "authoritativeDefinitions": {
+      "$ref": "#/$defs/AuthoritativeDefinitions"
+    },
+    "customProperties": {
+      "$ref": "#/$defs/CustomProperties"
+    },
+    "contractCreatedTs": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp in UTC of when the data contract was created."
+    }
+  },
+  "required": ["version", "apiVersion", "kind", "id", "status"],
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "$defs": {
+    "ShorthandReference": {
+      "type": "string",
+      "description": "Shorthand notation using name fields (table_name.column_name)",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "FullyQualifiedReference": {
+      "type": "string",
+      "description": "Fully qualified notation using id fields (section/id/properties/id), optionally prefixed with external file reference",
+      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.yaml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
+    },
+    "StableId": {
+      "type": "string",
+      "description": "Stable technical identifier for references. Must be unique within its containing array. Cannot contain special characters ('-', '_' allowed).",
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+    "Server": {
+      "type": "object",
+      "description": "Data source details of where data is physically stored.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "server": {
+          "type": "string",
+          "description": "Identifier of the server."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the server.",
+          "enum": [
+            "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
+            "duckdb", "glue", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the server."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment of the server.",
+          "examples": ["prod", "preprod", "dev", "uat"]
+        },
+        "roles": {
+          "type": "array",
+          "description": "List of roles that have access to the server.",
+          "items": {
+            "$ref": "#/$defs/Role"
+          }
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "api"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ApiServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "athena"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/AthenaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "azure"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/AzureServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "bigquery"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/BigQueryServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "clickhouse"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ClickHouseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "databricks"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DatabricksServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "denodo"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DenodoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dremio"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DremioServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "duckdb"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DuckdbServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "glue"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/GlueServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "cloudsql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/GoogleCloudSqlServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "db2"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IBMDB2Server"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "hive"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/HiveServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "impala"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ImpalaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "informix"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/InformixServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "zen"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ZenServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "custom"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/CustomServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "kafka"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/KafkaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "kinesis"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/KinesisServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "local"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/LocalServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mysql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/MySqlServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oracle"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "postgresql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PostgresServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "postgres"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PostgresServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "presto"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PrestoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pubsub"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PubSubServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "redshift"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/RedshiftServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "s3"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/S3Server"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sftp"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SftpServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "snowflake"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SnowflakeServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sqlserver"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SqlserverServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "synapse"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "trino"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TrinoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "vertica"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VerticaServer"
+          }
+        }
+      ],
+      "required": ["server", "type"],
+      "unevaluatedProperties": false
+    },
+    "ServerSource": {
+      "ApiServer": {
+        "type": "object",
+        "title": "AthenaServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "The url to the API.",
+            "examples": [
+              "https://api.example.com/v1"
+            ]
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "AthenaServer": {
+        "type": "object",
+        "title": "AthenaServer",
+        "properties": {
+          "stagingDir": {
+            "type": "string",
+            "format": "uri",
+            "description": "Amazon Athena automatically stores query results and metadata information for each query that runs in a query result location that you can specify in Amazon S3.",
+            "examples": [
+              "s3://my_storage_account_name/my_container/path"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "Identify the schema in the data source in which your tables exist."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "Identify the name of the Data Source, also referred to as a Catalog.",
+            "default": "awsdatacatalog"
+          },
+          "regionName": {
+            "type": "string",
+            "description": "The region your AWS account uses.",
+            "examples": ["eu-west-1"]
+          }
+        },
+        "required": [
+          "stagingDir",
+          "schema"
+        ]
+      },
+      "AzureServer": {
+        "type": "object",
+        "title": "AzureServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "Fully qualified path to Azure Blob Storage or Azure Data Lake Storage (ADLS), supports globs.",
+            "examples": [
+              "az://my_storage_account_name.blob.core.windows.net/my_container/path/*.parquet",
+              "abfss://my_storage_account_name.dfs.core.windows.net/my_container_name/path/*.parquet"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location",
+          "format"
+        ]
+      },
+      "BigQueryServer": {
+        "type": "object",
+        "title": "BigQueryServer",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The GCP project name."
+          },
+          "dataset": {
+            "type": "string",
+            "description": "The GCP dataset name."
+          }
+        },
+        "required": [
+          "project",
+          "dataset"
+        ]
+      },
+      "ClickHouseServer": {
+        "type": "object",
+        "title": "ClickHouseServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the ClickHouse server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the ClickHouse server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "DatabricksServer": {
+        "type": "object",
+        "title": "DatabricksServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The Databricks host",
+            "examples": [
+              "dbc-abcdefgh-1234.cloud.databricks.com"
+            ]
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the Hive or Unity catalog"
+          },
+          "schema": {
+            "type": "string",
+            "description": "The schema name in the catalog"
+          }
+        },
+        "required": [
+          "catalog",
+          "schema"
+        ]
+      },
+      "DenodoServer": {
+        "type": "object",
+        "title": "DenodoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Denodo server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Denodo server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port"
+        ]
+      },
+      "DremioServer": {
+        "type": "object",
+        "title": "DremioServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Dremio server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Dremio server."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port"
+        ]
+      },
+      "DuckdbServer": {
+        "type": "object",
+        "title": "DuckdbServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Path to duckdb database file."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "database"
+        ]
+      },
+      "GlueServer": {
+        "type": "object",
+        "title": "GlueServer",
+        "properties": {
+          "account": {
+            "type": "string",
+            "description": "The AWS Glue account",
+            "examples": [
+              "1234-5678-9012"
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "The AWS Glue database name",
+            "examples": [
+              "my_database"
+            ]
+          },
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "The AWS S3 path. Must be in the form of a URL.",
+            "examples": [
+              "s3://datacontract-example-orders-latest/data/{model}"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the files",
+            "examples": [
+              "parquet",
+              "csv",
+              "json",
+              "delta"
+            ]
+          }
+        },
+        "required": [
+          "account",
+          "database"
+        ]
+      },
+      "GoogleCloudSqlServer": {
+        "type": "object",
+        "title": "GoogleCloudSqlServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Google Cloud Sql server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Google Cloud Sql server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      },
+      "IBMDB2Server": {
+        "type": "object",
+        "title": "IBMDB2Server",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the IBM DB2 server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the IBM DB2 server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "HiveServer": {
+        "type": "object",
+        "title": "HiveServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Hive server. "
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Hive server. Defaults to 10000."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the Hive database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "ImpalaServer": {
+        "type": "object",
+        "title": "ImpalaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Impala server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Impala server. Defaults to 21050."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the Impala database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "InformixServer": {
+        "type": "object",
+        "title": "InformixServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Informix server. "
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Informix server. Defaults to 9088."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "ZenServer": {
+        "type": "object",
+        "title": "ZenServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Zen server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Zen server SQL connections port. Defaults to 1583."
+          },
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Zen server."
+          }
+        },
+        "required": ["host", "database"]
+      },
+      "CustomServer": {
+        "type": "object",
+        "title": "CustomServer",
+        "properties": {
+          "account": {
+            "type": "string",
+            "description": "Account used by the server."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "Name of the catalog."
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          },
+          "dataset": {
+            "type": "string",
+            "description": "Name of the dataset."
+          },
+          "delimiter": {
+            "type": "string",
+            "description": "Delimiter."
+          },
+          "endpointUrl": {
+            "type": "string",
+            "description": "Server endpoint.",
+            "format": "uri"
+          },
+          "format": {
+            "type": "string",
+            "description": "File format."
+          },
+          "host": {
+            "type": "string",
+            "description": "Host name or IP address."
+          },
+          "location": {
+            "type": "string",
+            "description": "A URL to a location.",
+            "format": "uri"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative or absolute path to the data file(s)."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port to the server. No default value is assumed for custom servers."
+          },
+          "project": {
+            "type": "string",
+            "description": "Project name."
+          },
+          "region": {
+            "type": "string",
+            "description": "Cloud region."
+          },
+          "regionName": {
+            "type": "string",
+            "description": "Region name."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "Name of the service."
+          },
+          "stagingDir": {
+            "type": "string",
+            "description": "Staging directory."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "Name of the cluster or warehouse."
+          },
+          "stream": {
+            "type": "string",
+            "description": "Name of the data stream."
+          }
+        }
+      },
+      "KafkaServer": {
+        "type": "object",
+        "title": "KafkaServer",
+        "description": "Kafka Server",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The bootstrap server of the kafka cluster."
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the messages.",
+            "examples": ["json", "avro", "protobuf", "xml"],
+            "default": "json"
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "KinesisServer": {
+        "type": "object",
+        "title": "KinesisDataStreamsServer",
+        "description": "Kinesis Data Streams Server",
+        "properties": {
+          "region": {
+            "type": "string",
+            "description": "AWS region.",
+            "examples": [
+              "eu-west-1"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the record",
+            "examples": [
+              "json",
+              "avro",
+              "protobuf"
+            ]
+          }
+        }
+      },
+      "LocalServer": {
+        "type": "object",
+        "title": "LocalServer",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The relative or absolute path to the data file(s).",
+            "examples": [
+              "./folder/data.parquet",
+              "./folder/*.parquet"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the file(s)",
+            "examples": [
+              "json",
+              "parquet",
+              "delta",
+              "csv"
+            ]
+          }
+        },
+        "required": [
+          "path",
+          "format"
+        ]
+      },
+      "MySqlServer": {
+        "type": "object",
+        "title": "MySqlServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the MySql server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the MySql server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "OracleServer": {
+        "type": "object",
+        "title": "OracleServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the oracle server",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the oracle server.",
+            "examples": [
+              1523
+            ]
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "The name of the service.",
+            "examples": [
+              "service"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "serviceName"
+        ]
+      },
+      "PostgresServer": {
+        "type": "object",
+        "title": "PostgresServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Postgres server"
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Postgres server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      },
+      "PrestoServer": {
+        "type": "object",
+        "title": "PrestoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Presto server",
+            "examples": [
+              "localhost:8080"
+            ]
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the catalog.",
+            "examples": [
+              "postgres"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema.",
+            "examples": [
+              "public"
+            ]
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "PubSubServer": {
+        "type": "object",
+        "title": "PubSubServer",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The GCP project name."
+          }
+        },
+        "required": [
+          "project"
+        ]
+      },
+      "RedshiftServer": {
+        "type": "object",
+        "title": "RedshiftServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "An optional string describing the server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          },
+          "region": {
+            "type": "string",
+            "description": "AWS region of Redshift server.",
+            "examples": ["us-east-1"]
+          },
+          "account": {
+            "type": "string",
+            "description": "The account used by the server."
+          }
+        },
+        "required": [
+          "database",
+          "schema"
+        ]
+      },
+      "S3Server": {
+        "type": "object",
+        "title": "S3Server",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "S3 URL, starting with `s3://`",
+            "examples": [
+              "s3://datacontract-example-orders-latest/data/{model}/*.json"
+            ]
+          },
+          "endpointUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "The server endpoint for S3-compatible servers.",
+            "examples": ["https://minio.example.com"]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "SftpServer": {
+        "type": "object",
+        "title": "SftpServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^sftp://.*",
+            "description": "SFTP URL, starting with `sftp://`",
+            "examples": [
+              "sftp://123.123.12.123/{model}/*.json"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "SnowflakeServer": {
+        "type": "object",
+        "title": "SnowflakeServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Snowflake server"
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Snowflake server."
+          },
+          "account": {
+            "type": "string",
+            "description": "The Snowflake account used by the server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "The name of the cluster of resources that is a Snowflake virtual warehouse."
+          }
+        },
+        "required": [
+          "account",
+          "database",
+          "schema"
+        ]
+      },
+      "SqlserverServer": {
+        "type": "object",
+        "title": "SqlserverServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the database server",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the database server.",
+            "default": 1433,
+            "examples": [
+              1433
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database.",
+            "examples": [
+              "database"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database.",
+            "examples": [
+              "dbo"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "database",
+          "schema"
+        ]
+      },
+      "SynapseServer": {
+        "type": "object",
+        "title": "SynapseServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Synapse server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Synapse server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "TrinoServer": {
+        "type": "object",
+        "title": "TrinoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The Trino host URL.",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The Trino port."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the catalog.",
+            "examples": [
+              "hive"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database.",
+            "examples": [
+              "my_schema"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "catalog",
+          "schema"
+        ]
+      },
+      "VerticaServer": {
+        "type": "object",
+        "title": "VerticaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Vertica server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Vertica server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      }
+    },
+    "SchemaElement": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the element."
+        },
+        "physicalType": {
+          "type": "string",
+          "description": "The physical element data type in the data source.",
+          "examples": ["table", "view", "topic", "file"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the element."
+        },
+        "businessName": {
+          "type": "string",
+          "description": "The business name of the element."
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "SchemaObject": {
+      "type": "object",
+      "properties": {
+        "logicalType": {
+          "type": "string",
+          "description": "The logical element data type.",
+          "enum": ["object"]
+        },
+        "physicalName": {
+          "type": "string",
+          "description": "Physical name.",
+          "examples": ["table_1_2_0"]
+        },
+        "dataGranularityDescription": {
+          "type": "string",
+          "description": "Granular level of the data in the object.",
+          "examples": ["Aggregation by country"]
+        },
+        "properties": {
+          "type": "array",
+          "description": "A list of properties for the object.",
+          "items": {
+            "$ref": "#/$defs/SchemaProperty"
+          }
+        },
+        "relationships": {
+          "type": "array",
+          "description": "A list of relationships to other properties. Each relationship must have 'from', 'to' and optionally 'type' field.",
+          "items": {
+            "$ref": "#/$defs/RelationshipSchemaLevel"
+          }
+        },
+        "quality": {
+          "$ref": "#/$defs/DataQualityChecks"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/SchemaElement"
+        }
+      ],
+      "required": ["name"],
+      "unevaluatedProperties": false
+    },
+    "SchemaBaseProperty": {
+      "type": "object",
+      "properties": {
+        "primaryKey": {
+          "type": "boolean",
+          "description": "Boolean value specifying whether the element is primary or not. Default is false."
+        },
+        "primaryKeyPosition": {
+          "type": "integer",
+          "default": -1,
+          "description": "If element is a primary key, the position of the primary key element. Starts from 1. Example of `account_id, name` being primary key columns, `account_id` has primaryKeyPosition 1 and `name` primaryKeyPosition 2. Default to -1."
+        },
+        "logicalType": {
+          "type": "string",
+          "description": "The logical element data type.",
+          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean"]
+        },
+        "logicalTypeOptions": {
+          "type": "object",
+          "description": "Additional optional metadata to describe the logical type."
+        },
+        "physicalType": {
+          "type": "string",
+          "description": "The physical element data type in the data source. For example, VARCHAR(2), DOUBLE, INT."
+        },
+        "physicalName": {
+          "type": "string",
+          "description": "Physical name.",
+          "examples": ["col_str_a"]
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element may contain Null values; possible values are true and false. Default is false."
+        },
+        "unique": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element contains unique values; possible values are true and false. Default is false."
+        },
+        "partitioned": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element is partitioned; possible values are true and false."
+        },
+        "partitionKeyPosition": {
+          "type": "integer",
+          "default": -1,
+          "description": "If element is used for partitioning, the position of the partition element. Starts from 1. Example of `country, year` being partition columns, `country` has partitionKeyPosition 1 and `year` partitionKeyPosition 2. Default to -1."
+        },
+        "classification": {
+          "type": "string",
+          "description": "Can be anything, like confidential, restricted, and public to more advanced categorization. Some companies like PayPal, use data classification indicating the class of data in the element; expected values are 1, 2, 3, 4, or 5.",
+          "examples": ["confidential", "restricted", "public"]
+        },
+        "encryptedName": {
+          "type": "string",
+          "description": "The element name within the dataset that contains the encrypted element value. For example, unencrypted element `email_address` might have an encryptedName of `email_address_encrypt`."
+        },
+        "transformSourceObjects": {
+          "type": "array",
+          "description": "List of objects in the data source used in the transformation.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transformLogic": {
+          "type": "string",
+          "description": "Logic used in the element transformation."
+        },
+        "transformDescription": {
+          "type": "string",
+          "description": "Describes the transform logic in very simple terms."
+        },
+        "examples": {
+          "type": "array",
+          "description": "List of sample element values.",
+          "items": {
+            "$ref": "#/$defs/AnyType"
+          }
+        },
+        "criticalDataElement": {
+          "type": "boolean",
+          "default": false,
+          "description": "True or false indicator; If element is considered a critical data element (CDE) then true else false."
+        },
+        "relationships": {
+          "type": "array",
+          "description": "A list of relationships to other properties. When defined at property level, the 'from' field is implicit and should not be specified.",
+          "items": {
+            "$ref": "#/$defs/RelationshipPropertyLevel"
+          }
+        },
+        "quality": {
+          "$ref": "#/$defs/DataQualityChecks"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/SchemaElement"
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "string"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum length of the string."
+                  },
+                  "maxLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum length of the string."
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regular expression pattern to define valid value. Follows regular expression syntax from ECMA-262 (https://262.ecma-international.org/5.1/#sec-15.10.1)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "examples": ["password", "byte", "binary", "email", "uuid", "uri", "hostname", "ipv4", "ipv6"],
+                    "description": "Provides extra context about what format the string follows."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "date"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "examples": ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss"],
+                    "description": "Format of the date. Follows the format as prescribed by [JDK DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, format 'yyyy-MM-dd'."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "string",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "maximum": {
+                    "type": "string",
+                    "description": "All date values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "string",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "minimum": {
+                    "type": "string",
+                    "description": "All date values are greater than or equal to this value (values >= minimum)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "timestamp"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "time"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "examples": ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss"],
+                    "description": "Format of the date. Follows the format as prescribed by [JDK DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, format 'yyyy-MM-dd'."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "string",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "maximum": {
+                    "type": "string",
+                    "description": "All date values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "string",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "minimum": {
+                    "type": "string",
+                    "description": "All date values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "timezone": {
+                    "type": "boolean",
+                    "description": "Whether the timestamp defines the timezone or not. If true, timezone information is included in the timestamp."
+                  },
+                  "defaultTimezone": {
+                    "type": "string",
+                    "description": "The default timezone of the timestamp. If timezone is not defined, the default timezone UTC is used.",
+                    "default": "Etc/UTC"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "integer"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "Values must be multiples of this number. For example, multiple of 5 has valid values 0, 5, 10, -5."
+                  },
+                  "maximum": {
+                    "type": "number",
+                    "description": "All values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "number",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "minimum": {
+                    "type": "number",
+                    "description": "All values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "number",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "default": "i32",
+                    "description": "Format of the value in terms of how many bits of space it can use and whether it is signed or unsigned (follows the Rust integer types).",
+                    "enum": ["i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "number"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "Values must be multiples of this number. For example, multiple of 5 has valid values 0, 5, 10, -5."
+                  },
+                  "maximum": {
+                    "type": "number",
+                    "description": "All values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "number",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "minimum": {
+                    "type": "number",
+                    "description": "All values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "number",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "default": "i32",
+                    "description": "Format of the value in terms of how many bits of space it can use (follows the Rust float types).",
+                    "enum": ["f32", "f64"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "object"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum number of properties."
+                  },
+                  "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Minimum number of properties."
+                  },
+                  "required": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "description": "Property names that are required to exist in the object."
+                  }
+                }
+              },
+              "properties": {
+                "type": "array",
+                "description": "A list of properties for the object.",
+                "items": {
+                  "$ref": "#/$defs/SchemaProperty"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "maxItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum number of items."
+                  },
+                  "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Minimum number of items"
+                  },
+                  "uniqueItems": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, all items in the array are unique."
+                  }
+                }
+              },
+              "items": {
+                "$ref": "#/$defs/SchemaItemProperty",
+                "description": "List of items in an array (only applicable when `logicalType: array`)."
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "SchemaProperty": {
+      "type": "object",
+      "$ref": "#/$defs/SchemaBaseProperty",
+      "required": ["name"],
+      "unevaluatedProperties": false
+    },
+    "SchemaItemProperty": {
+      "type": "object",
+      "$ref": "#/$defs/SchemaBaseProperty",
+      "properties": {
+        "properties": {
+          "type": "array",
+          "description": "A list of properties for the object.",
+          "items": {
+            "$ref": "#/$defs/SchemaProperty"
+          }
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "Tags": {
+      "type": "array",
+      "description": "A list of tags that may be assigned to the elements (object or property); the tags keyword may appear at any level. Tags may be used to better categorize an element. For example, `finance`, `sensitive`, `employee_record`.",
+      "examples": ["finance", "sensitive", "employee_record"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "DataQuality": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "businessImpact": {
+          "type": "string",
+          "description": "Consequences of the rule failure.",
+          "examples": ["operational", "regulatory"]
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Additional properties required for rule execution.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Describe the quality check to be completed."
+        },
+        "dimension": {
+          "type": "string",
+          "description": "The key performance indicator (KPI) or dimension for data quality.",
+          "enum": ["accuracy", "completeness", "conformity", "consistency", "coverage", "timeliness", "uniqueness"]
+        },
+        "method": {
+          "type": "string",
+          "examples": ["reconciliation"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the data quality check."
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Rule execution schedule details.",
+          "examples": ["0 20 * * *"]
+        },
+        "scheduler": {
+          "type": "string",
+          "description": "The name or type of scheduler used to start the data quality check.",
+          "examples": ["cron"]
+        },
+        "severity": {
+          "type": "string",
+          "description": "The severance of the quality rule.",
+          "examples": ["info", "warning", "error"]
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of quality check. 'text' is human-readable text that describes the quality of the data. 'library' is a set of maintained predefined quality attributes such as row count or unique. 'sql' is an individual SQL query that returns a value that can be compared. 'custom' is quality attributes that are vendor-specific, such as Soda or Great Expectations.",
+          "enum": ["text", "library", "sql", "custom"],
+          "default": "library"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit the rule is using, popular values are `rows` or `percent`, but any value is allowed.",
+          "examples": ["rows", "percent"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "library"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "properties": {
+                  "metric": {
+                    "type": "string"
+                  }
+                },
+                "required": ["metric"]
+              }
+            ]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualityLibrary"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualitySql"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "custom"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualityCustom"
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "DataQualityChecks": {
+      "type": "array",
+      "description": "Data quality rules with all the relevant information for rule setup and execution.",
+      "items": {
+        "$ref": "#/$defs/DataQuality"
+      }
+    },
+    "DataQualityOperators": {
+      "type": "object",
+      "description": "Common comparison operators for data quality checks.",
+      "oneOf": [
+        {
+          "properties": {
+            "mustBe": {
+              "description": "Must be equal to the value to be valid. When using numbers, it is equivalent to '='."
+            }
+          },
+          "required": ["mustBe"]
+        },
+        {
+          "properties": {
+            "mustNotBe": {
+              "description": "Must not be equal to the value to be valid. When using numbers, it is equivalent to '!='."
+            }
+          },
+          "required": ["mustNotBe"]
+        },
+        {
+          "properties": {
+            "mustBeGreaterThan": {
+              "type": "number",
+              "description": "Must be greater than the value to be valid. It is equivalent to '>'."
+            }
+          },
+          "required": ["mustBeGreaterThan"]
+        },
+        {
+          "properties": {
+            "mustBeGreaterOrEqualTo": {
+              "type": "number",
+              "description": "Must be greater than or equal to the value to be valid. It is equivalent to '>='."
+            }
+          },
+          "required": ["mustBeGreaterOrEqualTo"]
+        },
+        {
+          "properties": {
+            "mustBeLessThan": {
+              "type": "number",
+              "description": "Must be less than the value to be valid. It is equivalent to '<'."
+            }
+          },
+          "required": ["mustBeLessThan"]
+        },
+        {
+          "properties": {
+            "mustBeLessOrEqualTo": {
+              "type": "number",
+              "description": "Must be less than or equal to the value to be valid. It is equivalent to '<='."
+            }
+          },
+          "required": ["mustBeLessOrEqualTo"]
+        },
+        {
+          "properties": {
+            "mustBeBetween": {
+              "type": "array",
+              "description": "Must be between the two numbers to be valid. Smallest number first in the array.",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": ["mustBeBetween"]
+        },
+        {
+          "properties": {
+            "mustNotBeBetween": {
+              "type": "array",
+              "description": "Must not be between the two numbers to be valid. Smallest number first in the array.",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": ["mustNotBeBetween"]
+        }
+      ]
+    },
+    "DataQualityLibrary": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DataQualityOperators"
+        }
+      ],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "description": "Define a data quality check based on the predefined metrics as per ODCS.",
+          "enum": ["nullValues", "missingValues", "invalidValues", "duplicateValues", "rowCount"]
+        },
+        "rule": {
+          "type": "string",
+          "deprecated": true,
+          "description": "Use metric instead"
+        },
+        "arguments": {
+          "type": "object",
+          "description": "Additional arguments for the metric, if needed."
+        }
+      },
+      "required": ["metric"]
+    },
+    "DataQualitySql": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DataQualityOperators"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Query string that adheres to the dialect of the provided server.",
+          "examples": ["SELECT COUNT(*) FROM ${table} WHERE ${column} IS NOT NULL"]
+        }
+      },
+      "required": ["query"]
+    },
+    "DataQualityCustom": {
+      "type": "object",
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "Name of the engine which executes the data quality checks.",
+          "examples": ["soda", "great-expectations", "monte-carlo", "dbt"]
+        },
+        "implementation": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": ["engine", "implementation"]
+    },
+    "AuthoritativeDefinitions": {
+      "type": "array",
+      "description": "List of links to sources that provide more details on the dataset; examples would be a link to an external definition, a training video, a git repo, data catalog, or another tool. Authoritative definitions follow the same structure in the standard.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/$defs/StableId"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to the authority."
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of definition for authority: v2.3 adds standard values: `businessDefinition`, `transformationImplementation`, `videoTutorial`, `tutorial`, and `implementation`.",
+            "examples": ["businessDefinition", "transformationImplementation", "videoTutorial", "tutorial", "implementation"]
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the authoritative definition for humans."
+          }
+        },
+        "required": ["url", "type"],
+        "additionalProperties": false
+      }
+    },
+    "Support": {
+      "type": "array",
+      "description": "Top level for support channels.",
+      "items": {
+        "$ref": "#/$defs/SupportItem"
+      }
+    },
+    "SupportItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "channel": {
+          "type": "string",
+          "description": "Channel name or identifier."
+        },
+        "url": {
+          "type": "string",
+          "description": "Access URL using normal [URL scheme](https://en.wikipedia.org/wiki/URL#Syntax) (https, mailto, etc.)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the channel, free text."
+        },
+        "tool": {
+          "type": "string",
+          "description": "Name of the tool, value can be `email`, `slack`, `teams`, `discord`, `ticket`, `googlechat`, or `other`.",
+          "examples": ["email", "slack", "teams", "discord", "ticket", "googlechat", "other"]
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope can be: `interactive`, `announcements`, `issues`, `notifications`.",
+          "examples": ["interactive", "announcements", "issues", "notifications"]
+        },
+        "invitationUrl": {
+          "type": "string",
+          "description": "Some tools uses invitation URL for requesting or subscribing. Follows the [URL scheme](https://en.wikipedia.org/wiki/URL#Syntax)."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "required": ["channel"],
+      "additionalProperties": false
+    },
+    "Pricing": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "priceAmount": {
+          "type": "number",
+          "description": "Subscription price per unit of measure in `priceUnit`."
+        },
+        "priceCurrency": {
+          "type": "string",
+          "description": "Currency of the subscription price in `price.priceAmount`."
+        },
+        "priceUnit": {
+          "type": "string",
+          "description": "The unit of measure for calculating cost. Examples megabyte, gigabyte."
+        }
+      },
+      "additionalProperties": false
+    },
+    "TeamMember": {
+      "type": "object",
+      "description": "Team member information.",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "username": {
+          "type": "string",
+          "description": "The user's username or email."
+        },
+        "name": {
+          "type": "string",
+          "description": "The user's name."
+        },
+        "description": {
+          "type": "string",
+          "description": "The user's description."
+        },
+        "role": {
+          "type": "string",
+          "description": "The user's job role; Examples might be owner, data steward. There is no limit on the role."
+        },
+        "dateIn": {
+          "type": "string",
+          "format": "date",
+          "description": "The date when the user joined the team."
+        },
+        "dateOut": {
+          "type": "string",
+          "format": "date",
+          "description": "The date when the user ceased to be part of the team."
+        },
+        "replacedByUsername": {
+          "type": "string",
+          "description": "The username of the user who replaced the previous user."
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Custom properties block.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        }
+      },
+      "required": ["username"]
+    },
+    "Team": {
+      "type": "object",
+      "description": "Team information.",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "name": {
+          "type": "string",
+          "description": "Team name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Team description."
+        },
+        "members": {
+          "type": "array",
+          "description": "List of members.",
+          "items": {
+            "$ref": "#/$defs/TeamMember"
+          }
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Custom properties block.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        }
+      }
+    },
+    "Role": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "role": {
+          "type": "string",
+          "description": "Name of the IAM role that provides access to the dataset."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the IAM role and its permissions."
+        },
+        "access": {
+          "type": "string",
+          "description": "The type of access provided by the IAM role."
+        },
+        "firstLevelApprovers": {
+          "type": "string",
+          "description": "The name(s) of the first-level approver(s) of the role."
+        },
+        "secondLevelApprovers": {
+          "type": "string",
+          "description": "The name(s) of the second-level approver(s) of the role."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "required": ["role"],
+      "additionalProperties": false
+    },
+    "ServiceLevelAgreementProperty": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "property": {
+          "type": "string",
+          "description": "Specific property in SLA, check the periodic table. May requires units (more details to come)."
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agreement value. The label will change based on the property itself."
+        },
+        "valueExt": {
+          "$ref": "#/$defs/AnyNonCollectionType",
+          "description": "Extended agreement value. The label will change based on the property itself."
+        },
+        "unit": {
+          "type": "string",
+          "description": "**d**, day, days for days; **y**, yr, years for years, etc. Units use the ISO standard."
+        },
+        "element": {
+          "type": "string",
+          "description": "Element(s) to check on. Multiple elements should be extremely rare and, if so, separated by commas."
+        },
+        "driver": {
+          "type": "string",
+          "description": "Describes the importance of the SLA from the list of: `regulatory`, `analytics`, or `operational`.",
+          "examples": ["regulatory", "analytics", "operational"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the SLA for humans.",
+          "examples": ["99.9% of the time, data is available by 6 AM UTC"]
+        },
+        "scheduler": {
+          "type": "string",
+          "description": "Name of the scheduler, can be cron or any tool your organization support.",
+          "examples": ["cron"]
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Configuration information for the scheduling tool, for cron a possible value is 0 20 * * *.",
+          "examples": ["0 20 * * *"]
+        }
+      },
+      "required": ["property", "value"],
+      "additionalProperties": false
+    },
+    "CustomProperties": {
+      "type": "array",
+      "description": "A list of key/value pairs for custom properties.",
+      "items": {
+        "$ref": "#/$defs/CustomProperty"
+      }
+    },
+    "CustomProperty": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "property": {
+          "type": "string",
+          "description": "The name of the key. Names should be in camel case–the same as if they were permanent properties in the contract."
+        },
+        "value": {
+          "$ref": "#/$defs/AnyType",
+          "description": "The value of the key."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the custom property."
+        }
+      },
+      "required": ["property", "value"],
+      "additionalProperties": false
+    },
+    "AnyType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "AnyNonCollectionType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "RelationshipBase": {
+      "type": "object",
+      "description": "Base definition for relationships between properties, typically for foreign key constraints.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of relationship. Defaults to 'foreignKey'.",
+          "default": "foreignKey",
+          "enum": ["foreignKey"]
+        },
+        "from": {
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ShorthandReference"
+                },
+                {
+                  "$ref": "#/$defs/FullyQualifiedReference"
+                }
+              ],
+              "description": "Source property reference using fully qualified or shorthand notation."
+            },
+            {
+              "type": "array",
+              "description": "Array of source properties for composite keys.",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ShorthandReference"
+                  },
+                  {
+                    "$ref": "#/$defs/FullyQualifiedReference"
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          ],
+          "description": "Source property or properties."
+        },
+        "to": {
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ShorthandReference"
+                },
+                {
+                  "$ref": "#/$defs/FullyQualifiedReference"
+                }
+              ],
+              "description": "Target property reference using fully qualified or shorthand notation."
+            },
+            {
+              "type": "array",
+              "description": "Array of target properties for composite keys.",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ShorthandReference"
+                  },
+                  {
+                    "$ref": "#/$defs/FullyQualifiedReference"
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          ],
+          "description": "Target property or properties to reference."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "RelationshipSchemaLevel": {
+      "type": "object",
+      "description": "Relationship definition at schema level, requiring both 'from' and 'to' fields with matching types.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/RelationshipBase"
+        },
+        {
+          "required": ["from", "to"]
+        },
+        {
+          "oneOf": [
+            {
+              "description": "Single-column relationship - both fields must be strings",
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "description": "Composite key relationship - both fields must be arrays with matching lengths",
+              "properties": {
+                "from": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                },
+                "to": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "RelationshipPropertyLevel": {
+      "type": "object",
+      "description": "Relationship definition at property level, where 'from' is implicitly the current property.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/RelationshipBase"
+        },
+        {
+          "type": "object",
+          "required": ["to"]
+        },
+        {
+          "not": {
+            "required": ["from"]
+          },
+          "description": "The 'from' field must not be specified at property level as it is implicitly derived from the property context"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Relationship": {
+      "description": "Compatibility wrapper for relationship definitions.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/RelationshipSchemaLevel"
+        },
+        {
+          "$ref": "#/$defs/RelationshipPropertyLevel"
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/odcs_customer_bad.csv
+++ b/tests/fixtures/odcs_customer_bad.csv
@@ -1,0 +1,3 @@
+email,age,id,balance,phone,name,score,date,username,password,loyalty_tier
+not-an-email,-5,C1,10.5,0123,,150,2025-12-31,bad user,short,gold
+bob@example.org,41,C1,0,+15551234567,Bob,99,2025-12-31,bob_2,anotherlongpw,silver

--- a/tests/fixtures/odcs_customer_clean.csv
+++ b/tests/fixtures/odcs_customer_clean.csv
@@ -1,0 +1,3 @@
+email,age,id,balance,phone,name,score,date,username,password,loyalty_tier
+alice@example.com,30,C1,10.5,+441234567890,Alice,50,2026-01-02,alice_1,longpassword,gold
+bob@example.org,41,C2,0,+15551234567,Bob,99,2025-12-31,bob_2,anotherlongpw,silver

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,24 +138,20 @@ class TestCLIValidate:
 SAMPLE_ODCS = {
     "apiVersion": "v3.1.0",
     "kind": "DataContract",
-    "info": {
-        "title": "CLI Test Contract",
-        "version": "1.0",
-        "status": "active",
-        "description": "Created by CLI test",
-        "owner": "test-team",
-    },
+    "id": "cli-test-contract",
+    "name": "CLI Test Contract",
+    "version": "1.0",
+    "status": "active",
+    "description": {"purpose": "Created by CLI test"},
+    "team": {"name": "test-team"},
     "schema": [
         {
             "name": "records",
+            "logicalType": "object",
             "properties": [
-                {"name": "email", "required": True, "unique": True},
-                {
-                    "name": "age",
-                    "quality": [
-                        {"type": "range", "min": 0, "max": 120, "mustBeSatisfied": True}
-                    ],
-                },
+                {"name": "email", "logicalType": "string", "required": True, "unique": True},
+                {"name": "age", "logicalType": "integer",
+                 "logicalTypeOptions": {"minimum": 0, "maximum": 120}},
             ],
         }
     ],

--- a/tests/test_odcs_import.py
+++ b/tests/test_odcs_import.py
@@ -1,587 +1,555 @@
-"""Tests for ODCS 3.1 importer and exporter.
-
-Covers:
-  - import_odcs: field shortcuts, quality checks, dedup, skipped types
-  - odcs_to_yaml: returns (name, yaml_string) tuple
-  - export_odcs: produces valid ODCS 3.1 dict
-  - contract_to_odcs_yaml: produces valid YAML string
-  - POST /import/odcs API endpoint
-  - GET /export/odcs/{name} API endpoint
 """
+ODCS v3.1.0 importer / exporter tests (CRT179, v2.4.0).
 
+Two oracles:
+  * the official ODCS v3.1.0 JSON schema, vendored at tests/fixtures/ — every
+    export must validate against it;
+  * datacontract-cli (`datacontract lint`), when installed — same documents.
+
+Plus: round-trip idempotence on every bundled contract, the spec's own
+full example on import, and the import-path safety controls from the
+Sonnet pre-implementation review (denied fields, fail-closed on bad rules,
+duplicate-field reporting, 422 at the API).
+"""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
 import yaml
 
 from opendqv.core.importers.odcs import (
+    ODCS_API_VERSION,
+    _from_jdk_format,
+    _to_jdk_format,
+    contract_to_odcs_yaml,
+    export_odcs,
     import_odcs,
     odcs_to_yaml,
-    export_odcs,
-    contract_to_odcs_yaml,
 )
+from opendqv.core.rule_parser import Rule
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SCHEMA = json.loads((FIXTURES / "odcs-json-schema-v3.1.0.json").read_text(encoding="utf-8"))
+VALIDATOR = jsonschema.Draft202012Validator(SCHEMA)
+FULL_EXAMPLE = yaml.safe_load((FIXTURES / "odcs-full-example-v3.1.0.yaml").read_text(encoding="utf-8"))
+BUNDLED_DIR = Path(__file__).resolve().parent.parent / "opendqv" / "contracts"
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+def _schema_errors(doc: dict) -> list[str]:
+    return [f"{'/'.join(str(p) for p in e.path)}: {e.message}" for e in VALIDATOR.iter_errors(doc)]
 
-MINIMAL_CONTRACT = {
+
+def _rules(*dicts) -> list[Rule]:
+    return [Rule(**d) for d in dicts]
+
+
+def _bundled_contract_names() -> list[str]:
+    return sorted(p.stem for p in BUNDLED_DIR.glob("*.yaml"))
+
+
+def _load_bundled(name: str) -> dict:
+    return yaml.safe_load((BUNDLED_DIR / f"{name}.yaml").read_text(encoding="utf-8"))["contract"]
+
+
+def _export_bundled(name: str) -> dict:
+    c = _load_bundled(name)
+    return export_odcs(c["name"], [Rule(**r) for r in c.get("rules", [])],
+                       version=str(c.get("version", "1.0")), status=c.get("status", "active"),
+                       description=c.get("description", ""), owner=c.get("owner", ""),
+                       owner_email=c.get("owner_email"))
+
+
+# A minimal, schema-valid ODCS v3.1.0 document using only native constraints.
+NATIVE_ODCS = {
     "apiVersion": "v3.1.0",
     "kind": "DataContract",
-    "info": {
-        "title": "Customer Contract",
-        "version": "2.0",
-        "status": "active",
-        "description": "Test contract",
-        "owner": "data-team",
-    },
-    "schema": [
-        {
-            "name": "customers",
-            "properties": [
-                {"name": "email", "required": True, "unique": True},
-                {"name": "name", "required": True},
-            ],
-        }
-    ],
-}
-
-FULL_QUALITY_CONTRACT = {
-    "apiVersion": "v3.1.0",
-    "kind": "DataContract",
-    "info": {"title": "full_quality", "version": "1.0"},
+    "id": "customer-orders",
+    "name": "Customer Orders",
+    "version": "2.0",
+    "status": "active",
+    "description": {"purpose": "Orders placed by customers"},
+    "team": {"name": "data-team", "members": [{"username": "owner@example.com", "role": "owner"}]},
     "schema": [
         {
             "name": "orders",
+            "logicalType": "object",
             "properties": [
-                {
-                    "name": "email",
-                    "quality": [
-                        {"type": "not_null", "mustBeSatisfied": True},
-                        {"type": "regex", "pattern": r"^[\w.]+@[\w.]+$", "mustBeSatisfied": True},
-                    ],
-                },
-                {
-                    "name": "age",
-                    "quality": [
-                        {"type": "range", "min": 0, "max": 120, "mustBeSatisfied": False},
-                    ],
-                },
-                {
-                    "name": "score",
-                    "quality": [
-                        {"type": "min", "min": 0, "mustBeSatisfied": True},
-                        {"type": "max", "max": 100, "mustBeSatisfied": True},
-                    ],
-                },
-                {
-                    "name": "code",
-                    "minLength": 3,
-                    "maxLength": 10,
-                    "quality": [
-                        {"type": "min_length", "minLength": 3, "mustBeSatisfied": False},
-                        {"type": "date_format", "format": "%Y-%m-%d", "mustBeSatisfied": False},
-                    ],
-                },
+                {"name": "order_id", "logicalType": "string", "required": True, "unique": True,
+                 "logicalTypeOptions": {"pattern": "^ORD-[0-9]{6}$", "minLength": 10, "maxLength": 10}},
+                {"name": "amount", "logicalType": "number",
+                 "logicalTypeOptions": {"minimum": 0, "maximum": 10000}},
+                {"name": "qty", "logicalType": "integer", "logicalTypeOptions": {"exclusiveMinimum": 0}},
+                {"name": "order_date", "logicalType": "date", "logicalTypeOptions": {"format": "yyyy-MM-dd"}},
+                {"name": "country", "logicalType": "string", "quality": [
+                    {"type": "library", "metric": "invalidValues", "arguments": {"validValues": ["GB", "IE"]},
+                     "mustBe": 0, "severity": "error"},
+                    {"type": "library", "metric": "nullValues", "mustBeLessThan": 5, "unit": "percent"},
+                    {"type": "text", "description": "Country should follow ISO 3166-1 alpha-2"},
+                ]},
+                {"name": "email", "logicalType": "string", "quality": [
+                    {"type": "library", "metric": "nullValues", "mustBe": 0, "severity": "warning"},
+                    {"type": "library", "metric": "duplicateValues", "mustBe": 0},
+                    {"type": "sql", "query": "SELECT COUNT(*) FROM orders WHERE email IS NULL", "mustBe": 0},
+                ]},
             ],
         }
     ],
 }
 
 
-# ---------------------------------------------------------------------------
-# TestImportODCSBasic
-# ---------------------------------------------------------------------------
+# ─────────────────────────────────────────────────────────────────────────────
+# Export: schema validity
+# ─────────────────────────────────────────────────────────────────────────────
 
-class TestImportODCSBasic:
-    """Basic import_odcs functionality."""
+class TestExportIsValidODCS:
+    def test_native_fixture_is_itself_valid(self):
+        assert _schema_errors(NATIVE_ODCS) == []
 
-    def test_returns_contract_key(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert "contract" in result
-
-    def test_contract_name_from_title(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["contract"]["name"] == "customer_contract"
-
-    def test_name_sanitised_lowercase(self):
-        c = {"info": {"title": "My Contract-2"}, "schema": []}
-        result = import_odcs(c)
-        assert result["contract"]["name"] == "my_contract_2"
-
-    def test_version_extracted(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["contract"]["version"] == "2.0"
-
-    def test_status_extracted(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["contract"]["status"] == "active"
-
-    def test_description_extracted(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["contract"]["description"] == "Test contract"
-
-    def test_owner_extracted(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["contract"]["owner"] == "data-team"
-
-    def test_rule_count_in_result(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert result["rule_count"] == len(result["contract"]["rules"])
-
-    def test_skipped_checks_list(self):
-        result = import_odcs(MINIMAL_CONTRACT)
-        assert "skipped_checks" in result
-        assert isinstance(result["skipped_checks"], list)
-
-    def test_empty_schema_produces_no_rules(self):
-        c = {"info": {"title": "empty"}, "schema": []}
-        result = import_odcs(c)
-        assert result["contract"]["rules"] == []
-
-    def test_missing_info_uses_defaults(self):
-        c = {"schema": []}
-        result = import_odcs(c)
-        assert result["contract"]["name"] == "imported_contract"
-        assert result["contract"]["version"] == "1.0"
-        assert result["contract"]["status"] == "active"
-
-
-# ---------------------------------------------------------------------------
-# TestFieldShortcuts
-# ---------------------------------------------------------------------------
-
-class TestFieldShortcuts:
-    """Field-level shortcut attributes → rules."""
-
-    def _rules(self, contract):
-        return import_odcs(contract)["contract"]["rules"]
-
-    def test_required_produces_not_empty_rule(self):
-        rules = self._rules(MINIMAL_CONTRACT)
-        types = [r["type"] for r in rules if r["field"] == "email"]
-        assert "not_empty" in types
-
-    def test_required_rule_is_error_severity(self):
-        rules = self._rules(MINIMAL_CONTRACT)
-        r = next(r for r in rules if r["field"] == "email" and r["type"] == "not_empty")
-        assert r["severity"] == "error"
-
-    def test_unique_produces_unique_rule(self):
-        rules = self._rules(MINIMAL_CONTRACT)
-        types = [r["type"] for r in rules if r["field"] == "email"]
-        assert "unique" in types
-
-    def test_min_length_shortcut(self):
-        c = {
-            "info": {"title": "t"},
-            "schema": [{"name": "t", "properties": [{"name": "code", "minLength": 5}]}],
-        }
-        rules = self._rules(c)
-        r = next(r for r in rules if r["type"] == "min_length")
-        assert r["min_length"] == 5
-
-    def test_max_length_shortcut(self):
-        c = {
-            "info": {"title": "t"},
-            "schema": [{"name": "t", "properties": [{"name": "code", "maxLength": 20}]}],
-        }
-        rules = self._rules(c)
-        r = next(r for r in rules if r["type"] == "max_length")
-        assert r["max_length"] == 20
-
-
-# ---------------------------------------------------------------------------
-# TestQualityChecks
-# ---------------------------------------------------------------------------
-
-class TestQualityChecks:
-    """Inline quality[] checks → rules."""
-
-    def _rules(self):
-        return import_odcs(FULL_QUALITY_CONTRACT)["contract"]["rules"]
-
-    def test_not_null_maps_to_not_empty(self):
-        rules = self._rules()
-        types = [r["type"] for r in rules if r["field"] == "email"]
-        assert "not_empty" in types
-
-    def test_must_be_satisfied_true_is_error(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["field"] == "email" and r["type"] == "not_empty")
-        assert r["severity"] == "error"
-
-    def test_must_be_satisfied_false_is_warning(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["field"] == "age" and r["type"] == "range")
-        assert r["severity"] == "warning"
-
-    def test_regex_pattern_captured(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["type"] == "regex")
-        assert r["pattern"] == r"^[\w.]+@[\w.]+$"
-
-    def test_range_min_max(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["field"] == "age" and r["type"] == "range")
-        assert r["min_value"] == 0.0
-        assert r["max_value"] == 120.0
-
-    def test_min_rule(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["field"] == "score" and r["type"] == "min")
-        assert r["min_value"] == 0.0
-
-    def test_max_rule(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["field"] == "score" and r["type"] == "max")
-        assert r["max_value"] == 100.0
-
-    def test_min_length_quality(self):
-        rules = self._rules()
-        # Dedup by (type, field): shortcut "code_min_length" wins over quality "code_min_length_0"
-        r = next(r for r in rules if r["field"] == "code" and r["type"] == "min_length")
-        assert r["min_length"] == 3
-
-    def test_date_format_quality(self):
-        rules = self._rules()
-        r = next(r for r in rules if r["type"] == "date_format")
-        assert r["format"] == "%Y-%m-%d"
-
-    def test_unsupported_type_skipped(self):
-        c = {
-            "info": {"title": "t"},
-            "schema": [{
-                "name": "t",
-                "properties": [{"name": "f", "quality": [{"type": "custom_check"}]}],
-            }],
-        }
-        result = import_odcs(c)
-        assert "f.custom_check" in result["skipped_checks"]
-
-    def test_regex_without_pattern_skipped(self):
-        c = {
-            "info": {"title": "t"},
-            "schema": [{
-                "name": "t",
-                "properties": [{"name": "f", "quality": [{"type": "regex"}]}],
-            }],
-        }
-        result = import_odcs(c)
-        assert result["contract"]["rules"] == []
-
-
-# ---------------------------------------------------------------------------
-# TestDeduplication
-# ---------------------------------------------------------------------------
-
-class TestDeduplication:
-    """Shortcut + quality duplicates are deduplicated."""
-
-    def test_required_plus_not_null_quality_deduped(self):
-        c = {
-            "info": {"title": "t"},
-            "schema": [{
-                "name": "t",
-                "properties": [{
-                    "name": "email",
-                    "required": True,
-                    "quality": [{"type": "not_null", "mustBeSatisfied": True}],
-                }],
-            }],
-        }
-        result = import_odcs(c)
-        not_empty_rules = [r for r in result["contract"]["rules"] if r["type"] == "not_empty"]
-        # Dedup by (type, field): shortcut "email_not_empty" added first, quality check dropped.
-        assert len(not_empty_rules) == 1
-
-
-# ---------------------------------------------------------------------------
-# TestOdcsToYaml
-# ---------------------------------------------------------------------------
-
-class TestOdcsToYaml:
-    """odcs_to_yaml() returns (name, yaml_string)."""
-
-    def test_returns_tuple(self):
-        result = odcs_to_yaml(MINIMAL_CONTRACT)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-
-    def test_name_matches_title(self):
-        name, _ = odcs_to_yaml(MINIMAL_CONTRACT)
-        assert name == "customer_contract"
-
-    def test_name_override(self):
-        name, _ = odcs_to_yaml(MINIMAL_CONTRACT, contract_name="override_name")
-        assert name == "override_name"
-
-    def test_yaml_is_valid(self):
-        _, yaml_str = odcs_to_yaml(MINIMAL_CONTRACT)
-        parsed = yaml.safe_load(yaml_str)
-        assert "contract" in parsed
-
-    def test_yaml_has_rules(self):
-        _, yaml_str = odcs_to_yaml(MINIMAL_CONTRACT)
-        parsed = yaml.safe_load(yaml_str)
-        assert isinstance(parsed["contract"]["rules"], list)
-
-
-# ---------------------------------------------------------------------------
-# TestExportODCS
-# ---------------------------------------------------------------------------
-
-class TestExportODCS:
-    """export_odcs() produces valid ODCS 3.1 dict."""
-
-    def _make_rules(self):
-        return [
-            {"field": "email", "type": "not_empty", "severity": "error", "error_message": "required"},
-            {"field": "email", "type": "regex", "severity": "error", "pattern": r"^.+@.+$",
-             "error_message": "bad email"},
-            {"field": "age", "type": "range", "severity": "warning", "min_value": 0, "max_value": 120,
-             "error_message": "out of range"},
-            {"field": "name", "type": "min_length", "severity": "error", "min_length": 2,
-             "error_message": "too short"},
-            {"field": "code", "type": "max_length", "severity": "error", "max_length": 10,
-             "error_message": "too long"},
-        ]
-
-    def test_api_version(self):
-        doc = export_odcs("test", self._make_rules())
-        assert doc["apiVersion"] == "v3.1.0"
-
-    def test_kind_is_data_contract(self):
-        doc = export_odcs("test", self._make_rules())
+    def test_required_top_level_fields_present(self):
+        doc = export_odcs("t", _rules({"name": "r", "type": "not_empty", "field": "a"}))
+        for key in ("apiVersion", "kind", "id", "version", "status"):
+            assert key in doc
+        assert doc["apiVersion"] == ODCS_API_VERSION == "v3.1.0"
         assert doc["kind"] == "DataContract"
+        assert "info" not in doc
 
-    def test_info_title(self):
-        doc = export_odcs("mycontract", self._make_rules())
-        assert doc["info"]["title"] == "mycontract"
+    def test_empty_contract_is_valid(self):
+        doc = export_odcs("empty", [], status="draft")
+        assert _schema_errors(doc) == []
 
-    def test_info_version(self):
-        doc = export_odcs("test", self._make_rules(), version="3.0")
-        assert doc["info"]["version"] == "3.0"
+    @pytest.mark.parametrize("name", _bundled_contract_names())
+    def test_every_bundled_contract_exports_valid_odcs(self, name):
+        assert _schema_errors(_export_bundled(name)) == []
 
-    def test_info_status(self):
-        doc = export_odcs("test", self._make_rules(), status="draft")
-        assert doc["info"]["status"] == "draft"
+    def test_status_mapping_to_odcs_vocabulary(self):
+        for opendqv_status, odcs_status in (("draft", "draft"), ("review", "proposed"),
+                                            ("active", "active"), ("archived", "deprecated")):
+            doc = export_odcs("t", [], status=opendqv_status)
+            assert doc["status"] == odcs_status
+            assert {"property": "opendqv.status", "value": opendqv_status} in doc["customProperties"]
 
-    def test_schema_has_properties(self):
-        doc = export_odcs("test", self._make_rules())
-        assert len(doc["schema"]) == 1
-        props = doc["schema"][0]["properties"]
-        assert len(props) > 0
+    def test_description_and_team_shape(self):
+        doc = export_odcs("t", [], description="purpose text", owner="Team X", owner_email="x@example.com")
+        assert doc["description"] == {"purpose": "purpose text"}
+        assert doc["team"] == {"name": "Team X", "members": [{"username": "x@example.com", "role": "owner"}]}
+        assert _schema_errors(doc) == []
 
-    def test_not_empty_maps_to_not_null(self):
-        doc = export_odcs("test", self._make_rules())
-        email_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "email")
-        types = [q["type"] for q in email_prop["quality"]]
-        assert "not_null" in types
+    def test_no_description_or_team_when_empty(self):
+        doc = export_odcs("t", [])
+        assert "description" not in doc and "team" not in doc
 
-    def test_must_be_satisfied_for_error(self):
-        doc = export_odcs("test", self._make_rules())
-        email_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "email")
-        nn = next(q for q in email_prop["quality"] if q["type"] == "not_null")
-        assert nn["mustBeSatisfied"] is True
-
-    def test_must_be_satisfied_false_for_warning(self):
-        doc = export_odcs("test", self._make_rules())
-        age_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "age")
-        r = next(q for q in age_prop["quality"] if q["type"] == "range")
-        assert r["mustBeSatisfied"] is False
-
-    def test_regex_pattern_exported(self):
-        doc = export_odcs("test", self._make_rules())
-        email_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "email")
-        rx = next(q for q in email_prop["quality"] if q["type"] == "regex")
-        assert "pattern" in rx
-
-    def test_min_length_exported(self):
-        doc = export_odcs("test", self._make_rules())
-        name_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "name")
-        ml = next(q for q in name_prop["quality"] if q["type"] == "min_length")
-        assert ml["minLength"] == 2
-
-    def test_max_length_exported(self):
-        doc = export_odcs("test", self._make_rules())
-        code_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "code")
-        ml = next(q for q in code_prop["quality"] if q["type"] == "max_length")
-        assert ml["maxLength"] == 10
-
-    def test_description_in_quality(self):
-        doc = export_odcs("test", self._make_rules())
-        email_prop = next(p for p in doc["schema"][0]["properties"] if p["name"] == "email")
-        nn = next(q for q in email_prop["quality"] if q["type"] == "not_null")
-        assert nn["description"] == "required"
+    def test_yaml_helper_round_trips_to_same_dict(self):
+        rules = _rules({"name": "r", "type": "regex", "field": "a", "pattern": "^x$"})
+        assert yaml.safe_load(contract_to_odcs_yaml("t", rules)) == export_odcs("t", rules)
 
 
-# ---------------------------------------------------------------------------
-# TestContractToOdcsYaml
-# ---------------------------------------------------------------------------
+# ─────────────────────────────────────────────────────────────────────────────
+# Export: native projection rules
+# ─────────────────────────────────────────────────────────────────────────────
 
-class TestContractToOdcsYaml:
-    """contract_to_odcs_yaml() returns a valid YAML string."""
-
-    def test_returns_string(self):
-        result = contract_to_odcs_yaml("test", [])
-        assert isinstance(result, str)
-
-    def test_valid_yaml(self):
-        rules = [{"field": "x", "type": "not_empty", "severity": "error", "error_message": "e"}]
-        yaml_str = contract_to_odcs_yaml("test", rules)
-        parsed = yaml.safe_load(yaml_str)
-        assert parsed["apiVersion"] == "v3.1.0"
-
-    def test_empty_rules_produces_empty_properties(self):
-        yaml_str = contract_to_odcs_yaml("test", [])
-        parsed = yaml.safe_load(yaml_str)
-        assert parsed["schema"][0]["properties"] == []
+def _prop(doc: dict, field: str) -> dict:
+    return next(p for p in doc["schema"][0]["properties"] if p["name"] == field)
 
 
-# ---------------------------------------------------------------------------
-# TestODCSAPIEndpoints
-# ---------------------------------------------------------------------------
+class TestExportNativeProjection:
+    def test_error_not_empty_and_unique_project_to_flags(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "not_empty", "field": "f"},
+                                      {"name": "b", "type": "unique", "field": "f"}))
+        p = _prop(doc, "f")
+        assert p["required"] is True and p["unique"] is True
 
-class TestImportODCSEndpoint:
-    """POST /api/v1/import/odcs"""
+    def test_warning_rules_are_not_projected(self):
+        doc = export_odcs("t", _rules(
+            {"name": "a", "type": "not_empty", "field": "f", "severity": "warning"},
+            {"name": "b", "type": "max", "field": "n", "max_value": 150, "severity": "warning"},
+            {"name": "c", "type": "regex", "field": "s", "pattern": "^x$", "severity": "warning"}))
+        assert "required" not in _prop(doc, "f")
+        assert "logicalTypeOptions" not in _prop(doc, "n")
+        assert "logicalTypeOptions" not in _prop(doc, "s")
+        # …but every rule is still carried as a custom entry with its severity
+        for field in ("f", "n", "s"):
+            assert _prop(doc, field)["quality"][0]["severity"] == "warning"
 
-    def test_requires_auth(self, client):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT)
-        assert r.status_code == 401
+    def test_string_options(self):
+        doc = export_odcs("t", _rules(
+            {"name": "a", "type": "regex", "field": "s", "pattern": "^x$"},
+            {"name": "b", "type": "min_length", "field": "s", "min_length": 2},
+            {"name": "c", "type": "max_length", "field": "s", "max_length": 5}))
+        p = _prop(doc, "s")
+        assert p["logicalType"] == "string"
+        assert p["logicalTypeOptions"] == {"pattern": "^x$", "minLength": 2, "maxLength": 5}
 
-    def test_returns_200_with_auth(self, client, editor_headers):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT, headers=editor_headers)
-        assert r.status_code == 200
+    def test_number_options_from_min_max_range(self):
+        doc = export_odcs("t", _rules(
+            {"name": "a", "type": "range", "field": "n", "min": 1, "max": 9},
+            {"name": "b", "type": "min", "field": "m", "min_value": 0},
+            {"name": "c", "type": "max", "field": "k", "max_value": 100}))
+        assert _prop(doc, "n")["logicalTypeOptions"] == {"minimum": 1.0, "maximum": 9.0}
+        assert _prop(doc, "m")["logicalTypeOptions"] == {"minimum": 0.0}
+        assert _prop(doc, "k")["logicalTypeOptions"] == {"maximum": 100.0}
+        assert _prop(doc, "n")["logicalType"] == "number"
 
-    def test_response_has_contract(self, client, editor_headers):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT, headers=editor_headers)
-        data = r.json()
-        assert "contract" in data
+    def test_date_format_projects_jdk_pattern(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "date_format", "field": "d", "format": "%Y-%m-%d"}))
+        p = _prop(doc, "d")
+        assert p["logicalType"] == "date"
+        assert p["logicalTypeOptions"] == {"format": "yyyy-MM-dd"}
 
-    def test_response_has_rule_count(self, client, editor_headers):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT, headers=editor_headers)
-        data = r.json()
-        assert "rule_count" in data
-        assert data["rule_count"] >= 2  # email: not_empty + unique; name: not_empty
+    def test_unrepresentable_date_format_not_projected(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "date_format", "field": "d", "format": "%d %b %Y"}))
+        assert "logicalTypeOptions" not in _prop(doc, "d")
+        assert _schema_errors(doc) == []
 
-    def test_response_has_skipped_checks(self, client, editor_headers):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT, headers=editor_headers)
-        assert "skipped_checks" in r.json()
+    def test_conflicting_types_on_one_field_stay_schema_valid(self):
+        """regex + min on the same field: number wins, pattern is custom-only (Sonnet blocker #2)."""
+        doc = export_odcs("t", _rules(
+            {"name": "a", "type": "regex", "field": "f", "pattern": "^[0-9]+$"},
+            {"name": "b", "type": "min", "field": "f", "min_value": 0}))
+        p = _prop(doc, "f")
+        assert p["logicalType"] == "number"
+        assert p["logicalTypeOptions"] == {"minimum": 0.0}
+        assert _schema_errors(doc) == []
+        assert {q["name"] for q in p["quality"]} == {"a", "b"}
 
-    def test_rules_have_correct_fields(self, client, editor_headers):
-        r = client.post("/api/v1/import/odcs", json=MINIMAL_CONTRACT, headers=editor_headers)
-        rules = r.json()["contract"]["rules"]
-        for rule in rules:
-            assert "name" in rule
-            assert "type" in rule
-            assert "field" in rule
-            assert "severity" in rule
+    def test_lookup_allowed_values_emits_library_invalid_values(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "lookup", "field": "c", "allowed_values": ["GB", "IE"]}))
+        lib = [q for q in _prop(doc, "c")["quality"] if q["type"] == "library"]
+        assert lib == [{"type": "library", "metric": "invalidValues", "arguments": {"validValues": ["GB", "IE"]},
+                        "mustBe": 0, "severity": "error", "dimension": "conformity",
+                        "description": "Validation failed"}]
+
+    def test_custom_entry_shape(self):
+        doc = export_odcs("t", _rules({"name": "cmp", "type": "compare", "field": "end", "compare_to": "start",
+                                       "compare_op": "gte", "error_message": "end before start"}))
+        q = _prop(doc, "end")["quality"][0]
+        assert q["type"] == "custom" and q["engine"] == "opendqv"
+        assert q["name"] == "cmp" and q["severity"] == "error" and q["dimension"] == "consistency"
+        assert q["description"] == "end before start"
+        assert q["implementation"]["type"] == "compare"
+        assert q["implementation"]["compare_to"] == "start"
+        assert "min" not in q["implementation"] and "inherited" not in q["implementation"]
+
+    def test_every_rule_becomes_exactly_one_custom_entry(self):
+        for name in ("customer", "sox_control_test", "hipaa_disclosure_accounting"):
+            c = _load_bundled(name)
+            doc = _export_bundled(name)
+            custom = [q for p in doc["schema"][0]["properties"] for q in p["quality"] if q["type"] == "custom"]
+            assert len(custom) == len(c["rules"])
+            assert [q["name"] for q in custom] == [r["name"] for r in c["rules"]]
+
+    def test_export_is_deterministic(self):
+        assert _export_bundled("customer") == _export_bundled("customer")
 
 
-class TestExportODCSEndpoint:
-    """GET /api/v1/export/odcs/{contract_name}"""
+# ─────────────────────────────────────────────────────────────────────────────
+# Round trip
+# ─────────────────────────────────────────────────────────────────────────────
 
-    def test_requires_auth(self, client):
-        r = client.get("/api/v1/export/odcs/customer")
-        assert r.status_code == 401
+class TestRoundTrip:
+    @pytest.mark.parametrize("name", _bundled_contract_names())
+    def test_export_import_export_is_idempotent(self, name):
+        c = _load_bundled(name)
+        doc = _export_bundled(name)
+        imported = import_odcs(yaml.safe_load(yaml.dump(doc, sort_keys=False, allow_unicode=True)))
+        ic = imported["contract"]
+        assert len(ic["rules"]) == len(c.get("rules", []))
+        assert imported["skipped_checks"] == []
+        doc2 = export_odcs(ic["name"], [Rule(**r) for r in ic["rules"]], ic["version"], ic["status"],
+                           ic["description"], ic["owner"], ic.get("owner_email"))
+        assert doc2 == doc
 
-    def test_returns_200_for_known_contract(self, client, auth_headers):
+    def test_severity_and_message_survive(self):
+        rules = _rules({"name": "a", "type": "max", "field": "age", "max_value": 150,
+                        "severity": "warning", "error_message": "Age seems high"})
+        back = import_odcs(export_odcs("t", rules))["contract"]["rules"]
+        assert back == [{"name": "a", "type": "max", "field": "age", "severity": "warning",
+                         "error_message": "Age seems high", "max_value": 150.0}]
+
+    def test_status_round_trips_via_custom_property(self):
+        for s in ("draft", "review", "active", "archived"):
+            assert import_odcs(export_odcs("t", [], status=s))["contract"]["status"] == s
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Import: real ODCS documents
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestImportNative:
+    def test_full_example_from_spec(self):
+        r = import_odcs(FULL_EXAMPLE)
+        c = r["contract"]
+        assert c["version"] == "1.1.0"
+        assert c["status"] == "active"
+        assert c["owner"] == "my-team"
+        types = {(x["type"], x["field"]) for x in c["rules"]}
+        assert ("not_empty", "id") in types
+        assert ("unique", "id") in types
+        assert ("not_empty", "rcvr_cntry_code") in types
+        assert any("rowCount" in s for s in r["skipped_checks"])
+
+    def test_top_level_metadata(self):
+        c = import_odcs(NATIVE_ODCS)["contract"]
+        assert c["name"] == "customer_orders"
+        assert c["version"] == "2.0"
+        assert c["status"] == "active"
+        assert c["description"] == "Orders placed by customers"
+        assert c["owner"] == "data-team"
+        assert c["owner_email"] == "owner@example.com"
+
+    def test_name_falls_back_to_id_then_default(self):
+        base = {"apiVersion": "v3.1.0", "kind": "DataContract", "version": "1", "status": "draft", "schema": []}
+        assert import_odcs({**base, "id": "My-ID 7"})["contract"]["name"] == "my_id_7"
+        assert import_odcs(base)["contract"]["name"] == "imported_contract"
+
+    def test_status_vocabulary_mapping(self):
+        base = {"apiVersion": "v3.1.0", "kind": "DataContract", "id": "x", "version": "1", "schema": []}
+        for odcs, ours in (("proposed", "review"), ("deprecated", "archived"), ("retired", "archived"),
+                           ("draft", "draft"), ("active", "active"), ("weird", "draft")):
+            assert import_odcs({**base, "status": odcs})["contract"]["status"] == ours
+
+    def _by(self, result, rtype, field):
+        return next(r for r in result["contract"]["rules"] if r["type"] == rtype and r["field"] == field)
+
+    def test_flags_and_string_options(self):
+        r = import_odcs(NATIVE_ODCS)
+        assert self._by(r, "not_empty", "order_id")["severity"] == "error"
+        assert self._by(r, "unique", "order_id")
+        assert self._by(r, "regex", "order_id")["pattern"] == "^ORD-[0-9]{6}$"
+        assert self._by(r, "min_length", "order_id")["min_length"] == 10
+        assert self._by(r, "max_length", "order_id")["max_length"] == 10
+
+    def test_number_options(self):
+        r = import_odcs(NATIVE_ODCS)
+        rng = self._by(r, "range", "amount")
+        assert rng["min_value"] == 0.0 and rng["max_value"] == 10000.0
+        assert self._by(r, "min", "qty")["min_value"] == 0.0
+        assert any("qty.exclusiveMinimum" in s for s in r["skipped_checks"])
+
+    def test_date_format_jdk_to_strftime(self):
+        r = import_odcs(NATIVE_ODCS)
+        assert self._by(r, "date_format", "order_date")["format"] == "%Y-%m-%d"
+
+    def test_library_metrics(self):
+        r = import_odcs(NATIVE_ODCS)
+        assert self._by(r, "lookup", "country")["allowed_values"] == ["GB", "IE"]
+        assert self._by(r, "not_empty", "email")["severity"] == "warning"
+        assert self._by(r, "unique", "email")["severity"] == "error"
+
+    def test_dataset_level_and_text_sql_are_skipped_with_reason(self):
+        r = import_odcs(NATIVE_ODCS)
+        joined = " | ".join(r["skipped_checks"])
+        assert "country.nullValues" in joined      # percent threshold → dataset-level
+        assert "country.text" in joined
+        assert "email.sql" in joined
+
+    def test_deprecated_rule_key_accepted(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "quality": [{"type": "library", "rule": "nullValues", "mustBe": 0}]}]
+        assert self._by(import_odcs(doc), "not_empty", "f")
+
+    def test_v3_0_accepted(self):
+        doc = {**copy.deepcopy(NATIVE_ODCS), "apiVersion": "v3.0.0"}
+        assert import_odcs(doc)["rule_count"] > 0
+
+    def test_v3_0_team_list_form(self):
+        doc = {**copy.deepcopy(NATIVE_ODCS), "apiVersion": "v3.0.0",
+               "team": [{"username": "a@example.com", "role": "owner"}]}
+        c = import_odcs(doc)["contract"]
+        assert c["owner"] == "a@example.com" and c["owner_email"] == "a@example.com"
+
+    def test_rule_names_unique_across_objects_and_flatten_is_reported(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"].append({"name": "second", "properties": [
+            {"name": "order_id", "required": True},        # duplicate of orders.order_id
+            {"name": "note", "required": True},
+        ]})
+        r = import_odcs(doc)
+        names = [x["name"] for x in r["contract"]["rules"]]
+        assert len(names) == len(set(names))
+        assert any("second.order_id (duplicate of orders.order_id" in s for s in r["skipped_checks"])
+        assert self._by(r, "not_empty", "note")
+
+    def test_native_flag_and_library_entry_not_double_counted(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "required": True,
+                                           "quality": [{"type": "library", "metric": "nullValues", "mustBe": 0}]}]
+        r = import_odcs(doc)
+        assert [x["type"] for x in r["contract"]["rules"]] == ["not_empty"]
+
+    def test_passthrough_metadata(self):
+        r = import_odcs(FULL_EXAMPLE)
+        assert "servers" in r["_odcs_metadata"]
+        assert "schema" not in r["_odcs_metadata"]
+
+    def test_odcs_to_yaml_override_name(self):
+        name, text = odcs_to_yaml(NATIVE_ODCS, "override")
+        assert name == "override"
+        assert yaml.safe_load(text)["contract"]["name"] == "override"
+
+
+class TestImportCustomOpenDQV:
+    def _doc(self, quality, **prop):
+        return {"apiVersion": "v3.1.0", "kind": "DataContract", "id": "x", "version": "1", "status": "draft",
+                "schema": [{"name": "o", "properties": [{"name": "f", **prop, "quality": quality}]}]}
+
+    def test_custom_overrides_native_projection(self):
+        doc = self._doc([{"type": "custom", "engine": "opendqv",
+                          "implementation": {"name": "only", "type": "min", "field": "f", "min": 3,
+                                             "severity": "warning", "error_message": "m"}}],
+                        required=True, logicalTypeOptions={"pattern": "^x$"})
+        rules = import_odcs(doc)["contract"]["rules"]
+        assert rules == [{"name": "only", "type": "min", "field": "f", "severity": "warning",
+                          "error_message": "m", "min_value": 3.0}]
+
+    def test_field_defaults_to_property_name(self):
+        doc = self._doc([{"type": "custom", "engine": "opendqv", "implementation": {"type": "not_empty"}}])
+        r = import_odcs(doc)["contract"]["rules"][0]
+        assert r["field"] == "f" and r["name"] == "f_not_empty"
+
+    def test_other_engine_is_skipped(self):
+        doc = self._doc([{"type": "custom", "engine": "soda", "implementation": "checks: []"}])
+        r = import_odcs(doc)
+        assert r["contract"]["rules"] == [] and "f.custom (engine 'soda')" in r["skipped_checks"]
+
+    @pytest.mark.parametrize("field,value", [
+        ("inherited", True),
+        ("federation_tier", "REGULATORY"),
+        ("provenance", {"authority_node": "evil", "lsn": 1}),
+        ("severity_floor", "error"),
+        ("lookup_auth_header", "Bearer ${OPENDQV_LOOKUP_TOKEN}"),
+    ])
+    def test_denied_fields_fail_closed(self, field, value):
+        """Sonnet blocker #1: an import must not mint authority/provenance/credential fields."""
+        doc = self._doc([{"type": "custom", "engine": "opendqv",
+                          "implementation": {"type": "not_empty", field: value}}])
+        with pytest.raises(ValueError, match="may not be set by an ODCS import"):
+            import_odcs(doc)
+
+    def test_unknown_field_fails_closed(self):
+        doc = self._doc([{"type": "custom", "engine": "opendqv",
+                          "implementation": {"type": "not_empty", "bogus": 1}}])
+        with pytest.raises(ValueError, match="unknown rule field"):
+            import_odcs(doc)
+
+    def test_invalid_rule_fails_closed_without_stack_detail(self):
+        doc = self._doc([{"type": "custom", "engine": "opendqv",
+                          "implementation": {"type": "regex", "pattern": 123}}])
+        with pytest.raises(ValueError) as exc:
+            import_odcs(doc)
+        assert "invalid rule" in str(exc.value) and "Traceback" not in str(exc.value)
+
+    def test_non_dict_implementation_rejected(self):
+        doc = self._doc([{"type": "custom", "engine": "opendqv", "implementation": "SELECT 1"}])
+        with pytest.raises(ValueError, match="must be an object"):
+            import_odcs(doc)
+
+
+class TestImportRejectsNonODCS3:
+    @pytest.mark.parametrize("doc,msg", [
+        ({"kind": "DataContract"}, "Unsupported apiVersion"),
+        ({"apiVersion": "v2.2.2", "kind": "DataContract"}, "Unsupported apiVersion"),
+        ({"apiVersion": "v3.1.0", "kind": "DataProduct"}, "kind must be"),
+        ({"apiVersion": "v3.1.0", "kind": "DataContract", "schema": {"not": "a list"}}, "schema must be a list"),
+        ("not a mapping", "must be a mapping"),
+    ])
+    def test_rejected(self, doc, msg):
+        with pytest.raises(ValueError, match=msg):
+            import_odcs(doc)
+
+    def test_legacy_invented_shape_is_rejected_not_silently_empty(self):
+        """The pre-v2.4.0 `info:` + `mustBeSatisfied` shape must not import as a valid-looking empty contract."""
+        legacy = {"apiVersion": "v3.1.0", "kind": "DataContract",
+                  "info": {"title": "x", "version": "1.0"},
+                  "schema": [{"name": "t", "properties": [{"name": "f", "quality": [
+                      {"type": "not_null", "mustBeSatisfied": True}]}]}]}
+        r = import_odcs(legacy)
+        assert r["contract"]["rules"] == []
+        assert any("unknown quality type" in s for s in r["skipped_checks"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Date-format helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDateFormatConversion:
+    @pytest.mark.parametrize("ours,jdk", [
+        ("%Y-%m-%d", "yyyy-MM-dd"),
+        ("%Y-%m-%dT%H:%M:%S", "yyyy-MM-dd'T'HH:mm:ss".replace("'T'", "T")),
+        ("YYYY-MM-DD", "yyyy-MM-dd"),
+        ("YYYY-MM-DD HH:MM:SS", "yyyy-MM-dd HH:mm:ss"),
+        ("DD/MM/YYYY", "dd/MM/yyyy"),
+    ])
+    def test_to_jdk(self, ours, jdk):
+        assert _to_jdk_format(ours) == jdk
+
+    def test_to_jdk_unsupported_returns_none(self):
+        assert _to_jdk_format("%d %b %Y") is None
+        assert _to_jdk_format("") is None
+
+    @pytest.mark.parametrize("jdk,strf", [
+        ("yyyy-MM-dd", "%Y-%m-%d"),
+        ("yyyy-MM-dd HH:mm:ss", "%Y-%m-%d %H:%M:%S"),
+        ("dd/MM/yyyy", "%d/%m/%Y"),
+    ])
+    def test_from_jdk(self, jdk, strf):
+        assert _from_jdk_format(jdk) == strf
+
+    def test_from_jdk_unsupported_returns_none(self):
+        assert _from_jdk_format("EEE, dd MMM yyyy") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API surface
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestODCSAPI:
+    def test_export_endpoint_is_schema_valid(self, client, auth_headers):
         r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
         assert r.status_code == 200
+        assert _schema_errors(yaml.safe_load(r.text)) == []
 
-    def test_returns_404_for_unknown_contract(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/nonexistent_zzz", headers=auth_headers)
-        assert r.status_code == 404
+    def test_import_native_document(self, client, editor_headers):
+        r = client.post("/api/v1/import/odcs", json=NATIVE_ODCS, headers=editor_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["rule_count"] > 0
+        assert body["contract"]["status"] == "draft"
 
-    def test_content_type_is_yaml(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
-        assert "yaml" in r.headers.get("content-type", "")
+    def test_import_non_odcs_returns_422(self, client, editor_headers):
+        r = client.post("/api/v1/import/odcs", json={"info": {"title": "x"}}, headers=editor_headers)
+        assert r.status_code == 422
+        assert "Unsupported apiVersion" in r.json()["detail"]
 
-    def test_response_is_valid_yaml(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
-        parsed = yaml.safe_load(r.text)
-        assert parsed is not None
-
-    def test_api_version_in_response(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
-        parsed = yaml.safe_load(r.text)
-        assert parsed["apiVersion"] == "v3.1.0"
-
-    def test_kind_is_data_contract(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
-        parsed = yaml.safe_load(r.text)
-        assert parsed["kind"] == "DataContract"
-
-    def test_schema_has_properties(self, client, auth_headers):
-        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
-        parsed = yaml.safe_load(r.text)
-        assert len(parsed["schema"][0]["properties"]) > 0
+    def test_import_denied_field_returns_422(self, client, editor_headers):
+        doc = {"apiVersion": "v3.1.0", "kind": "DataContract", "id": "x", "version": "1", "status": "draft",
+               "schema": [{"name": "o", "properties": [{"name": "f", "quality": [
+                   {"type": "custom", "engine": "opendqv",
+                    "implementation": {"type": "not_empty", "inherited": True}}]}]}]}
+        r = client.post("/api/v1/import/odcs", json=doc, headers=editor_headers)
+        assert r.status_code == 422
+        assert "may not be set" in r.json()["detail"]
 
 
-# ---------------------------------------------------------------------------
-# C1/C2 — _odcs_metadata passthrough tests
-# ---------------------------------------------------------------------------
+# ─────────────────────────────────────────────────────────────────────────────
+# Optional external oracle: datacontract-cli
+# ─────────────────────────────────────────────────────────────────────────────
 
-class TestOdcsMetadataPassthrough:
-    """Tests for preserving unknown top-level ODCS sections (C1/C2)."""
+_DATACONTRACT = shutil.which("datacontract") or os.environ.get("OPENDQV_DATACONTRACT_BIN")
 
-    _CONTRACT_WITH_EXTRA = {
-        "apiVersion": "v3.1.0",
-        "kind": "DataContract",
-        "info": {
-            "title": "Order Contract",
-            "version": "1.0",
-            "status": "active",
-        },
-        "schema": [
-            {
-                "name": "orders",
-                "properties": [
-                    {
-                        "name": "order_id",
-                        "required": True,
-                    }
-                ],
-            }
-        ],
-        "sla": {
-            "responseTime": "100ms",
-            "availability": "99.9%",
-        },
-        "semantics": {
-            "description": "Order domain ontology",
-        },
-    }
 
-    def test_passthrough_import_preserves_sla(self):
-        result = import_odcs(self._CONTRACT_WITH_EXTRA)
-        assert "_odcs_metadata" in result
-        assert "sla" in result["_odcs_metadata"]
-        assert result["_odcs_metadata"]["sla"]["availability"] == "99.9%"
-
-    def test_passthrough_import_rules_unaffected(self):
-        result = import_odcs(self._CONTRACT_WITH_EXTRA)
-        assert result["rule_count"] == 1
-        assert result["contract"]["rules"][0]["type"] == "not_empty"
-
-    def test_clean_import_has_empty_odcs_metadata(self):
-        clean = {
-            "apiVersion": "v3.1.0",
-            "kind": "DataContract",
-            "info": {"title": "Clean", "version": "1.0"},
-            "schema": [],
-        }
-        result = import_odcs(clean)
-        assert "_odcs_metadata" in result
-        assert result["_odcs_metadata"] == {}
-
-    def test_round_trip_preserves_sla_and_semantics(self):
-        imported = import_odcs(self._CONTRACT_WITH_EXTRA)
-        exported = export_odcs(
-            contract_name=imported["contract"]["name"],
-            rules=imported["contract"]["rules"],
-            odcs_metadata=imported["_odcs_metadata"],
-        )
-        assert "sla" in exported
-        assert exported["sla"]["responseTime"] == "100ms"
-        assert "semantics" in exported
-        assert exported["semantics"]["description"] == "Order domain ontology"
+@pytest.mark.skipif(not _DATACONTRACT, reason="datacontract-cli not installed")
+class TestDatacontractCliLint:
+    @pytest.mark.parametrize("name", ["customer", "sox_control_test", "hipaa_disclosure_accounting"])
+    def test_export_passes_datacontract_lint(self, name, tmp_path):
+        out = tmp_path / f"{name}.odcs.yaml"
+        out.write_text(yaml.dump(_export_bundled(name), sort_keys=False, allow_unicode=True), encoding="utf-8")
+        proc = subprocess.run([_DATACONTRACT, "lint", str(out)], capture_output=True, text=True, timeout=120)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "data contract is valid" in proc.stdout

--- a/tests/test_odcs_import.py
+++ b/tests/test_odcs_import.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -37,7 +38,7 @@ from opendqv.core.rule_parser import Rule
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 SCHEMA = json.loads((FIXTURES / "odcs-json-schema-v3.1.0.json").read_text(encoding="utf-8"))
-VALIDATOR = jsonschema.Draft202012Validator(SCHEMA)
+VALIDATOR = jsonschema.Draft201909Validator(SCHEMA)  # the schema declares draft 2019-09
 FULL_EXAMPLE = yaml.safe_load((FIXTURES / "odcs-full-example-v3.1.0.yaml").read_text(encoding="utf-8"))
 BUNDLED_DIR = Path(__file__).resolve().parent.parent / "opendqv" / "contracts"
 
@@ -218,12 +219,45 @@ class TestExportNativeProjection:
         assert _schema_errors(doc) == []
         assert {q["name"] for q in p["quality"]} == {"a", "b"}
 
-    def test_lookup_allowed_values_emits_library_invalid_values(self):
-        doc = export_odcs("t", _rules({"name": "a", "type": "lookup", "field": "c", "allowed_values": ["GB", "IE"]}))
+    def test_allowed_values_emits_library_invalid_values_as_strings(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "allowed_values", "field": "c",
+                                       "allowed_values": [True, 1.0, "pending"]}))
         lib = [q for q in _prop(doc, "c")["quality"] if q["type"] == "library"]
-        assert lib == [{"type": "library", "metric": "invalidValues", "arguments": {"validValues": ["GB", "IE"]},
+        assert lib == [{"type": "library", "metric": "invalidValues",
+                        "arguments": {"validValues": ["True", "1.0", "pending"]},
                         "mustBe": 0, "severity": "error", "dimension": "conformity",
                         "description": "Validation failed"}]
+        assert _schema_errors(doc) == []
+
+    def test_non_portable_regex_is_not_projected(self):
+        """Lookahead/lookbehind/backreferences crash RE2-based consumers — custom-only."""
+        for pat in (r"^(?!BG|GB)[A-Z]{2}$", r"(?<=x)y", r"^(a)\1$", r"(?>ab)c"):
+            doc = export_odcs("t", _rules({"name": "a", "type": "regex", "field": "s", "pattern": pat}))
+            assert "logicalTypeOptions" not in _prop(doc, "s"), pat
+            assert _prop(doc, "s")["quality"][0]["implementation"]["pattern"] == pat
+
+    def test_builtin_pattern_alias_is_expanded_on_projection(self):
+        from opendqv.core.rule_parser import _BUILTIN_PATTERNS
+        alias, expanded = next(iter(_BUILTIN_PATTERNS.items()))
+        doc = export_odcs("t", _rules({"name": "a", "type": "regex", "field": "s", "pattern": alias}))
+        projected = _prop(doc, "s").get("logicalTypeOptions", {}).get("pattern")
+        assert projected in (expanded, None)   # None only if the builtin itself is non-portable
+        assert projected != alias
+
+    def test_datetime_format_uses_timestamp_logical_type(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "date_format", "field": "ts", "format": "%Y-%m-%dT%H:%M:%S"}))
+        p = _prop(doc, "ts")
+        assert p["logicalType"] == "timestamp"
+        assert p["logicalTypeOptions"] == {"format": "yyyy-MM-ddTHH:mm:ss"}
+        assert _schema_errors(doc) == []
+
+    def test_unique_with_group_by_becomes_object_level_duplicate_values(self):
+        doc = export_odcs("t", _rules({"name": "a", "type": "unique", "field": "sku", "group_by": ["store"]},
+                                      {"name": "b", "type": "unique", "field": "line", "group_by": ["order"]}))
+        oq = doc["schema"][0]["quality"]
+        assert len(oq) == 1   # at most one per object
+        assert oq[0]["metric"] == "duplicateValues" and oq[0]["arguments"] == {"properties": ["sku", "store"]}
+        assert _schema_errors(doc) == []
 
     def test_custom_entry_shape(self):
         doc = export_odcs("t", _rules({"name": "cmp", "type": "compare", "field": "end", "compare_to": "start",
@@ -329,8 +363,9 @@ class TestImportNative:
         r = import_odcs(NATIVE_ODCS)
         rng = self._by(r, "range", "amount")
         assert rng["min_value"] == 0.0 and rng["max_value"] == 10000.0
-        assert self._by(r, "min", "qty")["min_value"] == 0.0
-        assert any("qty.exclusiveMinimum" in s for s in r["skipped_checks"])
+        # Exclusive bounds are skipped, never loosened to inclusive (that would pass a value the document rejects).
+        assert not any(x["field"] == "qty" for x in r["contract"]["rules"])
+        assert any("qty.exclusiveMinimum" in s and "not loosened" in s for s in r["skipped_checks"])
 
     def test_date_format_jdk_to_strftime(self):
         r = import_odcs(NATIVE_ODCS)
@@ -338,7 +373,7 @@ class TestImportNative:
 
     def test_library_metrics(self):
         r = import_odcs(NATIVE_ODCS)
-        assert self._by(r, "lookup", "country")["allowed_values"] == ["GB", "IE"]
+        assert self._by(r, "allowed_values", "country")["allowed_values"] == ["GB", "IE"]
         assert self._by(r, "not_empty", "email")["severity"] == "warning"
         assert self._by(r, "unique", "email")["severity"] == "error"
 
@@ -348,6 +383,47 @@ class TestImportNative:
         assert "country.nullValues" in joined      # percent threshold → dataset-level
         assert "country.text" in joined
         assert "email.sql" in joined
+
+    def test_required_note_is_reported(self):
+        r = import_odcs(NATIVE_ODCS)
+        assert any(n.startswith("order_id.required") and "stricter" in n for n in r["import_notes"])
+
+    def test_missing_values_null_and_empty_maps_to_not_empty(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [
+            {"name": "f", "quality": [{"type": "library", "metric": "missingValues",
+                                       "arguments": {"missingValues": [None, ""]}, "mustBe": 0}]},
+            {"name": "g", "quality": [{"type": "library", "metric": "missingValues",
+                                       "arguments": {"missingValues": [None, "", "N/A"]}, "mustBe": 0}]},
+        ]
+        r = import_odcs(doc)
+        assert self._by(r, "not_empty", "f")
+        assert not any(x["field"] == "g" for x in r["contract"]["rules"])
+        assert any("g.missingValues" in s and "N/A" not in s for s in r["skipped_checks"])
+
+    def test_invalid_values_pattern_argument_maps_to_regex(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "quality": [
+            {"type": "library", "metric": "invalidValues", "arguments": {"pattern": "^[A-Z]+$"}, "mustBe": 0}]}]
+        assert self._by(import_odcs(doc), "regex", "f")["pattern"] == "^[A-Z]+$"
+
+    def test_text_entry_with_metric_is_treated_as_library(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "quality": [
+            {"type": "text", "metric": "nullValues", "mustBe": 0, "description": "no nulls"}]}]
+        assert self._by(import_odcs(doc), "not_empty", "f")["error_message"] == "no nulls"
+
+    def test_default_quality_type_is_library(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "quality": [{"metric": "duplicateValues", "mustBe": 0}]}]
+        assert self._by(import_odcs(doc), "unique", "f")
+
+    def test_native_pattern_that_does_not_compile_fails_closed(self):
+        doc = copy.deepcopy(NATIVE_ODCS)
+        doc["schema"][0]["properties"] = [{"name": "f", "logicalType": "string",
+                                           "logicalTypeOptions": {"pattern": "(unclosed"}}]
+        with pytest.raises(ValueError, match="f: invalid rule"):
+            import_odcs(doc)
 
     def test_deprecated_rule_key_accepted(self):
         doc = copy.deepcopy(NATIVE_ODCS)
@@ -542,6 +618,11 @@ class TestODCSAPI:
 # ─────────────────────────────────────────────────────────────────────────────
 
 _DATACONTRACT = shutil.which("datacontract") or os.environ.get("OPENDQV_DATACONTRACT_BIN")
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI.sub("", text)
 
 
 @pytest.mark.skipif(not _DATACONTRACT, reason="datacontract-cli not installed")
@@ -553,3 +634,26 @@ class TestDatacontractCliLint:
         proc = subprocess.run([_DATACONTRACT, "lint", str(out)], capture_output=True, text=True, timeout=120)
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "data contract is valid" in proc.stdout
+
+    @pytest.mark.parametrize("csv_name,expect_ok,expected_failing_fields", [
+        ("odcs_customer_clean.csv", True, set()),
+        ("odcs_customer_bad.csv", False, {"age", "email", "id", "name", "password", "phone", "score", "username"}),
+    ])
+    def test_reference_implementation_executes_projections(self, tmp_path, csv_name, expect_ok, expected_failing_fields):
+        """`datacontract test` runs the projected required/unique/logicalTypeOptions checks against a CSV.
+
+        Requires the [duckdb] extra; skipped when the local server type is unavailable.
+        """
+        doc = _export_bundled("customer")
+        csv_path = tmp_path / "rows.csv"
+        shutil.copy(FIXTURES / csv_name, csv_path)
+        doc["servers"] = [{"server": "local", "type": "local", "path": str(csv_path), "format": "csv"}]
+        out = tmp_path / "customer.odcs.yaml"
+        out.write_text(yaml.dump(doc, sort_keys=False, allow_unicode=True), encoding="utf-8")
+        proc = subprocess.run([_DATACONTRACT, "test", str(out)], capture_output=True, text=True, timeout=300)
+        text = _strip_ansi(proc.stdout + proc.stderr)
+        if "duckdb" in text.lower() and "No module" in text:
+            pytest.skip("datacontract-cli installed without the duckdb extra")
+        assert ("data contract is valid" in text) is expect_ok, text
+        failing = {m.group(1) for m in re.finditer(r"│ failed │[^│]*│ (\w+)\s*│", text)}
+        assert failing == expected_failing_fields, text

--- a/tests/test_odcs_import.py
+++ b/tests/test_odcs_import.py
@@ -248,7 +248,7 @@ class TestExportNativeProjection:
         doc = export_odcs("t", _rules({"name": "a", "type": "date_format", "field": "ts", "format": "%Y-%m-%dT%H:%M:%S"}))
         p = _prop(doc, "ts")
         assert p["logicalType"] == "timestamp"
-        assert p["logicalTypeOptions"] == {"format": "yyyy-MM-ddTHH:mm:ss"}
+        assert p["logicalTypeOptions"] == {"format": "yyyy-MM-dd'T'HH:mm:ss"}   # literal T is quoted (JDK)
         assert _schema_errors(doc) == []
 
     def test_unique_with_group_by_becomes_object_level_duplicate_values(self):
@@ -257,7 +257,42 @@ class TestExportNativeProjection:
         oq = doc["schema"][0]["quality"]
         assert len(oq) == 1   # at most one per object
         assert oq[0]["metric"] == "duplicateValues" and oq[0]["arguments"] == {"properties": ["sku", "store"]}
+        # unique-within-group must NOT also project as property-level unique: true
+        assert "unique" not in _prop(doc, "sku") and "unique" not in _prop(doc, "line")
         assert _schema_errors(doc) == []
+
+    def test_negated_regex_is_not_projected(self):
+        """negate: true inverts the match; ODCS pattern has no negate — projecting would invert semantics."""
+        doc = export_odcs("t", _rules({"name": "a", "type": "regex", "field": "e", "pattern": "^test@", "negate": True}))
+        assert "logicalTypeOptions" not in _prop(doc, "e")
+        assert _prop(doc, "e")["quality"][0]["implementation"]["negate"] is True
+
+    def test_conditional_rules_are_not_projected(self):
+        """A rule with condition: applies only sometimes; native ODCS is unconditional (proof_of_play case)."""
+        cond = {"field": "transaction_type", "not_value": "CREDIT"}
+        doc = export_odcs("t", _rules(
+            {"name": "a", "type": "min", "field": "revenue", "min_value": 0, "condition": cond},
+            {"name": "b", "type": "not_empty", "field": "ref", "condition": cond},
+            {"name": "c", "type": "date_format", "field": "d", "format": "%Y-%m-%d", "condition": cond},
+            {"name": "d", "type": "allowed_values", "field": "k", "allowed_values": ["x"], "condition": cond}))
+        assert "logicalTypeOptions" not in _prop(doc, "revenue")
+        assert "required" not in _prop(doc, "ref")
+        assert "logicalTypeOptions" not in _prop(doc, "d")
+        assert all(q["type"] == "custom" for q in _prop(doc, "k")["quality"])
+        assert _schema_errors(doc) == []
+
+    @pytest.mark.parametrize("name", _bundled_contract_names())
+    def test_no_bundled_qualified_rule_projects_natively(self, name):
+        """Ledger guard: every projected native constraint traces to an unconditional, un-negated, ungrouped error rule."""
+        c = _load_bundled(name)
+        doc = _export_bundled(name)
+        for p in doc["schema"][0]["properties"]:
+            projected = bool(p.get("required") or p.get("unique") or p.get("logicalTypeOptions"))
+            if not projected:
+                continue
+            clean = [r for r in c["rules"] if r["field"] == p["name"] and r.get("severity", "error") == "error"
+                     and not r.get("condition") and not r.get("negate") and not r.get("group_by")]
+            assert clean, f"{name}.{p['name']} projects a native constraint with no unqualified error rule behind it"
 
     def test_custom_entry_shape(self):
         doc = export_odcs("t", _rules({"name": "cmp", "type": "compare", "field": "end", "compare_to": "start",
@@ -277,6 +312,19 @@ class TestExportNativeProjection:
             custom = [q for p in doc["schema"][0]["properties"] for q in p["quality"] if q["type"] == "custom"]
             assert len(custom) == len(c["rules"])
             assert [q["name"] for q in custom] == [r["name"] for r in c["rules"]]
+
+    def test_engine_stamped_fields_never_exported_and_enums_are_plain_strings(self):
+        """severity_floor/provenance/inherited/federation_tier/lookup_auth_header are node-local; must not leak
+        (and an enum must never surface as a !!python/object YAML tag)."""
+        r = Rule(name="fed", type="not_empty", field="pii", severity_floor="error", inherited=True,
+                 federation_tier="REGULATORY", provenance={"authority_node": "a", "lsn": 1})
+        text = contract_to_odcs_yaml("t", [r])
+        assert "!!python" not in text
+        impl = yaml.safe_load(text)["schema"][0]["properties"][0]["quality"][0]["implementation"]
+        for k in ("severity_floor", "inherited", "federation_tier", "provenance", "lookup_auth_header"):
+            assert k not in impl
+        # and the export re-imports (the denylist would otherwise reject its own output)
+        assert import_odcs(yaml.safe_load(text))["rule_count"] == 1
 
     def test_export_is_deterministic(self):
         assert _export_bundled("customer") == _export_bundled("customer")
@@ -557,7 +605,7 @@ class TestImportRejectsNonODCS3:
 class TestDateFormatConversion:
     @pytest.mark.parametrize("ours,jdk", [
         ("%Y-%m-%d", "yyyy-MM-dd"),
-        ("%Y-%m-%dT%H:%M:%S", "yyyy-MM-dd'T'HH:mm:ss".replace("'T'", "T")),
+        ("%Y-%m-%dT%H:%M:%S", "yyyy-MM-dd'T'HH:mm:ss"),
         ("YYYY-MM-DD", "yyyy-MM-dd"),
         ("YYYY-MM-DD HH:MM:SS", "yyyy-MM-dd HH:mm:ss"),
         ("DD/MM/YYYY", "dd/MM/yyyy"),
@@ -573,6 +621,8 @@ class TestDateFormatConversion:
         ("yyyy-MM-dd", "%Y-%m-%d"),
         ("yyyy-MM-dd HH:mm:ss", "%Y-%m-%d %H:%M:%S"),
         ("dd/MM/yyyy", "%d/%m/%Y"),
+        ("yyyy-MM-dd'T'HH:mm:ss", "%Y-%m-%dT%H:%M:%S"),
+        ("yyyy-MM-dd'T'HH:mm:ss'Z'", "%Y-%m-%dT%H:%M:%SZ"),
     ])
     def test_from_jdk(self, jdk, strf):
         assert _from_jdk_format(jdk) == strf

--- a/ui/app.py
+++ b/ui/app.py
@@ -2050,6 +2050,8 @@ if section == "Import Rules":
                             st.success(f"Imported {rule_count} rules" + (f", skipped {len(skipped)}" if skipped else ""))
                             if skipped:
                                 st.warning(f"Skipped unsupported checks: {', '.join(skipped)}")
+                            if data.get("import_notes"):
+                                st.info("Notes: " + "; ".join(data["import_notes"]))
                             if data.get("saved_to"):
                                 st.info(f"Saved to: {data['saved_to']}")
                             st.markdown("**Generated contract YAML preview:**")

--- a/ui/app.py
+++ b/ui/app.py
@@ -2016,8 +2016,8 @@ if section == "Import Rules":
 
     with st.expander("Import / Export ODCS 3.1 (Open Data Contract Standard)", expanded=False):
         st.markdown(
-            "Import an [ODCS 3.1](https://bitol-io.github.io/open-data-contract-standard/) contract "
-            "(OpenMetadata, Soda, Monte Carlo, Data Contract CLI) or export any OpenDQV contract to ODCS format."
+            "Import an [ODCS v3.x](https://bitol-io.github.io/open-data-contract-standard/) contract "
+            "or export any OpenDQV contract as ODCS v3.1.0 (validates with `datacontract lint`)."
         )
 
         odcs_mode = st.radio("Mode", ["Import", "Export"], horizontal=True, key="odcs_mode")
@@ -2028,9 +2028,11 @@ if section == "Import Rules":
                 "ODCS contract (YAML or JSON)",
                 height=300,
                 placeholder=(
-                    "apiVersion: v3.1.0\nkind: DataContract\ninfo:\n  title: My Contract\n"
-                    "  version: '1.0'\nschema:\n  - name: customers\n    properties:\n"
-                    "      - name: email\n        required: true\n        unique: true"
+                    "apiVersion: v3.1.0\nkind: DataContract\nid: my_contract\nname: my_contract\n"
+                    "version: '1.0'\nstatus: draft\nschema:\n  - name: customers\n    logicalType: object\n"
+                    "    properties:\n      - name: email\n        logicalType: string\n"
+                    "        required: true\n        unique: true\n        logicalTypeOptions:\n"
+                    "          pattern: '^[^@]+@[^@]+$'"
                 ),
                 key="odcs_import_input",
             )


### PR DESCRIPTION
## Summary

The ODCS importer/exporter has claimed "ODCS 3.1" since v1.0 but emitted and consumed an invented shape: an `info:` block (ODCS 3 has none; `id`/`version`/`status` are required top-level), quality entries typed `not_null` / `regex` / `min` / … (the ODCS enum is `text | library | sql | custom`) and a `mustBeSatisfied` flag that does not exist. Verified against the **official ODCS v3.1.0 JSON schema** and **datacontract-cli 1.1.2**: every export failed `datacontract lint` on the first check, and a real ODCS document imported as an empty contract named `imported_contract`.

This is a breaking wire-format change on `export-odcs` / `GET /export/odcs/{name}` and `import-odcs` / `POST /import/odcs` → **v2.4.0**.

## What changed

- **Export** is schema-valid ODCS v3.1.0. Every rule is carried losslessly as a `quality` entry of `type: custom, engine: opendqv`. Error-severity rules are also projected onto native fields other tools read (`required`, `unique`, `logicalTypeOptions`, `library invalidValues`). Warning-severity rules are deliberately never projected (a native constraint is hard to every downstream consumer). One `logicalType` per field, numeric > date > string; incompatible rules stay custom-only.
- **Import** reads real v3.0.x / v3.1.0: flags, `logicalTypeOptions` (JDK date patterns converted), record-level library metrics, `custom/opendqv` (authoritative). Everything dataset-level or inexpressible is reported in `skipped_checks`. Non-ODCS-3 documents and invalid rules → **422** (was 200-with-empty / 500).
- **Import safety** (Sonnet pre-implementation review, 2 blockers + 2 shoulds all addressed): `custom/opendqv` implementation dicts are allow-listed against `Rule` and may not set `inherited`, `federation_tier`, `provenance`, `severity_floor`, `lookup_auth_header`. Duplicate fields across flattened schema objects are reported, not silently dropped.
- Docs: `importers.md` full mapping tables, `cli.md`, `api_reference.md`, `troubleshooting.md`, UI placeholder. CHANGELOG 2.4.0.

## Verification

- `tests/test_odcs_import.py` (149 tests): every bundled contract's export validates against the vendored official schema (`tests/fixtures/odcs-json-schema-v3.1.0.json`); export → import → export is **idempotent on all 41 bundled contracts with zero skipped checks**; the spec's own `full-example.odcs.yaml` imports; API 422 paths; denied-field tests.
- Optional oracle: with `datacontract` on PATH (or `OPENDQV_DATACONTRACT_BIN`), the same output is run through `datacontract lint`. Run locally against datacontract-cli 1.1.2: **41/41 pass**.
- Full suite: 4400 passed, 26 skipped, 0 failed. `ruff --select E,W,F` clean.

## Not in this PR

- datacontract-cli is not added as a dev dependency (heavy transitive tree); the vendored schema is the CI gate, datacontract-cli the local oracle.
- CRT177 Tier 3 chokepoint refactor and other v2.4 deferrals are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm