### PR TITLE
ci(release): attach library_manifest.json to every release at creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,14 @@ jobs:
 
       - name: Create GitHub release
         run: |
+          # library_manifest.json rides on every release: one SHA-256 per bundled
+          # contract's rules and one for the library — the machine-readable
+          # record of which starters changed (docs/contract_conformance.md, D5).
+          # Releases are immutable once published, so it must be attached here.
           gh release create v${{ steps.version.outputs.version }} \
             --title "v${{ steps.version.outputs.version }}" \
-            --notes-file release_notes.txt
+            --notes-file release_notes.txt \
+            library_manifest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Round-3 S1 / the maintainer's "wiring the asset into the release flow": the v2.5.0 release was created immutable by `release.yml`, so the manifest could not be added afterwards (`HTTP 422: Cannot upload assets to an immutable release`). This attaches `library_manifest.json` as a release asset at creation time, for every release from here on. For v2.5.0 the manifest is at the tag: `library_manifest.json` @ `v2.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vgWu6PuYnKaizE2gSBpeA