### PR TITLE
CHANGELOG: date the 2.6.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OpenDQV are documented here.
 
-## [2.6.0] - Unreleased
+## [2.6.0] - 2026-09-03
 
 Backlog release: the six follow-ups from the Core↔Cloud conformance review
 (#144–#149), the Dependabot queue including the mcp 2 port, and the release


### PR DESCRIPTION
Release prep: dates the [2.6.0] entry ahead of the tag. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm