### PR TITLE
docs: correct what drifted after 2.7.0 (compliance table, README limitations section, core_rules null handling, counts, contexts link, contributor fixture pointers)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,14 @@ All 43 checks must pass before the `ALL SMOKE TESTS PASSED` line appears.
   shows it landed (`source.export_ref`, `library_version`). Do not expect a
   starter PR to be merged into `opendqv/contracts/` directly — the digest
   check on the managed side would fail the build — expect it to land through
-  the export within the next release.
+  the export within the next release. If your change touches a bundled
+  contract's rules, it must move together with three fixture files —
+  `tests/fixtures/conformance/frozen/minimal_clean.jsonl` (re-freeze with
+  `scripts/freeze_minimal_clean.py`), `tests/fixtures/conformance/frozen/accepted_breaks.json`
+  (a deliberate verdict change, scoped to its error codes and tied to the
+  current CHANGELOG version), and `tests/fixtures/conformance/frozen/regulatory_claims.jsonl`
+  (a claim row per regulatory rule) — regenerated together via
+  `scripts/conformance_fixtures.py`.
 
 ### Project Conventions
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ OpenDQV Core owns layer one. Your catalog handles layer two, your pipeline tools
 
 ## Contracts
 
-43 production-ready contracts ship inside the `opendqv` package covering GDPR, HIPAA, SOX, MiFID II,
+41 production-ready contracts ship inside the `opendqv` package covering GDPR, HIPAA, SOX, MiFID II,
 UK Building Safety Act, Martyn's Law, Natasha's Law, Ofcom Online Safety Act, EU DORA,
 and 20+ other regulatory frameworks across UK, EU, and US. `pip install opendqv` gives you all of them
 — `opendqv list` works with zero configuration.
@@ -276,12 +276,12 @@ methodology, and monthly volume extrapolation.
 |---|---|
 | [Quickstart](docs/quickstart.md) | Build your first contract in 15 minutes |
 | [Rules Reference](docs/rules/) | All rule types with parameters and examples |
-| [Compliance Contracts](docs/compliance-contracts.md) | 44 contracts with regulatory context |
+| [Compliance Contracts](docs/compliance-contracts.md) | 41 contracts with regulatory context |
 | [API Reference](docs/index.md) | REST endpoints, SDK, GraphQL, webhooks |
 | [Security](SECURITY.md) | Deployment checklist, threat model, RBAC |
 | [Production Deployment](docs/production_deployment.md) | Token auth, TLS, Docker Compose, hardening |
 | [Integrations](docs/index.md) | Salesforce, Kafka, Snowflake, dbt, Databricks, MCP, and more |
-| [All docs →](docs/) | 76 documentation files |
+| [All docs →](docs/) | 94 documentation files |
 
 ---
 
@@ -295,19 +295,37 @@ OpenDQV is in Beta as of 2.0.0. The following stability commitments apply to the
 - **MCP tools** — tool names and parameters are stable within `v2.x`.
 - **Security fixes** — backported to the latest 2.x line on a best-effort basis.
 
-### Known limitations in v2.2.x
+### Absent and blank values, unknown rule types
 
-- **Rule null handling is inconsistent.** Most format rules fail when the target
-  field is missing; a few (`max_length`, `allowed_values`) pass silently;
-  `field_sum` and `ratio_check` coerce missing operands to `0`. Single-record
-  and batch paths disagree in a few cases. See
-  [`docs/rules/core_rules.md`](docs/rules/core_rules.md#null-handling-current-v22x-behaviour)
-  for the full matrix and the safe pattern to use today. v2.3.0 will make this
-  consistent (loud-by-default with an `optional: true` opt-out).
-- **Unknown rule types pass silently at runtime.** A typo in `type:` (e.g.
-  `min_lenght`) is caught by `opendqv lint` but not by the engine — a typo'd
-  rule is a disabled rule. Always lint before deploy. v2.3.0 will reject
-  unknown types at contract load.
+- **A `null`, empty, or whitespace-only value is treated as absent.** This is
+  structural, not per-handler: every rule type skips an absent value except
+  the presence rules (`not_empty`, `not_empty_string`, `required_if`), which
+  are the single reporter of absence. A format-class rule (`regex`, `min`,
+  `max`, `range`, `min_length`, `max_length`, `date_format`, `checksum`,
+  `lookup`, `allowed_values`, `compare`, `geospatial_bounds`, `age_match`,
+  and friends) simply has nothing to check on an absent field and passes —
+  add a `not_empty`/`not_empty_string` rule alongside it if the field must
+  also be present. `optional: true` is accepted on any rule and round-trips
+  on disk.
+- **A cross-field rule with an absent or blank counterpart fails.** `compare`,
+  `date_diff`, `cross_field_range`, `field_sum`, `ratio_check`, `age_match`,
+  and `geospatial_bounds` compare the target field against another field —
+  if that counterpart is absent or blank, the rule fails rather than passing
+  or silently coercing, and the error entry carries `counterpart_missing: true`
+  so callers can distinguish "the counterpart was missing" from an ordinary
+  value violation.
+- **`condition:` has a closed vocabulary.** A rule's `condition` block accepts
+  only `field`, `value`, `not_value`, and `present: true|false`; any other key
+  is a contract load error. See
+  [`docs/custom_rules.md`](docs/custom_rules.md) for the full reference.
+- **An unknown rule `type` still loads, with a warning, and never fires.** A
+  typo in `type:` (e.g. `min_lenght`) is caught by `opendqv lint` but not by
+  the engine — a typo'd rule is a disabled rule. Always lint before deploy.
+
+See [`docs/rules/core_rules.md`](docs/rules/core_rules.md#null-handling) for
+the full behaviour and worked examples, and
+[`docs/contract_conformance.md`](docs/contract_conformance.md) for how this
+model was derived and cross-checked against the managed engine.
 
 ---
 

--- a/docs/compliance-contracts.md
+++ b/docs/compliance-contracts.md
@@ -17,23 +17,23 @@ See [docs/community_use_cases.md](community_use_cases.md) for real-world example
 | Contract | Description | Contexts | Highlights |
 |----------|-------------|----------|-----------|
 | `customer` | General customer validation (email, age, name, phone, etc.) | — (worked example with `kids_app` / `financial` in `examples/contexts/`) | — |
-| `salesforce_contact` | Salesforce Contact — 18 validation criteria, production-grade | — (example in `examples/contexts/`) | Sentinel date rejection |
+| `salesforce_contact` | Salesforce Contact — 19 validation criteria, production-grade | — (example in `examples/contexts/`) | Sentinel date rejection |
 | `salesforce_lead` | Salesforce Lead — 16 validation criteria with lead-specific checks | — (example in `examples/contexts/`) | — |
-| `proof_of_play` | **Reference contract: OOH advertising impression validation** | `billing`, `operations` | Cross-field rules, conditional constraints, context-aware billing thresholds |
+| `proof_of_play` | **Reference contract: OOH advertising impression validation** | — (example in `examples/contexts/`) | Cross-field rules, conditional constraints, context-aware billing thresholds |
 | `social_media_age_compliance` | UK Online Safety Act / Ofcom age assurance — 13+ age gate, DOB consistency, identity verification audit trail | — | `age_match` rule, identity verification lookup, verification timestamp |
 | `ppds_menu_item` | Natasha's Law (PPDS) allergen compliance — all 14 major allergens must be explicitly declared before a QSR menu item is saved or labelled | — | 14 mandatory boolean fields, `required_if` for gluten/tree-nut type, sulphite threshold, audit trail |
 | `martyns_law_venue` | Martyn's Law (Terrorism (Protection of Premises) Act 2025) — venue terrorism preparedness compliance, two-tier (standard/enhanced), mandatory SRP and SIA registration for 800+ capacity venues | — | Two-tier `required_if` enforcement, capacity minimum, enhanced-duty field gate, audit trail |
-| `martyns_law_event` | Martyn's Law — qualifying events (temporary/one-off, 200+ expected attendance). Organiser-centric; SIA notification not registration; staff briefing not training; time-bounded with start/end dates | — | Distinct from venue contract: `sia_notification_reference` not `sia_registration_number`; event dates required |
+| `martyns_law_event` | Martyn's Law — qualifying events (temporary/one-off, 800+ expected attendance — s.3(1)(d); the 200 threshold is for premises, s.2). Organiser-centric; SIA notification not registration; staff briefing not training; time-bounded with start/end dates | — | Distinct from venue contract: `sia_notification_reference` not `sia_registration_number`; event dates required; no `duty_tier` field — every qualifying event carries the enhanced-level duties |
 | `building_safety_golden_thread` | Building Safety Act 2022 — Golden Thread compliance for higher-risk buildings (18m+ / 7+ storeys). Enforces accountable person, BSR registration, safety case, and golden thread audit trail at point of write | — | Named accountable person + BSM mandatory, BSR registration gate, `required_if safety_case_documented = true` |
 | `companies_house_filing` | Economic Crime and Corporate Transparency Act 2023 — identity verification for Companies House director and PSC filings. A missing verification field blocks the record before submission | — | `required_if id_verification_completed = true` gates method, date, and verifier; role and method lookups |
 | `gdpr_processing_record` | UK GDPR Article 30 — Record of Processing Activities (ROPA). Enforces lawful basis declaration, consent-specific fields, legitimate interests assessment, special category data basis, and international transfer safeguard at the point of write | — | All 6 Article 6 lawful bases via lookup; consent/LIA/special-category/transfer fields via `required_if`; DPO audit trail |
 | `gdpr_dsar_request` | UK GDPR Article 15 — Data Subject Access Request handling. Enforces 30-day deadline recording, identity verification gate, extension logic, and outcome tracking before a request enters the case management workflow | — | 30-day deadline field required at intake; `required_if` for verification method, extension reason, and refusal reason |
 | `eu_gdpr_processing_record` | EU GDPR Article 30 — Record of Processing Activities (ROPA). EU variant with EU Standard Contractual Clauses, 27-DPA supervisory authority lookup, and EU adequacy decision list | — | EU transfer safeguards and supervisory authority lookup; otherwise identical pattern to UK GDPR |
 | `eu_gdpr_dsar_request` | EU GDPR Article 15 — Data Subject Access Request handling. EU variant with €20M / 4% turnover penalty references and EU supervisory authority | — | Same enforcement pattern as UK GDPR DSAR; fines referenced in EUR |
-| `dora_ict_incident` | EU DORA (Digital Operational Resilience Act) Articles 17-19 — ICT incident report for financial entities. In force 17 January 2025. Enforces incident classification, statutory reporting timelines (24h / 72h / 30 days), and root cause documentation | — | `date_diff` enforces 24h early warning and 72h notification windows; `required_if` for root_cause when major/significant |
+| `dora_ict_incident` | EU DORA (Digital Operational Resilience Act) Articles 17-19 — ICT incident report for financial entities. In force 17 January 2025. Enforces incident classification, the CDR (EU) 2025/301 reporting clocks (4h / 24h / 72h / one month), and root cause documentation | — | `date_diff` enforces the initial notification's 4-hour classification clock and 24-hour detection clock, the 72-hour intermediate report window, and the one-month final report window; `required_if` for root_cause and all three reports when `incident_classification == major` (values are `major` / `non_major`, not `significant`) |
 | `hipaa_disclosure_accounting` | US HIPAA 45 CFR 164.528 — Accounting of Disclosures. Enforces complete disclosure records before they enter covered entity systems. OCR penalties up to $2.1M/year | — | `required_if` for authorization_reference when patient_authorization; minimum_necessary_applied boolean gated on non-treatment purposes |
 | `sox_control_test` | US Sarbanes-Oxley Act 2002, Sections 302/404 — Internal control test record. CEO/CFO personal certification liability. Enforces deficiency classification and remediation plan completeness before control test records are saved | — | Three-level `required_if` cascade: test_result → deficiency_classification → remediation plan + audit committee escalation |
-| `mifid_transaction_report` | MiFID II / MiFIR Article 26 — Transaction reporting for investment firms and trading venues. Enforces LEI, ISIN, and venue MIC format at point of write before submission to an Approved Reporting Mechanism | — | LEI regex (`^[A-Z0-9]{18}[0-9]{2}$`), ISIN regex, MIC regex; buyer/seller ID type lookups |
+| `mifid_transaction_report` | MiFID II / MiFIR Article 26 — Transaction reporting for investment firms and trading venues. Enforces LEI, ISIN, and venue MIC format at point of write before submission to an Approved Reporting Mechanism | — | LEI check digit (`checksum` rule, `checksum_algorithm: lei_mod97` — ISO 17442 mod-97-10), ISIN regex, MIC regex; buyer/seller ID type lookups against the RTS 22 Annex I codes (LEI, NIDN, CCPT, CONCAT, MIC, INTC) |
 
 For the remaining 25+ contracts (agriculture, automotive, energy, HR, insurance, logistics,
 manufacturing, media, pharma, real estate, telecoms, travel, water utility, and more) see
@@ -100,9 +100,13 @@ data of EU residents.
 
 `dora_ict_incident` enforces ICT incident reporting completeness for EU financial entities.
 Incident classification, affected services, and root cause are mandatory before an incident
-record enters a case management system. The `date_diff` rule enforces DORA's statutory
-reporting windows: 24-hour early warning and 72-hour initial notification from the moment of
-becoming aware.
+record enters a case management system. The `date_diff` rules enforce the CDR (EU) 2025/301
+Art 5 reporting clocks for major incidents: initial notification within 4 hours of
+`major_classification_timestamp` and within 24 hours of `detection_timestamp`, intermediate
+report within 72 hours of the initial notification, and final report within one month of the
+intermediate report. `incident_classification` is `major` or `non_major` — DORA's "significant"
+is Article 18(2) cyber-threat vocabulary, not an incident class — and `root_cause` is required
+whenever the incident is major.
 
 ### US HIPAA — 45 CFR 164.528
 
@@ -136,4 +140,7 @@ and conditional constraints. It demonstrates:
 - `compare` rule: `impression_end` must be strictly after `impression_start` (catches phantom billing from inverted timestamps)
 - `required_if` rule: `refresh_rate_hz` required only when `panel_type == DIGITAL`
 - `condition` block: revenue floor applied only to `CHARGE` records, not `CREDIT` notes
-- Two contexts: `billing` (all warnings become errors) and `operations` (relaxed thresholds for dashboards)
+- Contexts: no bundled contract carries a `contexts:` block since 2.7.0. The worked example
+  is [`examples/contexts/proof_of_play.yaml`](../examples/contexts/proof_of_play.yaml), which
+  adds two contexts: `billing` (all warnings become errors) and `operations` (relaxed
+  thresholds for dashboards)

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -316,4 +316,4 @@ curl -s -X DELETE "http://localhost:8000/api/v1/quality/stats?context=demo" \
 ## See also
 
 - [docs/naming_conventions.md](naming_conventions.md) — naming conventions for contracts, rules, and fields
-- [contracts/customer.yaml](../examples/contexts/customer.yaml) — the reference contract with live `contexts:` examples
+- [examples/contexts/customer.yaml](../examples/contexts/customer.yaml) — the reference contract with live `contexts:` examples

--- a/docs/rules/core_rules.md
+++ b/docs/rules/core_rules.md
@@ -1,48 +1,77 @@
 # Core Rule Types Reference
 
-Last reviewed: 2026-04-16
+Last reviewed: 2026-09-03
 
-OpenDQV ships 13 core rule types. Each rule lives under `contract.rules[]` in
-a YAML data contract.
+OpenDQV ships 25 core rule types (`_KNOWN_RULE_TYPES` in
+`opendqv/core/linter.py`): `not_empty`, `not_empty_string`, `regex`, `min`,
+`max`, `range`, `min_length`, `max_length`, `date_format`, `unique`,
+`min_age`, `max_age`, `compare`, `required_if`, `lookup`, `checksum`,
+`cross_field_range`, `field_sum`, `forbidden_if`, `conditional_value`,
+`date_diff`, `ratio_check`, `geospatial_bounds`, `allowed_values`, and
+`age_match`. Each rule lives under `contract.rules[]` in a YAML data
+contract.
+
+This page documents the 13 foundational types in full worked detail below.
+The other 12 (`not_empty_string`, `min_age`, `max_age`, `checksum`,
+`cross_field_range`, `field_sum`, `forbidden_if`, `conditional_value`,
+`date_diff`, `ratio_check`, `geospatial_bounds`, `age_match`) each have their
+own page — see [docs/rules/README.md](README.md) for the full index.
 
 Every rule requires these fields:
 
 ```yaml
 - name: rule_name          # unique within the contract
   field: target_field      # the record field to validate
-  type: rule_type          # one of the 13 types below
+  type: rule_type          # one of the types above
   severity: error          # error (block) or warning (allow but flag)
   error_message: "..."     # returned when validation fails
 ```
 
-Optional on any rule: `description`, `condition` (conditional application).
+Optional on any rule: `description`, `condition` (conditional application),
+`optional: true` (see Null handling below).
 
 ---
 
-## Null handling (current v2.2.x behaviour)
+## Null handling
 
-Rule handlers are not yet fully consistent about missing values:
+A `null`, empty, or whitespace-only value is treated as absent (D6). This is
+structural, not per-handler:
 
-- Most format rules (`regex`, `min`, `max`, `range`, `date_format`, `checksum`,
-  `compare`, `geospatial_bounds`, `conditional_value`, `cross_field_range`,
-  `conditional_lookup`, `age_match`) **fail** when the target field is `None`
-  or absent.
-- A few (`max_length`, `allowed_values`, single-record `lookup`,
-  single-record `date_diff`) **pass silently** on missing values.
-- `field_sum` and `ratio_check` silently **coerce** missing operands to `0`.
-- In a handful of cases the single-record path and the batch path disagree.
+- **Presence rules are the single reporter of absence.** `not_empty`,
+  `not_empty_string`, and `required_if` are the only rule types that fire on
+  an absent or blank value; every other rule type skips it.
+- **Format-class rules skip an absent field.** `regex`, `min`, `max`,
+  `range`, `min_length`, `max_length`, `date_format`, `checksum`, `lookup`,
+  `allowed_values`, `compare`, `geospatial_bounds`, `age_match`, and the rest
+  simply have nothing to check on an absent value and pass. If a field must
+  also be present, add a `not_empty`/`not_empty_string` rule alongside the
+  format rule — this is how most of the 41 shipped contracts already handle
+  it.
+- **A cross-field rule with an absent or blank counterpart fails, not
+  passes.** `compare`, `date_diff`, `cross_field_range`, `field_sum`,
+  `ratio_check`, `age_match`, and `geospatial_bounds` check a target field
+  against a counterpart field; if the counterpart is absent or blank, the
+  rule fails (D10) and the error entry carries `counterpart_missing: true`
+  so callers can tell that apart from an ordinary value violation. This
+  holds on both the single-record and batch paths.
+- **`date_diff` is fractional and signed on both units.** The day count
+  between the two dates is a fractional, signed delta (positive when the
+  target field's date is later); for `date_diff_unit: years` the delta is
+  divided by 365.25. A contract enforcing "end must be at least 1 year after
+  start" fails correctly when end is *before* start.
+- **`optional: true` is accepted on any rule and round-trips on disk** — it
+  is not read by the runtime validator (`opendqv/core/validator.py`;
+  `_RULE_HANDLERS` has no `optional` branch), but the linter uses it to
+  suppress its `FORMAT_ONLY_FIELD_ACCEPTS_EMPTY` advisory on a format-only
+  field.
+- **An unknown rule `type` still loads, with a warning, and never fires.**
+  `opendqv lint` catches it (`UNKNOWN_RULE_TYPE`); the engine does not — a
+  typo'd rule is a disabled rule at runtime. Always lint before deploy.
 
-**Safe pattern today:** if you want guaranteed presence enforcement on a
-field, add an explicit `not_empty` rule alongside any format rule. This is
-how most of the 43 shipped contracts already handle it.
-
-**Planned for v2.3.0** (breaking change, tracked to ship after the
-April 2026 demo window): every rule handler will fail on missing values by
-default, with a new `optional: true` flag for authors who want
-"format-validate-if-present, pass-if-absent". Single and batch paths will
-agree in every case. Unknown rule types will be rejected at contract load
-rather than silently passing at runtime. See `CHANGELOG.md` when v2.3.0
-ships for the full migration guide.
+See [docs/contract_conformance.md](../contract_conformance.md) for how this
+model was derived and cross-checked against the managed engine, and
+[docs/custom_rules.md](../custom_rules.md) for the closed `condition:`
+vocabulary (`field`, `value`, `not_value`, `present: true|false`).
 
 ---
 


### PR DESCRIPTION
Docs-only. A drift sweep after the 2.7.0 library sync (read-only audit of every user-facing page against the shipped contracts and `validator.py` / `linter.py`) found these stale claims; every number here was computed from the tree, and every behaviour statement was checked against the source.

- **`docs/compliance-contracts.md`** — `proof_of_play` row and reference section still named `billing` / `operations` as contexts of the bundled contract (no bundled contract carries `contexts:` since 2.7.0; the worked example is `examples/contexts/proof_of_play.yaml`); `martyns_law_event` said 200+ (the contract enforces 800+, 2025 c.10 s.3(1)(d); 200 is the premises tier, s.2) and the event contract has no duty tier; the DORA row and section described "24h early warning / 72h notification" (NIS2 vocabulary) — now the CDR (EU) 2025/301 clocks as the contract enforces them, gated on `major`, with `major` / `non_major` classification; MiFID's LEI checks are `checksum` (`lei_mod97`), not regex, and the identifier types are the RTS 22 Annex I codes; `salesforce_contact` count 18 → 19.
- **`README.md`** — contract counts 43/44 → 41, doc count 76 → 94 (`find docs -name '*.md'`), and the "Known limitations in v2.2.x" section (a v2.3.0 promise, five minors old) replaced by a current-behaviour section: absent/blank = absent, presence rules are the single reporter, cross-field rules fail on an absent/blank counterpart with `counterpart_missing: true`, closed `condition:` vocabulary, unknown rule types load with a warning and never fire.
- **`docs/rules/core_rules.md`** — "13 core rule types" → 25 (from `_KNOWN_RULE_TYPES`), the v2.2.x null-handling section rewritten to the current model (incl. fractional, signed `date_diff`), 43 contracts → 41, reviewed date.
- **`docs/contexts.md`** — link text now matches its href (`examples/contexts/customer.yaml`).
- **`CONTRIBUTING.md`** — a contributor changing a bundled contract's rules is pointed at the three fixture files that move with it and the regeneration script.

No source, contract, test or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vgWu6PuYnKaizE2gSBpeA