### PR TITLE
docs: 2.4.0→2.7.0 drift audit — 64 files brought to the shipped engine and library; 16 starter templates migrated to the current rule shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ It validates records against YAML data contracts at the point of write — befor
 data enters the pipeline ("shift-left"). It is **not** a pipeline monitoring tool
 (that's Monte Carlo) or a pipeline test framework (that's dbt/Soda).
 
-**Version:** 2.6.0
+**Version:** 2.7.0
 **Stack:** FastAPI + Gunicorn/Uvicorn, Streamlit UI, SQLite/PostgreSQL, DuckDB (batch), MCP
 
 ---
@@ -36,17 +36,20 @@ opendqv/core/           Engine: validator, rule_parser, contracts, code_generato
                         isolation_log, quality_stats, quality_analytics,
                         worker_heartbeat, onboarding, jsonschema, linter, storage
 opendqv/core/importers/ 8 format importers: GX, dbt, Soda, CSV, ODCS, CSVW, OTel, NDC
-opendqv/contracts/      YAML data contracts (41 bundled, 22+ industry domains) — shipped in the wheel since v2.2.4
+opendqv/contracts/      YAML data contracts (41 bundled, 22+ industry domains) — shipped in the wheel since v2.2.4.
+                        Since v2.7.0 a MIRROR of the Cloud golden library (provenance in
+                        library_manifest.json); no bundled contract carries `contexts:` —
+                        the worked example is examples/contexts/customer.yaml
 opendqv/contracts/ref/  Lookup reference files (.txt) used by lookup rules
 opendqv/sdk/            Python SDK: sync client, async client, local validator
 opendqv/security/       JWT PAT auth (auth.py)
-opendqv/cli.py          CLI (~26 subcommands). opendqv/main.py = FastAPI app.
-opendqv/mcp_server.py   In-process MCP server (official mcp SDK, stdio)
+opendqv/cli.py          CLI (23 subcommands — `opendqv --help` is authoritative). opendqv/main.py = FastAPI app.
+opendqv/mcp_server.py   In-process MCP server (official mcp SDK 2.x, constructor-registered handlers, stdio)
 opendqv_mcp_proxy.py    Standalone REST-bridge MCP proxy (repo root, NOT in the wheel)
-docs/           76 markdown files: integration guides, security, operations
+docs/           Markdown docs (60+ top-level, plus rules/ and security/ subdirs): integration guides, security, operations
 examples/       Starter contracts + sample records by domain
 scripts/        Demo, wizard, perf-test, smoke tests, diagnostics
-tests/          4,100+ unit/integration tests (138 test files)
+tests/          4,900+ unit/integration tests (150+ test files)
 ui/             Streamlit governance workbench (app.py ~2,800 lines)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ opendqv/core/           Engine: validator, rule_parser, contracts, code_generato
 opendqv/core/importers/ 8 format importers: GX, dbt, Soda, CSV, ODCS, CSVW, OTel, NDC
 opendqv/contracts/      YAML data contracts (41 bundled, 22+ industry domains) — shipped in the wheel since v2.2.4.
                         Since v2.7.0 a MIRROR of the Cloud golden library (provenance in
-                        library_manifest.json); no bundled contract carries `contexts:` —
+                        library_manifest.json at the repo root, not in the wheel); no bundled contract carries `contexts:` —
                         the worked example is examples/contexts/customer.yaml
 opendqv/contracts/ref/  Lookup reference files (.txt) used by lookup rules
 opendqv/sdk/            Python SDK: sync client, async client, local validator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,14 @@ All three parts must pass before the `ALL SMOKE TESTS PASSED` line appears.
   shows it landed (`source.export_ref`, `library_version`). Do not expect a
   starter PR to be merged into `opendqv/contracts/` directly — the digest
   check on the managed side would fail the build — expect it to land through
-  the export within the next release.
+  the export within the next release. If your change touches a bundled
+  contract's rules, it must move together with three fixture files —
+  `tests/fixtures/conformance/frozen/minimal_clean.jsonl` (re-freeze with
+  `scripts/freeze_minimal_clean.py`), `tests/fixtures/conformance/frozen/accepted_breaks.json`
+  (a deliberate verdict change, scoped to its error codes and tied to the
+  current CHANGELOG version), and `tests/fixtures/conformance/frozen/regulatory_claims.jsonl`
+  (a claim row per regulatory rule) — regenerated together via
+  `scripts/conformance_fixtures.py`.
 
 ### Project Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ docker compose exec api python -m pytest tests/ -v
 ## Running Tests
 
 ```bash
-# Full suite (3,390+ tests)
+# Full suite (4,900+ tests)
 pytest tests/ -v
 
 # Specific test file
@@ -93,11 +93,11 @@ Pre-release gate — runs the full three-part suite locally with one command:
 bash scripts/run_smoke_tests.sh
 ```
 
-- **Part 1:** 3,390+ unit tests in a clean Python 3.11 container (`Dockerfile.smoketest`)
-- **Part 2:** 42 HTTP checks via Docker Compose — auth modes, write guardrails, CLI, batch upload, webhook SSRF, rate limiting, federation SSE, UI
+- **Part 1:** the full unit suite (4,900+ tests) in a clean Python 3.11 container (`Dockerfile.smoketest`)
+- **Part 2:** 20 HTTP checks via Docker Compose — auth modes, write guardrails, CLI, batch upload, webhook SSRF, rate limiting, federation SSE, UI
 - **Part 3:** `pip install .` in a clean container, verifies the `opendqv` CLI entry point
 
-All 43 checks must pass before the `ALL SMOKE TESTS PASSED` line appears.
+All three parts must pass before the `ALL SMOKE TESTS PASSED` line appears.
 
 **Important:** the smoke test starts its own Docker Compose stack on ports 8000 and 8501. Ensure no other stack is running on those ports before running — the script will fail immediately with a clear message if they are occupied (`docker compose down` to clear).
 
@@ -116,7 +116,7 @@ All 43 checks must pass before the `ALL SMOKE TESTS PASSED` line appears.
 - **Python style:** Follow PEP 8. Use type hints for function signatures.
 - **Keep it simple:** Only add what's needed. Don't over-engineer.
 - **Write tests:** New features need tests. Bug fixes need a regression test.
-- **Contracts are YAML:** Rule definitions live in `contracts/*.yaml`, not in Python code.
+- **Contracts are YAML:** Rule definitions live in `opendqv/contracts/*.yaml`, not in Python code.
 - **Starter contracts have one owner, and contributions are still welcome here.**
   Since 2.7.0 `opendqv/contracts/` is a mirror of the golden OpenDQV Cloud
   starter library (`library_manifest.json` records the export in its `source`
@@ -165,6 +165,7 @@ only when the condition is met; otherwise it is silently skipped.
 A condition dict has exactly one of:
 - `value: X` — apply rule only when `field == X`
 - `not_value: X` — apply rule only when `field != X`
+- `present: true` / `present: false` — apply rule only when `field` is present (or absent/blank)
 
 Works in both single-record and batch (DuckDB) modes.
 
@@ -232,28 +233,26 @@ advertiser IDs, or market codes that change too frequently to hardcode in YAML).
 Notes:
 - Files are loaded once and cached in-process. Call `_load_lookup_set.cache_clear()` to invalidate.
 - For production use, mount the reference file as a Docker volume (e.g. `-v ./data:/app/data`).
-- REST-based lookups with configurable TTL are planned for a future release.
+- `lookup_file` may also be an HTTP(S) URL; `cache_ttl` controls how long the fetched list is cached. See `docs/rules/`.
 
 ### `allowed_values` — static values only
 
-The `regex` rule type with a pipe-delimited alternation pattern is how OpenDQV
-enforces a fixed allowed-values list:
+`allowed_values` checks a field against a fixed list declared in the contract:
 
 ```yaml
 - name: market_allowed
-  type: regex
+  type: allowed_values
   field: market
-  pattern: "^(UK|DE|FR|ES)$"
+  allowed_values: [UK, DE, FR, ES]
   error_message: "market must be UK, DE, FR or ES"
 ```
 
-> **Important:** There is no `allowed_values` rule type with dynamic/database-backed
-> lookups. For a static list, use `regex` with an alternation pattern as shown above.
-> For a dynamic list that changes at runtime, use `lookup` with a reference file.
+> **Important:** `allowed_values` has no dynamic/database-backed mode. For a list
+> that changes at runtime, use `lookup` with a reference file or HTTP endpoint.
 
 ### Adding a New Rule Type
 
-1. Add the type check in `opendqv/core/validator.py` -- both `_check_rule()` (single) and `_batch_check_rule()` (batch)
+1. Add the type check in `opendqv/core/validator.py` -- both `_check_rule()` (single) and `_batch_check_rule_inner()` (batch SQL)
 2. Add code generation in `opendqv/core/code_generator.py` -- `_generate_salesforce()`, `_js_rule_check()`, and `_generate_snowflake()`
 3. Add tests in `tests/test_core.py`
 4. Update the Rule Types table in `README.md`
@@ -289,14 +288,14 @@ Reference implementation: `opendqv/core/importers/csv_rules.py`
        }
    ```
 5. **Wire into `opendqv/api/routes_imports.py`** — add an import endpoint following the existing `POST /api/v1/import/csv` pattern
-6. **Add tests** in `tests/test_importers.py` with a representative sample input
+6. **Add tests** in a new `tests/test_<format>_import.py` (see `test_gx_import.py`, `test_odcs_import.py`) with a representative sample input
 7. **Add sample input** in `tests/sample_data/` if useful for manual testing
 
 The `skipped` list is important — callers need to know which rules could not be translated, not just the ones that succeeded.
 
 ### Adding a New Contract
 
-1. Create a YAML file in `contracts/`
+1. Create a YAML file in `opendqv/contracts/` (see the mirror note above — starter changes land via the golden-library export)
 2. Follow the `contract:` format (see `salesforce_contact.yaml` for a complete example)
 3. Restart the API or call `POST /api/v1/contracts/reload`
 4. Add sample data in `tests/sample_data/` if useful for testing
@@ -305,7 +304,7 @@ The `skipped` list is important — callers need to know which rules could not b
 
 1. **Create a feature branch** from `main`
 2. **Make your changes** with tests
-3. **Run the full test suite:** `pytest tests/ -v` -- all 3,390+ tests must pass
+3. **Run the full test suite:** `pytest tests/ -v` -- every test must pass
 4. **Keep PRs focused** on a single change
 5. **Write a clear description** of what changed and why
 
@@ -367,7 +366,7 @@ Changes to the following files require extra care and a higher bar for review:
 |------|-----|
 | `opendqv/core/validator.py` | The validation engine. Any change to rule evaluation logic must include a test for the specific case being changed — both a passing and a failing case. Pay particular attention to datetime comparison, checksum algorithms, and batch vs. single-record parity. |
 | `opendqv/security/auth.py` | Authentication and RBAC. Changes must not weaken token validation, role enforcement, or the revocation mechanism. |
-| `opendqv/api/routes.py` | Route wiring and sub-routers (`routes_*.py`). ACTIVE contract immutability guards (HTTP 409) must not be relaxed. |
+| `opendqv/api/routes.py` | Route wiring and sub-routers (`routes_*.py`). ACTIVE and REVIEW contract immutability guards (HTTP 409) must not be relaxed. |
 
 If you are unsure whether your change affects these files, open a Discussion before submitting a PR.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The `customer` contract ships pre-seeded if you want to skip step 1. The [quicks
 | `regex` | Field matches (or does not match) a pattern. Built-ins: `builtin:email`, `builtin:uuid`, `builtin:ipv4`, `builtin:url` |
 | `min` / `max` / `range` | Numeric bounds |
 | `min_length` / `max_length` | String length |
-| `min_age` / `max_age` | Age derived from a date-of-birth field within bounds |
+| `min_age` / `max_age` | Keys on a `date_format` rule (not rule types): age derived from the date within bounds |
 | `date_format` | Parseable date/datetime. Falls back through common formats if no explicit format is set |
 | `allowed_values` | Value must be in a fixed list |
 | `lookup` | Value must appear in a local file or HTTP endpoint (with TTL cache) |
@@ -281,7 +281,7 @@ methodology, and monthly volume extrapolation.
 |---|---|
 | [Quickstart](docs/quickstart.md) | Build your first contract in 15 minutes |
 | [Rules Reference](docs/rules/) | All rule types with parameters and examples |
-| [Compliance Contracts](docs/compliance-contracts.md) | Every bundled contract with its regulatory context |
+| [Compliance Contracts](docs/compliance-contracts.md) | Regulatory context for the compliance-critical bundled contracts |
 | [API Reference](docs/index.md) | REST endpoints, SDK, GraphQL, webhooks |
 | [Security](SECURITY.md) | Deployment checklist, threat model, RBAC |
 | [Production Deployment](docs/production_deployment.md) | Token auth, TLS, Docker Compose, hardening |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For tool reference, write guardrails, remote/enterprise mode, and the Marmot com
 
 ## Your First Validation
 
-**1. Write a contract** — drop a YAML file in your contracts directory (run `opendqv init --all` to copy the 43 bundled contracts, or `opendqv init` for a single starter):
+**1. Write a contract** — drop a YAML file in your contracts directory (run `opendqv init --all` to copy every bundled contract, or `opendqv init` for a single starter):
 
 ```yaml
 contract:
@@ -169,14 +169,16 @@ curl -s -X POST http://localhost:8000/api/v1/validate \
 {
   "valid": false,
   "errors": [
-    {"field": "email",  "rule": "valid_email",    "message": "Invalid email format",        "severity": "error"},
-    {"field": "amount", "rule": "amount_positive", "message": "Order amount must be positive", "severity": "error"},
-    {"field": "status", "rule": "status_valid",    "message": "Invalid order status",        "severity": "error"}
+    {"field": "email",  "rule": "valid_email",    "message": "Invalid email format",        "severity": "error", "error_code": "OPENDQV_REGEX_VALID_EMAIL"},
+    {"field": "amount", "rule": "amount_positive", "message": "Order amount must be positive", "severity": "error", "error_code": "OPENDQV_MIN_AMOUNT_POSITIVE"},
+    {"field": "status", "rule": "status_valid",    "message": "Invalid order status",        "severity": "error", "error_code": "OPENDQV_ALLOWED_VALUES_STATUS_VALID"}
   ],
   "contract": "order",
   "version": "1.0"
 }
 ```
+
+(Abridged — the real response also carries `contract_hash`, `engine_version`, `validated_at`, and per-error `suggested_fix`.)
 
 **4. Fix the record — it passes:**
 
@@ -203,21 +205,24 @@ The `customer` contract ships pre-seeded if you want to skip step 1. The [quicks
 | `regex` | Field matches (or does not match) a pattern. Built-ins: `builtin:email`, `builtin:uuid`, `builtin:ipv4`, `builtin:url` |
 | `min` / `max` / `range` | Numeric bounds |
 | `min_length` / `max_length` | String length |
+| `min_age` / `max_age` | Age derived from a date-of-birth field within bounds |
 | `date_format` | Parseable date/datetime. Falls back through common formats if no explicit format is set |
 | `allowed_values` | Value must be in a fixed list |
 | `lookup` | Value must appear in a local file or HTTP endpoint (with TTL cache) |
 | `compare` | Cross-field: `field` op `compare_to` — supports `gt`, `lt`, `gte`, `lte`, `eq`, `neq`, and `today`/`now` sentinels |
 | `required_if` / `forbidden_if` | Conditional: required or forbidden when another field equals a value |
+| `conditional_value` | Field must hold a given value when another field holds a given value |
 | `checksum` | Check-digit integrity: IBAN, GTIN/GS1, NHS, ISIN, LEI, VIN, CPF, ISRC |
 | `unique` | No duplicates within a batch (batch mode only) |
 | `cross_field_range` | Value must be between two other fields in the same record |
 | `field_sum` | Sum of named fields must equal a target (within optional tolerance) |
 | `geospatial_bounds` | Lat/lon pair within a bounding box |
 | `date_diff` | Difference between two date fields within a range |
+| `ratio_check` | Ratio of two numeric fields within a range |
 | `age_match` | Declared age consistent with date-of-birth field |
 
 Rules have `severity: error` (blocks the record) or `severity: warning` (flags but allows).
-Any rule can include a `condition` block to apply it only when another field equals a given value.
+Any rule can include a `condition` block so it applies only when a condition on another field holds — `value`, `not_value`, or `present: true|false`.
 
 Full reference: [docs/rules/](docs/rules/)
 
@@ -249,7 +254,7 @@ OpenDQV Core owns layer one. Your catalog handles layer two, your pipeline tools
 
 ## Contracts
 
-43 production-ready contracts ship inside the `opendqv` package covering GDPR, HIPAA, SOX, MiFID II,
+41 production-ready contracts ship inside the `opendqv` package covering GDPR, HIPAA, SOX, MiFID II,
 UK Building Safety Act, Martyn's Law, Natasha's Law, Ofcom Online Safety Act, EU DORA,
 and 20+ other regulatory frameworks across UK, EU, and US. `pip install opendqv` gives you all of them
 — `opendqv list` works with zero configuration.
@@ -276,12 +281,12 @@ methodology, and monthly volume extrapolation.
 |---|---|
 | [Quickstart](docs/quickstart.md) | Build your first contract in 15 minutes |
 | [Rules Reference](docs/rules/) | All rule types with parameters and examples |
-| [Compliance Contracts](docs/compliance-contracts.md) | 44 contracts with regulatory context |
+| [Compliance Contracts](docs/compliance-contracts.md) | Every bundled contract with its regulatory context |
 | [API Reference](docs/index.md) | REST endpoints, SDK, GraphQL, webhooks |
 | [Security](SECURITY.md) | Deployment checklist, threat model, RBAC |
 | [Production Deployment](docs/production_deployment.md) | Token auth, TLS, Docker Compose, hardening |
 | [Integrations](docs/index.md) | Salesforce, Kafka, Snowflake, dbt, Databricks, MCP, and more |
-| [All docs →](docs/) | 76 documentation files |
+| [All docs →](docs/) | The full documentation set |
 
 ---
 
@@ -295,19 +300,17 @@ OpenDQV is in Beta as of 2.0.0. The following stability commitments apply to the
 - **MCP tools** — tool names and parameters are stable within `v2.x`.
 - **Security fixes** — backported to the latest 2.x line on a best-effort basis.
 
-### Known limitations in v2.2.x
+### Presence and null handling (v2.5+)
 
-- **Rule null handling is inconsistent.** Most format rules fail when the target
-  field is missing; a few (`max_length`, `allowed_values`) pass silently;
-  `field_sum` and `ratio_check` coerce missing operands to `0`. Single-record
-  and batch paths disagree in a few cases. See
-  [`docs/rules/core_rules.md`](docs/rules/core_rules.md#null-handling-current-v22x-behaviour)
-  for the full matrix and the safe pattern to use today. v2.3.0 will make this
-  consistent (loud-by-default with an `optional: true` opt-out).
-- **Unknown rule types pass silently at runtime.** A typo in `type:` (e.g.
-  `min_lenght`) is caught by `opendqv lint` but not by the engine — a typo'd
-  rule is a disabled rule. Always lint before deploy. v2.3.0 will reject
-  unknown types at contract load.
+- **Presence is explicit.** A format rule (`regex`, `min`, `max_length`, `date_format`, …)
+  never implies that a field must exist — add `not_empty` / `not_empty_string` when it must.
+  Every non-presence rule treats a missing, `null`, or blank value as absent and passes.
+  A cross-field rule (`compare`, `field_sum`, `ratio_check`, `date_diff`, …) whose
+  counterpart is absent or blank **fails**, and the error entry carries
+  `counterpart_missing: true`. See [`docs/contract_conformance.md`](docs/contract_conformance.md).
+- **Unknown rule types load with a warning and pass.** A typo in `type:` (e.g.
+  `min_lenght`) is logged at contract load, and the rule then passes every record —
+  a typo'd rule is a disabled rule. `opendqv lint` fails it. Always lint before deploy.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,8 +95,8 @@ OpenDQV Core's audit-event and metrics endpoints assume a **single-tenant trust 
 
 **Mitigation:**
 
-- Single-tenant deployments are the supported v2.3.x model. Run one engine per tenant, isolated by network or process boundary.
-- Multi-tenant deployments must wait for the v2.4 per-contract scoping work tracked in `routes_audit_events.py` module docstring. v2.4 will gate audit and metrics by per-contract role grant.
+- Single-tenant deployments are the supported model. Run one engine per tenant, isolated by network or process boundary.
+- Per-contract auditor scoping (gating audit and metrics by per-contract role grant) is not yet implemented; the caveat is tracked in the `routes_audit_events.py` module docstring. Multi-tenant deployments should not rely on it.
 - The `auth_mode` field on `GET /api/v1/audit/events` responses (added in v2.3.23) gives consuming systems machine-readable evidence of the trust mode in effect; regulated deployments should refuse to render an audit-event response with `auth_mode: "open"`.
 
 ### 4. SQLite Persistence — Single-File, No Encryption at Rest
@@ -202,7 +202,7 @@ OpenDQV explicitly follows some standards and intentionally diverges from others
 
 | Standard | Status | Notes |
 |---|---|---|
-| **RFC 5321** — Simple Mail Transfer Protocol (email address format) | **Intentionally simplified** | The default email regex (`^[^@]+@[^@]+\.[^@]+$`) accepts most practical email addresses but does not implement the full RFC 5321 local-part grammar (quoted strings, IP domain literals, comments). This is deliberate — RFC 5321-compliant email parsers accept addresses that most production systems reject.
+| **RFC 5321** — Simple Mail Transfer Protocol (email address format) | **Intentionally simplified** | The `builtin:email` regex (`^[^@\s]+@[^@\s]+\.[^@\s]+$`) accepts most practical email addresses but does not implement the full RFC 5321 local-part grammar (quoted strings, IP domain literals, comments). This is deliberate — RFC 5321-compliant email parsers accept addresses that most production systems reject.
 
 > **Salesforce overlap note:** Salesforce's native email validation is also an RFC 5321 approximation. When OpenDQV runs as a Salesforce Before trigger, Salesforce's check fires first for truly malformed addresses; our rule validates what Salesforce passes. |
 | **ISO 8601** — Date and time format | **Followed in spirit** | The `date_format` rule validates that values are parseable as dates, not that they conform to a specific ISO 8601 profile. Rules with `date_format` accept `YYYY-MM-DD` and most ISO 8601 variants. Strict ISO 8601 profile enforcement (e.g. time zones required) is done via `regex` rules in the contract. |
@@ -220,7 +220,7 @@ OpenDQV explicitly follows some standards and intentionally diverges from others
 
 ## Dependency Provenance
 
-Dependencies are specified in `requirements.txt`. `pip-audit` runs in CI on every push and pull request (see `.github/workflows/ci.yml` — "Security audit" step) to detect known CVEs in the dependency tree. The audit result is visible in each GitHub Actions run. An SBOM (Software Bill of Materials) is generated with each release.
+Dependencies are declared in `pyproject.toml` and pinned by the poetry lockfile; `requirements.txt` is generated from it (never hand-edited) and CI checks the two stay in sync. `pip-audit` runs in CI on every push and pull request (see `.github/workflows/ci.yml` — "Security audit" step) to detect known CVEs in the dependency tree. The audit result is visible in each GitHub Actions run. An SBOM (Software Bill of Materials) is generated with each release.
 
 ---
 
@@ -253,6 +253,7 @@ Before any deployment that will handle real financial data or be accessible to u
 
 - [ ] `POST /api/v1/contracts/customer/status?status=active` with a validator credential returns HTTP 403
 - [ ] `POST /api/v1/contracts/customer/version?new_version=99.0` with a validator credential returns HTTP 403
+- [ ] `POST /api/v1/contracts/customer/rules` against an ACTIVE (or REVIEW) contract returns HTTP 409 — ACTIVE and REVIEW contracts are immutable; edit via a new version or reject REVIEW back to DRAFT
 - [ ] `POST /api/v1/validate` with a valid record and a known contract returns HTTP 200 with `valid: true`
 - [ ] A log line for the validation above contains `trace_id=`, `caller=`, `ip=`, `record_id=`, `contract=`, `valid=`
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -22,12 +22,25 @@ Full interactive docs at `/docs` (Swagger) and `/redoc` (ReDoc) when the server 
 | `POST` | `/api/v1/contracts/{name}/{version}/reject` | Yes | Reject contract back to DRAFT; role: approver/admin |
 | `GET` | `/api/v1/contracts/{name}/history` | No | Append-only hash-chained audit log of all contract changes |
 | `GET` | `/api/v1/contracts/{name}/explain` | No | Plain-English description of all rules |
+| `GET` | `/api/v1/contracts/{name}/explain/{field}/{rule_name}` | No | Explanation, valid/invalid examples and constraint for one rule |
+| `GET` | `/api/v1/contracts/{name}/jsonschema` | No | Contract projected as JSON Schema |
+| `GET` | `/api/v1/contracts/{name}/versions` | No | List all versions of a contract |
+| `GET` | `/api/v1/contracts/{name}/at` | No | Contract as it was at a point in time / version |
+| `GET` | `/api/v1/contracts/{name}/diff` | No | Diff two versions of a contract |
+| `POST` | `/api/v1/contracts/{name}/version` | Yes | Create a new version (`?new_version=`); existing version → 400 |
 | `GET` | `/api/v1/contracts/{name}/lint` | No | Lint a contract — validate its YAML structure |
 | `GET` | `/api/v1/contracts/{name}/quality-trend` | No | Quality trend data for a contract |
 | `POST` | `/api/v1/contracts/reload` | Yes (admin) | Reload contracts from disk |
 | `POST` | `/api/v1/generate` | Yes | Generate platform-specific validation code |
 | `GET` | `/api/v1/stats` | Yes | Validation statistics |
-| `GET` | `/api/v1/analytics/quality-trend` | Yes | Global quality trend data |
+| `DELETE` | `/api/v1/quality/stats` | Yes (admin) | Reset quality statistics |
+| `GET` | `/api/v1/agents` | Yes | Distinct agent_id values seen |
+| `GET` | `/api/v1/analytics/summary` | Yes | Analytics summary |
+| `GET` | `/api/v1/analytics/rule-heatmap` | Yes | Rule failure heat-map |
+| `GET` | `/api/v1/rejection-summary` | Yes | Rejection summary |
+| `GET` | `/api/v1/audit/events` | Yes (auditor+) | List validation audit events |
+| `GET` | `/api/v1/audit/events/{event_id}` | Yes (auditor+) | Fetch one audit event |
+| `GET` | `/config` | No | Effective engine configuration |
 | `GET` | `/api/v1/analytics/rule-velocity` | Yes | Rule failure velocity (trend) |
 | `POST` | `/api/v1/tokens/generate` | Yes (admin) | Generate a Personal Access Token |
 | `POST` | `/api/v1/tokens/revoke` | Yes (admin) | Revoke a PAT by token value |
@@ -47,10 +60,18 @@ Full interactive docs at `/docs` (Swagger) and `/redoc` (ReDoc) when the server 
 | `POST` | `/api/v1/import/otel` | Yes (editor+) | Import OpenTelemetry semantic conventions |
 | `POST` | `/api/v1/import/ndc` | Yes (editor+) | Import NDC format |
 | `GET` | `/api/v1/export/odcs/{contract}` | No | Export contract as ODCS v3.1.0 YAML |
+| `GET` | `/api/v1/export/gx/{contract}` | No | Export contract as a GX expectation suite |
+| `POST` | `/api/v1/profile` | Yes | Profile records and propose rules |
+| `POST` | `/api/v1/profile/file` | Yes | Profile an uploaded CSV/Parquet file |
+| `GET` | `/api/v1/observation/summary` | Yes | Observation-mode summary |
+| `GET` | `/api/v1/observation/fields` | Yes | Observation-mode per-field stats |
+| `GET` | `/api/v1/observation/trend` | Yes | Observation-mode trend |
 | `GET` | `/api/v1/trace/verify` | Yes (auditor+) | Verify trace log hash-chain integrity |
 | `GET` | `/api/v1/registry` | No | Schema registry — list all contracts as versioned schemas |
 | `GET` | `/api/v1/registry/{name}` | No | Schema registry — get specific schema |
 | `GET` | `/api/v1/federation/events` | No | SSE stream of federation sync events |
+| `POST` | `/api/v1/federation/register` | Yes | Register a federated node |
+| `GET` | `/api/v1/federation/status` / `health` / `log` / `sync-status` | No | Federation node status, health, log, sync state |
 | `*` | `/graphql` | No | GraphQL endpoint (queries + mutations) |
 
 ---
@@ -72,10 +93,16 @@ Response:
   "errors": [],
   "warnings": [],
   "contract": "customer",
-  "version": "1.0",
-  "owner": "Data Governance"
+  "version": "1.1",
+  "owner": "Data Governance",
+  "engine_version": "<engine-version>",
+  "contract_hash": "…",
+  "event_id": "…",
+  "validated_at": "…"
 }
 ```
+
+(Abridged. Each error entry carries `field`, `rule`, `message`, `severity`, `error_code`, `suggested_fix`, and `counterpart_missing` — `true` when a cross-field rule failed because its counterpart was absent or blank. See [error_codes.md](error_codes.md).)
 
 Both `/validate` and `/validate/batch` include an `owner` field echoing the contract's owner —
 route alerts and disputes to the right team without a separate contract lookup.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -21,8 +21,8 @@ Full interactive docs at `/docs` (Swagger) and `/redoc` (ReDoc) when the server 
 | `POST` | `/api/v1/contracts/{name}/{version}/approve` | Yes | Approve contract (REVIEW → ACTIVE); role: approver/admin |
 | `POST` | `/api/v1/contracts/{name}/{version}/reject` | Yes | Reject contract back to DRAFT; role: approver/admin |
 | `GET` | `/api/v1/contracts/{name}/history` | No | Append-only hash-chained audit log of all contract changes |
-| `GET` | `/api/v1/contracts/{name}/explain` | No | Plain-English description of all rules |
-| `GET` | `/api/v1/contracts/{name}/explain/{field}/{rule_name}` | No | Explanation, valid/invalid examples and constraint for one rule |
+| `GET` | `/api/v1/contracts/{name}/explain` | Yes (auth-gated by default) | Plain-English description of all rules |
+| `GET` | `/api/v1/contracts/{name}/explain/{field}/{rule_name}` | Yes (auth-gated by default) | Explanation, valid/invalid examples and constraint for one rule |
 | `GET` | `/api/v1/contracts/{name}/jsonschema` | No | Contract projected as JSON Schema |
 | `GET` | `/api/v1/contracts/{name}/versions` | No | List all versions of a contract |
 | `GET` | `/api/v1/contracts/{name}/at` | No | Contract as it was at a point in time / version |
@@ -48,7 +48,7 @@ Full interactive docs at `/docs` (Swagger) and `/redoc` (ReDoc) when the server 
 | `GET` | `/api/v1/tokens` | Yes (admin) | List all tokens |
 | `POST` | `/api/v1/webhooks` | Yes (editor+) | Register a webhook |
 | `GET` | `/api/v1/webhooks` | Yes | List webhooks |
-| `DELETE` | `/api/v1/webhooks/{id}` | Yes (editor+) | Delete a webhook |
+| `DELETE` | `/api/v1/webhooks` | Yes (editor+) | Delete a webhook (body: `{"url": ...}`) |
 | `GET` | `/health` | No | Health check |
 | `GET` | `/metrics` | No | Prometheus metrics |
 | `POST` | `/api/v1/import/gx` | Yes (editor+) | Import Great Expectations suite JSON |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,66 +4,82 @@
 
 ```
 OpenDQV/
-├── api/
-│   ├── routes.py              # FastAPI app assembly and middleware (~39 lines)
-│   ├── routes_validation.py   # Validation endpoints — /validate, /validate/batch (~378 lines)
-│   ├── routes_contracts.py    # Contract management — CRUD, lifecycle, audit (~840 lines)
-│   ├── routes_analytics.py    # Analytics endpoints — trends, velocity (~238 lines)
-│   ├── models.py              # Pydantic request/response models (~359 lines)
-│   ├── graphql_schema.py      # Strawberry GraphQL schema (~237 lines)
-│   └── deps.py                # FastAPI dependency injection
+├── opendqv/                   # The installable package — all importable code lives here
+│   ├── api/
+│   │   ├── routes.py              # Assembly shim — mounts the 9 domain sub-routers below
+│   │   ├── routes_validation.py   # /validate, /validate/batch
+│   │   ├── routes_contracts.py    # Contract CRUD, lifecycle, versioning, audit
+│   │   ├── routes_imports.py      # /import/* (8 format importers)
+│   │   ├── routes_tokens.py       # /tokens/* (PAT issue / revoke)
+│   │   ├── routes_webhooks.py     # /webhooks
+│   │   ├── routes_analytics.py    # Trends, velocity, quality metrics
+│   │   ├── routes_audit_events.py # Audit event read surface
+│   │   ├── routes_federation.py   # Multi-node federation
+│   │   ├── routes_profiler.py     # /profile, /profile/file
+│   │   ├── models.py              # Pydantic request/response models
+│   │   ├── graphql_schema.py      # Strawberry GraphQL schema (mounted at /graphql)
+│   │   └── deps.py                # Shared router state, limiter, auth/validation helpers
+│   │
+│   ├── core/
+│   │   ├── validator.py           # Validation engine — single-record + DuckDB batch
+│   │   ├── rule_parser.py         # Rule Pydantic model, YAML parsing, compiled patterns
+│   │   ├── contracts.py           # Contract registry, YAML load/save, versioning, history
+│   │   ├── code_generator.py      # Push-down code generation (Apex/JS/Snowflake/SQL)
+│   │   ├── onboarding.py          # Interactive setup wizard
+│   │   ├── webhooks.py            # Lifecycle webhook dispatch
+│   │   ├── federation.py          # Multi-node contract federation
+│   │   ├── trace_log.py           # Per-record validation trace log (hash chain + HMAC)
+│   │   ├── node_health.py         # Node health state machine
+│   │   ├── isolation_log.py       # Federation isolation audit log
+│   │   ├── quality_stats.py       # Validation quality statistics
+│   │   ├── quality_analytics.py   # DuckDB OLAP analytics layer
+│   │   ├── worker_heartbeat.py    # Gunicorn worker liveness tracking
+│   │   ├── profiler.py            # Field-level data profiling
+│   │   ├── linter.py              # Contract linter
+│   │   ├── jsonschema.py          # Contract → JSON Schema projection
+│   │   ├── storage.py             # History backends (SQLite / PostgreSQL)
+│   │   └── importers/             # 8 format importers (GX, dbt, Soda, CSV, ODCS, CSVW, OTel, NDC)
+│   │
+│   ├── contracts/                 # Bundled YAML contracts — a mirror of the OpenDQV Cloud
+│   │   │                          #   golden library; provenance in library_manifest.json
+│   │   └── ref/                   # Lookup reference files used by lookup rules
+│   │
+│   ├── security/
+│   │   └── auth.py                # JWT PAT authentication, RBAC — 6 roles
+│   │
+│   ├── sdk/
+│   │   ├── client.py              # Synchronous + asynchronous Python SDK (httpx-based)
+│   │   └── local.py               # Zero-network in-process validation (LocalValidator)
+│   │
+│   ├── cli.py                     # CLI (~26 subcommands)
+│   ├── config.py                  # All configuration via environment variables
+│   ├── main.py                    # FastAPI app entry point, lifespan, /health, GraphQL mount
+│   ├── monitoring.py              # Prometheus metrics + in-memory validation stats
+│   └── mcp_server.py              # In-process MCP server (official mcp SDK, stdio)
 │
-├── core/
-│   ├── validator.py           # Validation engine — single-record + DuckDB batch (~1,400 lines)
-│   ├── rule_parser.py         # Rule Pydantic model, YAML parsing, compiled patterns (~304 lines)
-│   ├── contracts.py           # Contract registry, YAML load/save, versioning (~1,053 lines)
-│   ├── code_generator.py      # Push-down code generation (Apex/JS/Snowflake/SQL) (~465 lines)
-│   ├── onboarding.py          # Interactive setup wizard (~1,254 lines)
-│   ├── webhooks.py            # Lifecycle webhook dispatch (~330 lines)
-│   ├── federation.py          # Multi-node contract federation (~236 lines)
-│   ├── trace_log.py           # Per-record validation trace log
-│   ├── node_health.py         # Node health state machine
-│   ├── isolation_log.py       # Federation isolation audit log
-│   ├── quality_stats.py       # Validation quality statistics
-│   ├── worker_heartbeat.py    # Gunicorn worker liveness tracking
-│   ├── profiler.py            # Field-level data profiling
-│   └── importers/             # 8 format importers (GX, dbt, Soda, CSV, ODCS, CSVW, OTel, NDC)
-│
-├── security/
-│   └── auth.py                # JWT PAT authentication, RBAC — 6 roles (~224 lines)
-│
-├── sdk/
-│   ├── client.py              # Synchronous Python SDK (httpx-based) (~547 lines)
-│   ├── async_client.py        # Asynchronous Python SDK
-│   └── local_validator.py     # Zero-network in-process validation
+├── opendqv_mcp_proxy.py       # Standalone REST-bridge MCP proxy (repo root, not in the wheel)
 │
 ├── ui/
-│   └── app.py                 # Streamlit governance workbench, 12 sections (~2,826 lines)
-│
-├── contracts/                 # YAML data contracts (45 active, 22+ industry domains)
-│   └── ref/                   # Lookup reference files used by lookup rules
+│   └── app.py                 # Streamlit governance workbench
 │
 ├── examples/
-│   ├── starter_contracts/     # 17 minimal starter templates
-│   └── sample_records/        # Sample records by domain
+│   ├── starter_contracts/     # Minimal starter templates
+│   ├── contexts/              # Worked `contexts:` example (customer.yaml)
+│   └── <domain>/              # Sample records + starter contract by domain
 │
-├── tests/                     # pytest suite (3,398+ tests, 72 test files)
+├── tests/                     # pytest suite (see CLAUDE.md for the current count)
 │   └── conftest.py            # Fixtures — temp contracts dir, auth tokens, test isolation
 │
-├── docs/                      # 79 markdown integration and operations guides
+├── docs/                      # Markdown integration and operations guides
 │
 ├── scripts/
 │   ├── demo_*.py              # Domain-specific demo seeders (OOH, PPDS, Salesforce, etc.)
-│   ├── run_smoke_tests.sh     # Full pre-release smoke test suite (43 checks)
+│   ├── run_smoke_tests.sh     # Full pre-release smoke test suite
 │   ├── perf-test.sh           # Load testing with Apache Bench
 │   └── diagnostics/           # Debug and diagnostic utilities
 │
-├── postman/                   # Postman collection + environment (all 50 endpoints)
+├── postman/                   # Postman collection + environment
 │
-├── monitoring.py              # Prometheus metrics + in-memory validation stats (~355 lines)
-├── mcp_server.py              # MCP server (Claude Desktop / Cursor integration) (~1,059 lines)
-├── config.py                  # All configuration via environment variables (~185 lines)
-├── main.py                    # FastAPI app entry point (~212 lines)
 ├── docker-compose.yml         # Production stack (API + UI + PostgreSQL)
 ├── docker-compose.dev.yml     # Development stack (hot-reload API)
 └── docker-compose.demo.yml    # Demo stack (ports 8080/8502, pre-seeded data)
@@ -81,7 +97,7 @@ can run behind a load balancer with no coordination.
 
 **2. Contract-as-Code**
 
-YAML files in `contracts/` are the single source of truth. The API writes back to YAML
+YAML files in `config.CONTRACTS_DIR` (the bundled `opendqv/contracts/` by default) are the single source of truth. The API writes back to YAML
 atomically on every mutation. The in-memory registry is rebuilt from disk on reload.
 
 **3. Config via environment variables**
@@ -112,20 +128,20 @@ Source system
     │
     │  POST /validate
     ▼
-FastAPI (routes_validation.py)
+FastAPI (opendqv/api/routes_validation.py)
     │
-    ├─ Auth check (security/auth.py)
+    ├─ Auth check (opendqv/security/auth.py)
     ├─ Rate limit check (slowapi)
     │
     ▼
-Validator (core/validator.py)
+Validator (opendqv/core/validator.py)
     │
-    ├─ Load contract from registry (core/contracts.py)
+    ├─ Load contract from registry (opendqv/core/contracts.py)
     ├─ Apply each rule in sequence
-    │   ├─ regex: compiled_pattern.match() with ReDoS timeout
+    │   ├─ regex: unanchored pattern.search() with ReDoS timeout (anchor with ^…$)
     │   ├─ lookup: TTL-cached HTTP or file lookup
     │   ├─ compare: cross-field evaluation
-    │   └─ ... (15 rule types)
+    │   └─ ... (every rule type in the dispatch table — see rules.md)
     │
     ├─ Collect errors + warnings
     ├─ Write analytics event (fire-and-forget, SQLite async)
@@ -143,19 +159,22 @@ Response: {valid, errors, warnings, contract, version, owner}
 
 | Control | Where | Description |
 |---------|-------|-------------|
-| SEC-001 | `core/validator.py` | ReDoS timeout via `regex` library (0.5s default) |
+| SEC-001 | `core/validator.py` | ReDoS timeout via `regex` library (0.5s default, `OPENDQV_REGEX_TIMEOUT`) |
 | SEC-002 | `core/contracts.py` | Path traversal prevention (`pathlib.resolve()` + containment) |
-| SEC-004 | `core/validator.py` | Field name SQL injection protection (parameterised DuckDB) |
-| SEC-008 | `core/webhooks.py` | Webhook SSRF protection (RFC 1918 + loopback blocked) |
+| SEC-004 | `core/validator.py`, `core/rule_parser.py` | SQL injection protection — every field reference a rule carries (`field`, trigger fields, `compare_to`, cross-field names) is parameterised; `date_format.format` is a bound SQL parameter |
+| SEC-006 | `core/importers/` | Path traversal prevention on importer `lookup_file` paths |
+| SEC-008 | `core/webhooks.py` | Webhook SSRF protection (RFC 1918 + loopback + link-local blocked) |
 | SEC-009 | `security/auth.py` | Token role whitelist — unknown roles rejected with 422 |
-| SEC-010 | `api/routes_contracts.py` | Role guards on import, webhook, reload, and token endpoints |
-| — | `core/contracts.py` | ACTIVE contracts are immutable — rule mutations return 409 |
+| SEC-010 | `api/deps.py` + every sub-router | Role guards — `POST /import/*`, `POST/DELETE /webhooks` require `editor`/`admin`; `POST /contracts/reload` and `/tokens/*` require `admin` |
+| SEC-011 | `core/validator.py`, `config.py` | `lookup_auth_header` secret substitution — `OPENDQV_LOOKUP_` prefix allowlist, disabled under `AUTH_MODE=open`, egress host allowlist (`OPENDQV_LOOKUP_EGRESS_ALLOWLIST`) |
+| — | `core/contracts.py` | `CONTRACT_NAME_RE` — the single contract-name charset; every core write path taking a caller-supplied name checks it |
+| — | `core/contracts.py` | ACTIVE and REVIEW contracts are immutable — rule mutations return 409 (registry-level gate); reject REVIEW → DRAFT to edit |
 
 ---
 
 ## Related
 
 - [Quickstart](quickstart.md) — first validation in 15 minutes
-- [API Reference](api_reference.md) — all 50 endpoints
+- [API Reference](api_reference.md) — all REST endpoints
 - [Production Deployment](production_deployment.md) — Docker Compose, TLS, scaling
 - [Security](../SECURITY.md) — threat model, deployment checklist

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ OpenDQV/
 │   │   └── importers/             # 8 format importers (GX, dbt, Soda, CSV, ODCS, CSVW, OTel, NDC)
 │   │
 │   ├── contracts/                 # Bundled YAML contracts — a mirror of the OpenDQV Cloud
-│   │   │                          #   golden library; provenance in library_manifest.json
+│   │   │                          #   golden library; provenance in repo-root library_manifest.json (not in the wheel)
 │   │   └── ref/                   # Lookup reference files used by lookup rules
 │   │
 │   ├── security/
@@ -51,7 +51,7 @@ OpenDQV/
 │   │   ├── client.py              # Synchronous + asynchronous Python SDK (httpx-based)
 │   │   └── local.py               # Zero-network in-process validation (LocalValidator)
 │   │
-│   ├── cli.py                     # CLI (~26 subcommands)
+│   ├── cli.py                     # CLI (23 subcommands)
 │   ├── config.py                  # All configuration via environment variables
 │   ├── main.py                    # FastAPI app entry point, lifespan, /health, GraphQL mount
 │   ├── monitoring.py              # Prometheus metrics + in-memory validation stats

--- a/docs/atlan_integration.md
+++ b/docs/atlan_integration.md
@@ -40,7 +40,7 @@ Before any sync can run, create the `OpenDQV` namespace in the Atlan Admin panel
 | `contract_name` | `String` | OpenDQV contract identifier |
 | `contract_version` | `String` | Semantic version string |
 | `contract_status` | `String` | `active`, `draft`, or `archived` |
-| `contract_hash` | `String` | SHA-256 hash of the contract YAML |
+| `schema_hash` | `String` | SHA-256 `entry_hash` of the contract's latest audit-chain entry |
 | `rule_count` | `Integer` | Total number of active rules |
 | `owner_team` | `String` | Owning team name |
 | `owner_email` | `String` | Owner contact email |
@@ -59,7 +59,7 @@ Push every active OpenDQV contract into the Atlan `Table` entity that the contra
 | `name` | `contract_name` |
 | `version` | `contract_version` |
 | `status` | `contract_status` |
-| `contract_hash` | `contract_hash` |
+| `schema_hash` | `schema_hash` |
 | `rule_count` | `rule_count` |
 | `owner_team` | `owner_team` |
 | `owner_email` | `owner_email` |
@@ -84,7 +84,7 @@ client = AtlanClient(base_url=ATLAN_URL, api_key=ATLAN_TOKEN)
 contracts = requests.get(
     f"{OPENDQV_URL}/api/v1/registry",
     headers={"Authorization": f"Bearer {OPENDQV_TOKEN}"},
-).json()
+).json()["registry"]
 
 for contract in contracts:
     asset_id = contract.get("asset_id", "")
@@ -101,7 +101,7 @@ for contract in contracts:
         cm["contract_name"]       = contract["name"]
         cm["contract_version"]    = contract.get("version", "")
         cm["contract_status"]     = contract.get("status", "")
-        cm["contract_hash"]       = contract.get("contract_hash", "")
+        cm["schema_hash"]       = contract.get("schema_hash", "")
         cm["rule_count"]          = contract.get("rule_count", 0)
         cm["owner_team"]          = contract.get("owner_team", "")
         cm["owner_email"]         = contract.get("owner_email", "")
@@ -320,7 +320,7 @@ for field_name, rules in rules_by_field.items():
 
 ## Approach 5 — Incremental Sync via Read-Back from Atlan
 
-Instead of a local state file, read the `contract_hash` currently stored in Atlan and skip the write if it matches the OpenDQV hash.
+Instead of a local state file, read the `schema_hash` currently stored in Atlan and skip the write if it matches the OpenDQV hash.
 
 ```python
 # pip install pyatlan requests
@@ -344,7 +344,7 @@ for contract in contracts:
     if current_page:
         existing = current_page[0]
         cm = existing.get_custom_metadata("OpenDQV") or {}
-        if cm.get("contract_hash") == contract.get("contract_hash"):
+        if cm.get("schema_hash") == contract.get("schema_hash"):
             print(f"Skipping {contract['name']}: hash unchanged")
             continue
 

--- a/docs/beginner-quickstart.md
+++ b/docs/beginner-quickstart.md
@@ -27,7 +27,7 @@ You need Python 3.11 or higher. To check if you have it:
 Scroll down to **Assets** and click **Source code (zip)**.
 
 Unzip it somewhere you can find it (your Desktop is fine). You'll see a folder called
-`OpenDQV-1.x.y` (where 1.x.y is the version number).
+`OpenDQV-2.x.y` (where 2.x.y is the version number).
 
 ---
 
@@ -39,16 +39,16 @@ will open and text will scroll — this is normal. First run takes 2–3 minutes
 **Mac** — open Spotlight (⌘ Space), search for Terminal, and type:
 
 ```bash
-cd ~/Desktop/OpenDQV-1.x.y
+cd ~/Desktop/OpenDQV-2.x.y
 bash install.sh
 ```
 
-*(replace `Desktop/OpenDQV-1.x.y` with the actual folder path)*
+*(replace `Desktop/OpenDQV-2.x.y` with the actual folder path)*
 
 **Linux:**
 
 ```bash
-cd /path/to/OpenDQV-1.x.y
+cd /path/to/OpenDQV-2.x.y
 bash install.sh
 ```
 

--- a/docs/benchmark_throughput.md
+++ b/docs/benchmark_throughput.md
@@ -6,7 +6,9 @@ Throughput was measured using a reproducible three-duration load test series aga
 Docker deployment. The same test was run at 1 minute, 5 minutes, and 10 minutes to confirm
 that throughput is stable over time — not a short burst that degrades.
 
-**Full results and raw data:** `tests/load-test-results.md` (latest run: 2026-03-27)
+**Full results and raw data:** `tests/load-test-results.md` (latest run: 2026-03-27, engine v1.8.7)
+
+> **Note:** these figures pre-date the 2.5.0 conformance changes (strict-schema / `allowed_fields`, explicit presence, unanchored regex search), which altered the single-record hot path. Treat them as an order-of-magnitude baseline; a re-run on the current engine is pending.
 
 ## Test environment
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-> **Last reviewed:** 2026-04-11.
+> **Last reviewed:** 2026-09-03 (engine 2.7.0).
 > Covers every subcommand in `opendqv/cli.py`. Run `opendqv --help` or `python -m opendqv.cli --help` for the same information inline.
 
 OpenDQV ships a standalone CLI for contract management, validation, imports, exports, lifecycle governance, and code generation. All commands operate on the local filesystem and SQLite database — no running API server is required.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # CLI Reference
 
 > **Last reviewed:** 2026-04-11.
-> Covers all 20 commands available in `cli.py`. Run `opendqv --help` or `python -m opendqv.cli --help` for the same information inline.
+> Covers every subcommand in `opendqv/cli.py`. Run `opendqv --help` or `python -m opendqv.cli --help` for the same information inline.
 
 OpenDQV ships a standalone CLI for contract management, validation, imports, exports, lifecycle governance, and code generation. All commands operate on the local filesystem and SQLite database — no running API server is required.
 
@@ -25,7 +25,7 @@ python -m opendqv.cli <command> [options]
 
 ```bash
 opendqv --version
-# opendqv 2.1.0
+# opendqv <engine-version>
 # Trust is easier to build than to repair.
 ```
 
@@ -35,9 +35,9 @@ opendqv --version
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `OPENDQV_CONTRACTS_DIR` | `./contracts` | Directory where YAML contract files are read from and written to |
+| `OPENDQV_CONTRACTS_DIR` | the bundled `opendqv/contracts/` package directory | Directory where YAML contract files are read from and written to |
 | `OPENDQV_DB_PATH` | `opendqv.db` | Path to the SQLite database (contract history, audit chain) |
-| `OPENDQV_AUTH_MODE` | `none` | Authentication mode for the API server (`none` or `token`); does not affect CLI directly, but `token-generate` writes to the same DB |
+| `AUTH_MODE` | `open` | Authentication mode for the API server (`open` or `token`); does not affect CLI directly, but `token-generate` writes to the same DB |
 
 ---
 
@@ -45,7 +45,7 @@ opendqv --version
 
 | Command | Arguments | Flags | Description |
 |---|---|---|---|
-| `init` | — | `--dir`, `--force` | Bootstrap a `contracts/` directory with a starter contract |
+| `init` | — | `--dir`, `--force`, `--all` | Bootstrap a `contracts/` directory with a starter contract (`--all` copies every bundled contract) |
 | `list` | — | — | List all contracts with name, version, status, and rule count |
 | `show` | `<contract>` | — | Show contract metadata and a table of all rules with type, field, and severity |
 | `validate` | `<contract> <json>` | `--context` | Validate a JSON record string against a contract; exits 0 on PASS, 1 on FAIL |
@@ -58,6 +58,9 @@ opendqv --version
 | `export-odcs` | `<contract>` | `--context`, `--output`/`-o` | Export contract as ODCS v3.1.0 YAML (validates with `datacontract lint`) |
 | `export-dbt` | `<contract>` | `--context`, `--output`/`-o` | Export contract as a dbt `schema.yml` |
 | `generate` | `<contract> <target>` | `--context` | Generate push-down validation code for `salesforce`, `js`, or `snowflake` |
+| `validate-file` | `<contract> <path>` | `--context`, `--output-failures`, `--observe-only` | Validate a CSV or Parquet file against a contract (no API server required) |
+| `fork` | `<src> <dst>` | `--force` | Copy a contract to a new name as a clean DRAFT v1.0 (preserves comments) |
+| `lint` | `<contract>` | `--format` | Lint a contract YAML for logical errors before deployment |
 | `onboard` | — | — | Launch the interactive setup wizard; first validation in ~90 seconds |
 | `submit-review` | `<contract>` | `--version` (required), `--proposed-by` | Transition a DRAFT contract to REVIEW status |
 | `approve` | `<contract>` | `--version` (required), `--approved-by` | Transition a REVIEW contract to ACTIVE status |
@@ -76,9 +79,18 @@ Bootstraps a `contracts/` directory with a starter contract. Designed for pip us
 
 ```bash
 opendqv init
-# Created contracts/customer.yaml — edit it or add more contracts.
-# Validate: opendqv validate customer '{"name":"Alice","email":"alice@example.com","age":30}'
+#   Created contracts/customer.yaml
+#
+# Next steps:
+#   export OPENDQV_CONTRACTS_DIR=/path/to/contracts
+#   opendqv list
+#   opendqv validate customer '{"name": "Alice", "email": "alice@example.com", "age": 30}'
+#
+# Add more contracts by creating .yaml files in the contracts directory.
+# Or run `opendqv init --all` to copy all bundled regulated contracts.
 ```
+
+Use `--all` to copy every bundled contract instead of the single starter.
 
 Override the target directory:
 
@@ -181,7 +193,7 @@ opendqv import-soda soda_checks.yml
 
 ### `import-csv <file>`
 
-Reads a CSV file where each row defines one rule. The contract name defaults to the CSV filename stem; override with `--name`.
+Reads a CSV file where each row defines one rule. Columns: `field, rule_type, value, severity, error_message` (`value` is the pattern, threshold, or list the rule type needs). The contract name defaults to the CSV filename stem; override with `--name`. The saved contract is `active` at version `1.0`.
 
 ```bash
 opendqv import-csv rules/customer_rules.csv --name customer_v2
@@ -251,7 +263,7 @@ opendqv submit-review customer --version 1.0.0 --proposed-by alice
 
 ### `approve <contract>`
 
-Transitions a `REVIEW` contract to `ACTIVE` status. Once active, a contract is immutable — rule mutations via the API return HTTP 409.
+Transitions a `REVIEW` contract to `ACTIVE` status. Once in `REVIEW` or `ACTIVE`, a contract is immutable — rule mutations via the API return HTTP 409 (reject a `REVIEW` contract back to `DRAFT` to edit it).
 
 ```bash
 opendqv approve customer --version 1.0.0 --approved-by bob
@@ -358,17 +370,18 @@ For live, always-in-sync governance use the API integration rather than generate
 
 ## Worked Workflow: CSV to Active Contract
 
-This example walks through a complete lifecycle: import rules from a spreadsheet, validate a record, promote the contract to active.
+This example walks through a complete lifecycle: import rules from a spreadsheet, validate a record, fork a working copy and promote it through review to active.
 
 **Step 1 — Prepare a CSV rules file.**
 
 Create `customer_rules.csv`:
 
 ```
-name,type,field,min,max,pattern,severity,error_message
-name_required,not_empty,name,,,,,Name is required
-email_format,regex,email,,,^[^@\s]+@[^@\s]+\.[^@\s]+$,error,Invalid email address
-age_range,range,age,18,120,,error,Age must be between 18 and 120
+field,rule_type,value,severity,error_message
+name,not_empty,,error,Name is required
+email,regex,^[^@\s]+@[^@\s]+\.[^@\s]+$,error,Invalid email address
+age,min,18,error,Age must be at least 18
+age,max,120,error,Age must be at most 120
 ```
 
 **Step 2 — Import the CSV.**
@@ -376,9 +389,9 @@ age_range,range,age,18,120,,error,Age must be between 18 and 120
 ```bash
 opendqv import-csv customer_rules.csv --name customer
 # Contract: customer
-# Saved to: contracts/customer.yaml
-# Total rules:    3
-# Imported rules: 3
+# Saved to: /path/to/contracts/customer.yaml
+# Total rules:    4
+# Imported rules: 4
 # Skipped:        0
 ```
 
@@ -387,13 +400,15 @@ opendqv import-csv customer_rules.csv --name customer
 ```bash
 opendqv show customer
 # Contract: customer
-# Version:  1.0.0
-# Status:   draft
+# Version:  1.0
+# Status:   active
+# Owner:    imported-from-csv
 # ...
-#   RULE            TYPE       FIELD   SEVERITY
-#   name_required   not_empty  name    error
-#   email_format    regex      email   error
-#   age_range       range      age     error
+#   RULE            TYPE       FIELD  SEVERITY
+#   name_not_empty  not_empty  name   error
+#   email_regex     regex      email  error
+#   age_min         min        age    error
+#   age_max         max        age    error
 ```
 
 **Step 4 — Test with a valid record.**
@@ -416,16 +431,24 @@ opendqv validate customer '{"name":"","email":"not-an-email","age":15}'
 # Errors:
 #   - [name] Name is required
 #   - [email] Invalid email address
-#   - [age] Age must be between 18 and 120
+#   - [age] Age must be at least 18
 echo $?
 # 1
 ```
 
-**Step 6 — Submit for review.**
+**Step 6 — Fork a DRAFT and submit it for review.**
+
+The CSV importer saves the contract as `active`, so it is usable immediately. To take a change through maker-checker, fork it into a DRAFT first:
 
 ```bash
-opendqv submit-review customer --version 1.0.0 --proposed-by alice
-# Contract 'customer' v1.0.0 submitted for review.
+opendqv fork customer customer_v2
+# Forked customer -> customer_v2
+#   Source: /path/to/contracts/customer.yaml
+#   New:    /path/to/contracts/customer_v2.yaml
+#
+# The new contract is DRAFT at version 1.0.
+opendqv submit-review customer_v2 --version 1.0 --proposed-by alice
+# Contract 'customer_v2' v1.0 submitted for review.
 #   Status   : review
 #   Proposed : alice
 ```
@@ -433,8 +456,8 @@ opendqv submit-review customer --version 1.0.0 --proposed-by alice
 **Step 7 — Approve the contract.**
 
 ```bash
-opendqv approve customer --version 1.0.0 --approved-by bob
-# Contract 'customer' v1.0.0 approved.
+opendqv approve customer_v2 --version 1.0 --approved-by bob
+# Contract 'customer_v2' v1.0 approved.
 #   Status    : active
 #   Approved  : bob
 ```

--- a/docs/code_generation.md
+++ b/docs/code_generation.md
@@ -26,7 +26,8 @@ curl -s -X POST "http://localhost:8000/api/v1/generate" \
   -H "Authorization: Bearer <token>" \
   -G --data-urlencode "contract_name=salesforce_contact" \
      --data-urlencode "target=salesforce" \
-     --data-urlencode "context=salesforce_prod"
+     --data-urlencode "context=salesforce_prod"   # optional; the bundled contract declares no contexts —
+                                                  # see examples/contexts/salesforce_contact.yaml
 
 # JavaScript (Node.js, browser, etc.)
 curl -s -X POST "http://localhost:8000/api/v1/generate" \
@@ -61,7 +62,7 @@ curl -s -X POST "http://localhost:8000/api/v1/generate" \
 python -m opendqv.cli generate <contract> <target> [--context <context>]
 
 # Examples
-python -m opendqv.cli generate salesforce_contact salesforce --context salesforce_prod
+python -m opendqv.cli generate salesforce_contact salesforce   # add --context salesforce_prod with examples/contexts/salesforce_contact.yaml loaded
 python -m opendqv.cli generate customer js
 python -m opendqv.cli generate customer snowflake
 ```

--- a/docs/compliance-contracts.md
+++ b/docs/compliance-contracts.md
@@ -1,7 +1,7 @@
 # Compliance Contracts Reference
 
 OpenDQV ships 41 production-ready contracts in `opendqv/contracts/` (installed with the
-wheel; a mirror of the OpenDQV Cloud golden library — see `library_manifest.json`) covering agriculture, automotive,
+wheel; a mirror of the OpenDQV Cloud golden library — see `library_manifest.json` at the repo root) covering agriculture, automotive,
 banking, building safety, corporate compliance, data protection, education, energy, financial
 controls, FMCG, food safety, healthcare, HR, insurance, logistics, manufacturing, media,
 pharma, public safety, public sector, real estate, retail, telecoms, travel, water utility,

--- a/docs/compliance-contracts.md
+++ b/docs/compliance-contracts.md
@@ -1,12 +1,14 @@
 # Compliance Contracts Reference
 
-OpenDQV ships 41 production-ready contracts in `contracts/` covering agriculture, automotive,
+OpenDQV ships 41 production-ready contracts in `opendqv/contracts/` (installed with the
+wheel; a mirror of the OpenDQV Cloud golden library — see `library_manifest.json`) covering agriculture, automotive,
 banking, building safety, corporate compliance, data protection, education, energy, financial
 controls, FMCG, food safety, healthcare, HR, insurance, logistics, manufacturing, media,
 pharma, public safety, public sector, real estate, retail, telecoms, travel, water utility,
 and more — across UK, EU, and US regulatory frameworks.
 
-17 minimal starter templates are in `examples/starter_contracts/`.
+17 industry starter templates are in `examples/starter_contracts/` — they are not loaded
+by default; copy the ones you need into `$OPENDQV_CONTRACTS_DIR`.
 
 See [docs/community_use_cases.md](community_use_cases.md) for real-world examples by industry.
 
@@ -19,25 +21,25 @@ See [docs/community_use_cases.md](community_use_cases.md) for real-world example
 | `customer` | General customer validation (email, age, name, phone, etc.) | — (worked example with `kids_app` / `financial` in `examples/contexts/`) | — |
 | `salesforce_contact` | Salesforce Contact — 18 validation criteria, production-grade | — (example in `examples/contexts/`) | Sentinel date rejection |
 | `salesforce_lead` | Salesforce Lead — 16 validation criteria with lead-specific checks | — (example in `examples/contexts/`) | — |
-| `proof_of_play` | **Reference contract: OOH advertising impression validation** | `billing`, `operations` | Cross-field rules, conditional constraints, context-aware billing thresholds |
+| `proof_of_play` | **Reference contract: OOH advertising impression validation** | — (`billing` / `operations` example in `examples/contexts/proof_of_play.yaml`) | Cross-field rules, conditional constraints, context-aware billing thresholds |
 | `social_media_age_compliance` | UK Online Safety Act / Ofcom age assurance — 13+ age gate, DOB consistency, identity verification audit trail | — | `age_match` rule, identity verification lookup, verification timestamp |
 | `ppds_menu_item` | Natasha's Law (PPDS) allergen compliance — all 14 major allergens must be explicitly declared before a QSR menu item is saved or labelled | — | 14 mandatory boolean fields, `required_if` for gluten/tree-nut type, sulphite threshold, audit trail |
 | `martyns_law_venue` | Martyn's Law (Terrorism (Protection of Premises) Act 2025) — venue terrorism preparedness compliance, two-tier (standard/enhanced), mandatory SRP and SIA registration for 800+ capacity venues | — | Two-tier `required_if` enforcement, capacity minimum, enhanced-duty field gate, audit trail |
-| `martyns_law_event` | Martyn's Law — qualifying events (temporary/one-off, 200+ expected attendance). Organiser-centric; SIA notification not registration; staff briefing not training; time-bounded with start/end dates | — | Distinct from venue contract: `sia_notification_reference` not `sia_registration_number`; event dates required |
+| `martyns_law_event` | Martyn's Law — qualifying events (temporary/one-off, 800+ expected attendance, s.3(1)(d); there is no 200-person tier for events, so every qualifying event carries the enhanced-level duties). Responsible-person-centric; SIA notification not registration; staff briefing not training; time-bounded with start/end dates | — | Distinct from venue contract: no `duty_tier`, `expected_attendance` min 800, `sia_notification_reference` not `sia_registration_number`; event dates required |
 | `building_safety_golden_thread` | Building Safety Act 2022 — Golden Thread compliance for higher-risk buildings (18m+ / 7+ storeys). Enforces accountable person, BSR registration, safety case, and golden thread audit trail at point of write | — | Named accountable person + BSM mandatory, BSR registration gate, `required_if safety_case_documented = true` |
 | `companies_house_filing` | Economic Crime and Corporate Transparency Act 2023 — identity verification for Companies House director and PSC filings. A missing verification field blocks the record before submission | — | `required_if id_verification_completed = true` gates method, date, and verifier; role and method lookups |
 | `gdpr_processing_record` | UK GDPR Article 30 — Record of Processing Activities (ROPA). Enforces lawful basis declaration, consent-specific fields, legitimate interests assessment, special category data basis, and international transfer safeguard at the point of write | — | All 6 Article 6 lawful bases via lookup; consent/LIA/special-category/transfer fields via `required_if`; DPO audit trail |
 | `gdpr_dsar_request` | UK GDPR Article 15 — Data Subject Access Request handling. Enforces 30-day deadline recording, identity verification gate, extension logic, and outcome tracking before a request enters the case management workflow | — | 30-day deadline field required at intake; `required_if` for verification method, extension reason, and refusal reason |
 | `eu_gdpr_processing_record` | EU GDPR Article 30 — Record of Processing Activities (ROPA). EU variant with EU Standard Contractual Clauses, 27-DPA supervisory authority lookup, and EU adequacy decision list | — | EU transfer safeguards and supervisory authority lookup; otherwise identical pattern to UK GDPR |
 | `eu_gdpr_dsar_request` | EU GDPR Article 15 — Data Subject Access Request handling. EU variant with €20M / 4% turnover penalty references and EU supervisory authority | — | Same enforcement pattern as UK GDPR DSAR; fines referenced in EUR |
-| `dora_ict_incident` | EU DORA (Digital Operational Resilience Act) Articles 17-19 — ICT incident report for financial entities. In force 17 January 2025. Enforces incident classification, statutory reporting timelines (24h / 72h / 30 days), and root cause documentation | — | `date_diff` enforces 24h early warning and 72h notification windows; `required_if` for root_cause when major/significant |
+| `dora_ict_incident` | EU DORA (Digital Operational Resilience Act) Articles 17-19 — ICT incident report for financial entities. In force 17 January 2025. Enforces incident classification, the major-incident reporting clock of CDR (EU) 2025/301 (initial notification, intermediate report, final report), and root cause documentation | — | Reporting fields `required_if` classification is `major`; `date_diff` enforces initial notification within 24 h of awareness *and* 4 h of major classification (`max: 0.16667` days), intermediate report within 72 h of the initial notification, final report within 31 days |
 | `hipaa_disclosure_accounting` | US HIPAA 45 CFR 164.528 — Accounting of Disclosures. Enforces complete disclosure records before they enter covered entity systems. OCR penalties up to $2.1M/year | — | `required_if` for authorization_reference when patient_authorization; minimum_necessary_applied boolean gated on non-treatment purposes |
 | `sox_control_test` | US Sarbanes-Oxley Act 2002, Sections 302/404 — Internal control test record. CEO/CFO personal certification liability. Enforces deficiency classification and remediation plan completeness before control test records are saved | — | Three-level `required_if` cascade: test_result → deficiency_classification → remediation plan + audit committee escalation |
-| `mifid_transaction_report` | MiFID II / MiFIR Article 26 — Transaction reporting for investment firms and trading venues. Enforces LEI, ISIN, and venue MIC format at point of write before submission to an Approved Reporting Mechanism | — | LEI regex (`^[A-Z0-9]{18}[0-9]{2}$`), ISIN regex, MIC regex; buyer/seller ID type lookups |
+| `mifid_transaction_report` | MiFID II / MiFIR Article 26 — Transaction reporting for investment firms and trading venues. Enforces LEI and ISIN check digits and venue MIC membership at point of write before submission to an Approved Reporting Mechanism | — | `checksum` (`lei_mod97`, `isin_luhn`) on reporting/executing entity and instrument; venue MIC `lookup` against ISO 10383; buyer/seller ID type lookup (RTS 22: `LEI NIDN CCPT CONCAT MIC INTC`); `transaction_type` `BUYI`/`SELL`; `price >= 0`, `quantity > 0` |
 
 For the remaining 25+ contracts (agriculture, automotive, energy, HR, insurance, logistics,
 manufacturing, media, pharma, real estate, telecoms, travel, water utility, and more) see
-the [`contracts/`](../contracts/) directory directly.
+the [`opendqv/contracts/`](../opendqv/contracts/) directory directly.
 
 ---
 
@@ -59,9 +61,12 @@ is structurally impossible and triggers a 422 before the record enters the syste
 ### Martyn's Law (Royal Assent 3 April 2025)
 
 The `martyns_law_venue` and `martyns_law_event` contracts enforce terrorism preparedness
-compliance for venues and events with a capacity of 200 or more. Enhanced-duty premises (800+)
-must declare a named Senior Responsible Person, SIA registration/notification reference, and
-Terrorism Protection Plan — omission triggers a 422 before the record enters the system. Named
+compliance. Venues qualify at a capacity of 200 or more (two tiers: standard 200–799, enhanced
+800+, declared in `duty_tier`); enhanced-duty premises must declare a named designated senior
+individual, SIA notification reference, and public protection measures. Qualifying *events* are
+those where 800 or more individuals may be present (s.3(1)(d)) — there is no 200-person tier for
+events, so the event contract has no `duty_tier` and every qualifying event carries the
+enhanced-level duties. Omission triggers a 422 before the record enters the system. Named
 after Martyn Hett (1987–2017), killed in the Manchester Arena attack. See
 [docs/integrations/martyns-law-compliance.md](integrations/martyns-law-compliance.md).
 
@@ -100,9 +105,12 @@ data of EU residents.
 
 `dora_ict_incident` enforces ICT incident reporting completeness for EU financial entities.
 Incident classification, affected services, and root cause are mandatory before an incident
-record enters a case management system. The `date_diff` rule enforces DORA's statutory
-reporting windows: 24-hour early warning and 72-hour initial notification from the moment of
-becoming aware.
+record enters a case management system. For incidents classified `major`, the reporting
+fields become `required_if` and `date_diff` rules enforce the clock set by CDR (EU) 2025/301:
+initial notification within 24 hours of becoming aware and within 4 hours of classifying the
+incident as major (`max: 0.16667` days — the fractional `date_diff` added in 2.7.0),
+intermediate report within 72 hours of the initial notification, and final report within 31
+days of the intermediate report.
 
 ### US HIPAA — 45 CFR 164.528
 
@@ -123,8 +131,11 @@ companies).
 ### MiFID II / MiFIR Article 26
 
 `mifid_transaction_report` enforces transaction reporting completeness for investment firms and
-trading venues. LEI, ISIN, and venue MIC codes are format-validated at point of write before
-submission to an Approved Reporting Mechanism. Applies across EU and UK markets.
+trading venues. LEI and ISIN are check-digit validated (`checksum`: `lei_mod97`, `isin_luhn`),
+venue MIC is checked against the ISO 10383 list, buyer/seller identifier types against the
+RTS 22 code set (`LEI NIDN CCPT CONCAT MIC INTC`), `transaction_type` must be `BUYI` or `SELL`,
+and `price >= 0` / `quantity > 0` — all at point of write before submission to an Approved
+Reporting Mechanism. Applies across EU and UK markets.
 
 ---
 
@@ -136,4 +147,4 @@ and conditional constraints. It demonstrates:
 - `compare` rule: `impression_end` must be strictly after `impression_start` (catches phantom billing from inverted timestamps)
 - `required_if` rule: `refresh_rate_hz` required only when `panel_type == DIGITAL`
 - `condition` block: revenue floor applied only to `CHARGE` records, not `CREDIT` notes
-- Two contexts: `billing` (all warnings become errors) and `operations` (relaxed thresholds for dashboards)
+- Contexts: the bundled contract carries none (no bundled contract does — 2.7.0 library mirror); the `billing` (all warnings become errors) and `operations` (relaxed thresholds for dashboards) worked example lives in `examples/contexts/proof_of_play.yaml`

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -316,4 +316,4 @@ curl -s -X DELETE "http://localhost:8000/api/v1/quality/stats?context=demo" \
 ## See also
 
 - [docs/naming_conventions.md](naming_conventions.md) — naming conventions for contracts, rules, and fields
-- [contracts/customer.yaml](../examples/contexts/customer.yaml) — the reference contract with live `contexts:` examples
+- [examples/contexts/customer.yaml](../examples/contexts/customer.yaml) — the reference contract with live `contexts:` examples

--- a/docs/contract_versioning.md
+++ b/docs/contract_versioning.md
@@ -12,6 +12,23 @@ The system does **not** validate that version strings follow semver, and it does
 
 ---
 
+## Creating a New Version
+
+`POST /contracts/{name}/version?new_version=<v>` creates the
+new version as a **separate contract object with its own file**, `{name}_v{version}.yaml`,
+in DRAFT status with the approval trail cleared. The version it was copied from is not
+modified and keeps serving validation until the new version is approved. The request is
+rejected with `400` if that version — or a file for it — already exists, and the version
+string must match `[A-Za-z0-9][A-Za-z0-9._-]{0,49}`. The copy is lossless: rules, `contexts:`,
+`strict_schema` / `allowed_fields` and every other key carry over.
+
+Rule mutations are only accepted while the new version is DRAFT. Once it is submitted for
+review (`/contracts/{name}/{version}/submit-review`) it is immutable — the registry returns
+`409` on every surface — until an approver approves it (`/approve`) or rejects it back to
+DRAFT (`/reject`). Activation archives the previously ACTIVE version of the same name.
+
+---
+
 ## In-Flight Semantics
 
 Active version resolves at request time: when a validation request arrives, OpenDQV looks up the currently `ACTIVE` version of the named contract and applies its rules. The resolved version is recorded in the response (`"version"` field) and in the audit log entry for that request.

--- a/docs/custom_rules.md
+++ b/docs/custom_rules.md
@@ -1,9 +1,9 @@
 # Adding a Custom Rule Type
 
-> **Last reviewed:** 2026-03-17.
+> **Last reviewed:** 2026-09-03 (engine 2.7.0).
 > Covers the four files you need to touch, a complete worked example (`phone_e164`), and pointers to existing rule implementations you can copy from.
 
-OpenDQV's rule dispatch is an explicit `if/elif` chain. There is no plugin registry. Adding a new rule type means editing source files — the tradeoff is that every rule type is trivially grep-able and auditable.
+OpenDQV's rule dispatch is a module-level table, `_RULE_HANDLERS` in `opendqv/core/validator.py`, mapping a type name to a `_check_<type>(value, rule, record)` function. There is no plugin registry. Adding a new rule type means editing source files — the tradeoff is that every rule type is trivially grep-able and auditable.
 
 ---
 
@@ -11,18 +11,19 @@ OpenDQV's rule dispatch is an explicit `if/elif` chain. There is no plugin regis
 
 Adding a rule type requires changes to **three files**, or four if you want push-down code generation:
 
-1. `core/rule_parser.py` — add optional config fields to the `Rule` Pydantic model.
-2. `core/validator.py` (`_check_rule`) — add an `elif` branch for single-record validation.
-3. `core/validator.py` (`_batch_check_rule`) — add a corresponding DuckDB branch for batch validation.
-4. `core/code_generator.py` *(optional)* — add a branch to emit Apex / JS / Snowflake code.
+1. `opendqv/core/rule_parser.py` — add optional config fields to the `Rule` Pydantic model.
+2. `opendqv/core/validator.py` — write `_check_<type>()` and register it in `_RULE_HANDLERS`.
+3. `opendqv/core/validator.py` (`_batch_check_rule_inner`) — add a corresponding DuckDB branch for batch validation.
+4. `opendqv/core/linter.py` — add the type to `_KNOWN_RULE_TYPES` so `opendqv lint` does not report `UNKNOWN_RULE_TYPE`.
+5. `opendqv/core/code_generator.py` *(optional)* — add a branch to emit Apex / JS / Snowflake code.
 
 All changes are additive. Existing behaviour is unaffected.
 
 ---
 
-## Step 1: `core/rule_parser.py` — Add Model Fields
+## Step 1: `opendqv/core/rule_parser.py` — Add Model Fields
 
-Open `core/rule_parser.py` and add optional fields to the `Rule` Pydantic model for any configuration parameters your rule needs. Use `Optional[<type>] = None` so that contracts that do not use your rule are unaffected.
+Open `opendqv/core/rule_parser.py` and add optional fields to the `Rule` Pydantic model for any configuration parameters your rule needs. Use `Optional[<type>] = None` so that contracts that do not use your rule are unaffected.
 
 Also add your rule type to the module-level docstring's supported types list so that `show` and the governance workbench display it correctly.
 
@@ -47,73 +48,65 @@ No Pydantic import changes are needed — `Optional` is already imported.
 
 ---
 
-## Step 2: `core/validator.py` — `_check_rule()`
+## Step 2: `opendqv/core/validator.py` — handler + `_RULE_HANDLERS`
 
-Open `core/validator.py` and add an `elif` branch inside `_check_rule()`. The function returns the rule's `error_message` string on failure and `None` on success.
+Open `opendqv/core/validator.py` and write a `_check_phone_e164(value, rule, record)` function next to the other `_check_*` handlers. A handler returns the rule's `error_message` string on failure and `None` on success. Then register it in the `_RULE_HANDLERS` dict — `_check_rule()` dispatches through that table and logs an `Unknown rule type` warning (and passes the record) for anything not in it.
 
-Place your branch before the final catch-all warning block near line 720. The catch-all logs an `Unknown rule type` warning for any unrecognised type, so your new type must appear before it.
+You do not need to guard against a missing value: `_check_rule()` applies D6 (blank-is-absent) before calling any handler, so an absent or whitespace-only value never reaches you. Keep the `_is_field_absent(value)` guard only if your handler can be called directly from elsewhere. Compile patterns with the `regex` library and match through `_safe_match(compiled, str_val)`, which applies the ReDoS timeout (SEC-001); note that the engine's own `regex` rule is an unanchored search, so anchor deliberately.
 
 ```python
-if rule.type == "phone_e164":
-    if value is None or (isinstance(value, str) and value.strip() == ""):
-        # Treat missing/empty as a separate not_empty concern; phone_e164 passes silently.
-        return None
-    import re as _re
+# validator.py already imports the ReDoS-safe library as `_regex_lib` (SEC-001)
+
+_E164 = _regex_lib.compile(r"^\+[1-9]\d{7,14}$")
+# Allow optional extension suffix: +14155550100x123 or +14155550100 ext 123
+_E164_EXT = _regex_lib.compile(r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$")
+
+
+def _check_phone_e164(value, rule: Rule, record: dict | None = None) -> str | None:
+    if _is_field_absent(value):
+        return None  # D6 — presence is a separate not_empty concern
     str_val = str(value).strip()
-    # E.164: + followed by 1-3 digit country code, then 7-12 digits (total 8-15 digits after +)
-    base_pattern = r"^\+[1-9]\d{7,14}$"
-    if rule.allow_extensions:
-        # Allow optional extension suffix: +14155550100x123 or +14155550100 ext 123
-        pattern = r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$"
-    else:
-        pattern = base_pattern
-    if not _re.match(pattern, str_val):
+    compiled = _E164_EXT if rule.allow_extensions else _E164
+    if not _safe_match(compiled, str_val):
         return rule.error_message
     return None
+
+
+_RULE_HANDLERS: dict[str, Callable] = {
+    "not_empty": _check_not_empty,
+    # ...existing entries...
+    "phone_e164": _check_phone_e164,   # <- add here
+}
 ```
 
 **Contract:** return `None` on success, return `rule.error_message` (a `str`) on failure. Never raise. If required configuration is missing, log a warning and return `None` (pass silently) rather than raising — this prevents a misconfigured rule from blocking unrelated fields.
 
 ---
 
-## Step 3: `core/validator.py` — `_batch_check_rule()`
+## Step 3: `opendqv/core/validator.py` — `_batch_check_rule_inner()`
 
-The `_batch_check_rule()` function runs the same rule against a batch via DuckDB. Add a corresponding `elif` branch. Use parameterised queries where possible.
+The batch SQL lives in `_batch_check_rule_inner()` (`_batch_check_rule()` is the wrapper that records timing and failure bookkeeping around it). It runs the same rule against a batch via DuckDB. Add a corresponding `elif` branch. Use parameterised queries where possible.
 
 For rules whose logic is too complex for SQL (multi-step lookups, external calls, complex regex), fall back to a Python loop — as the `regex` and `compare` rules do. Never use f-string interpolation for user-supplied values in SQL; use DuckDB's `$param` binding or Python pre-computation.
 
 ```python
 elif rule.type == "phone_e164":
     # Fall back to Python — regex with optional extension suffix is simpler to maintain here.
-    import re as _re
-    if rule.allow_extensions:
-        pat = _re.compile(r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$")
-    else:
-        pat = _re.compile(r"^\+[1-9]\d{7,14}$")
+    pat = _E164_EXT if rule.allow_extensions else _E164
     for idx, val in enumerate(df[field]):
-        if val is None:
-            continue  # missing values pass; use not_empty to enforce presence
-        if not pat.match(str(val).strip()):
+        if _is_field_absent(val):
+            continue  # D6 — missing/blank values pass; use not_empty to enforce presence
+        if not _safe_match(pat, str(val).strip()):
             failing.add(idx)
 ```
 
-Add this branch after the existing `elif rule.type == "max_length"` block and before the `elif rule.type == "date_format"` block to keep numeric/string/format rules grouped together.
+Add this branch after the existing `elif rule.type == "max_length"` block and before the `elif rule.type == "date_format"` block to keep numeric/string/format rules grouped together. Single-record and batch paths must agree on every input — that is a conformance guarantee, so add a test that runs the same records through both.
 
-Also add `"phone_e164"` to the exhaustive type list in the final catch-all block of `_check_rule()` (around line 720) so the unknown-type warning is not emitted:
-
-```python
-if rule.type not in ("not_empty", "regex", "min", "max", "range", "min_length",
-                      "max_length", "date_format", "unique", "compare",
-                      "required_if", "lookup", "checksum", "cross_field_range",
-                      "field_sum", "forbidden_if", "conditional_value",
-                      "date_diff", "ratio_check", "conditional_lookup",
-                      "geospatial_bounds", "age_match", "phone_e164"):  # <- add here
-    logger.warning("Unknown rule type '%s' for rule '%s'", rule.type, rule.name)
-```
+Then add `"phone_e164"` to `_KNOWN_RULE_TYPES` in `opendqv/core/linter.py`, otherwise `opendqv lint` reports `UNKNOWN_RULE_TYPE` (a lint error) on every contract that uses it.
 
 ---
 
-## Step 4 (Optional): `core/code_generator.py`
+## Step 4 (Optional): `opendqv/core/code_generator.py`
 
 To emit the rule as push-down code, add a branch to `_js_rule_check()` (shared by the `js` and `snowflake` targets) and a separate branch in `_generate_salesforce()`.
 
@@ -179,7 +172,7 @@ rules:
     error_message: "Support phone should be E.164 format; extensions permitted"
 ```
 
-### `core/rule_parser.py` — model field
+### `opendqv/core/rule_parser.py` — model field
 
 ```python
 # Phone E.164 validation — type: phone_e164
@@ -193,36 +186,32 @@ phone_e164         — field must be a valid E.164 phone number (+[1-3 digit cc]
                      set allow_extensions: true to permit trailing extension suffixes
 ```
 
-### `core/validator.py` — `_check_rule()`
+### `opendqv/core/validator.py` — handler + `_RULE_HANDLERS` entry
 
 ```python
-if rule.type == "phone_e164":
-    if value is None or (isinstance(value, str) and value.strip() == ""):
+_E164 = _regex_lib.compile(r"^\+[1-9]\d{7,14}$")
+_E164_EXT = _regex_lib.compile(r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$")
+
+def _check_phone_e164(value, rule: Rule, record: dict | None = None) -> str | None:
+    if _is_field_absent(value):
         return None
-    import re as _re
-    str_val = str(value).strip()
-    if rule.allow_extensions:
-        pattern = r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$"
-    else:
-        pattern = r"^\+[1-9]\d{7,14}$"
-    if not _re.match(pattern, str_val):
+    compiled = _E164_EXT if rule.allow_extensions else _E164
+    if not _safe_match(compiled, str(value).strip()):
         return rule.error_message
     return None
+
+_RULE_HANDLERS["phone_e164"] = _check_phone_e164   # i.e. add the entry to the dict literal
 ```
 
-### `core/validator.py` — `_batch_check_rule()`
+### `opendqv/core/validator.py` — `_batch_check_rule_inner()`
 
 ```python
 elif rule.type == "phone_e164":
-    import re as _re
-    if rule.allow_extensions:
-        pat = _re.compile(r"^\+[1-9]\d{7,14}(\s*(x|ext\.?)\s*\d{1,6})?$")
-    else:
-        pat = _re.compile(r"^\+[1-9]\d{7,14}$")
+    pat = _E164_EXT if rule.allow_extensions else _E164
     for idx, val in enumerate(df[field]):
-        if val is None:
+        if _is_field_absent(val):
             continue
-        if not pat.match(str(val).strip()):
+        if not _safe_match(pat, str(val).strip()):
             failing.add(idx)
 ```
 

--- a/docs/datahub_integration.md
+++ b/docs/datahub_integration.md
@@ -11,7 +11,7 @@ OpenDQV and DataHub serve complementary roles: OpenDQV validates data at the sou
 ## Design Goals
 
 1. **Contract-first** — OpenDQV contracts are the source of truth; DataHub reflects their state, not the reverse
-2. **Incremental** — use `contract_hash` to skip unchanged contracts and avoid redundant API calls
+2. **Incremental** — use `schema_hash` to skip unchanged contracts and avoid redundant API calls
 3. **Federation-aware** — check `/federation/status` before pulling contracts from a federated node
 4. **Non-invasive** — no changes to OpenDQV internals; integration lives entirely in a thin sync script or connector
 
@@ -40,7 +40,7 @@ Push every active OpenDQV contract into DataHub as a dataset entity with `Datase
 | `name` | `DatasetProperties.name`; also used in `DatasetUrn` |
 | `description` | `DatasetProperties.description` |
 | `version` | `DatasetProperties.customProperties["contract_version"]` |
-| `contract_hash` | `DatasetProperties.customProperties["contract_hash"]` |
+| `schema_hash` | `DatasetProperties.customProperties["schema_hash"]` |
 | `owner` | `Ownership.owners[0].owner` (`TECHNICAL_OWNER`) |
 | `owner_team` | `Ownership.owners[1].owner` via `make_group_urn` |
 | `owner_email` | `DatasetProperties.customProperties["owner_email"]` |
@@ -73,7 +73,7 @@ emitter = DatahubRestEmitter(
 contracts = requests.get(
     f"{OPENDQV_URL}/api/v1/registry",
     headers={"Authorization": f"Bearer {OPENDQV_TOKEN}"},
-).json()
+).json()["registry"]
 
 for contract in contracts:
     # Skip archived contracts
@@ -91,7 +91,7 @@ for contract in contracts:
 
     custom_props = {
         "contract_version": contract.get("version", ""),
-        "contract_hash":    contract.get("contract_hash", ""),
+        "schema_hash":    contract.get("schema_hash", ""),
         "contract_status":  contract.get("status", ""),
         "owner_email":      contract.get("owner_email", ""),
     }
@@ -263,7 +263,7 @@ Map OpenDQV contract rules to DataHub Assertion entities for richer governance v
 
 ---
 
-## Approach 5 — Incremental Sync with `contract_hash`
+## Approach 5 — Incremental Sync with `schema_hash`
 
 Avoid pushing unchanged contracts by persisting the last-seen hash in a local state file.
 
@@ -287,12 +287,12 @@ state = load_state()
 contracts = requests.get(
     "http://localhost:8000/api/v1/registry",
     headers={"Authorization": f"Bearer {OPENDQV_TOKEN}"},
-).json()
+).json()["registry"]
 
 synced, skipped = 0, 0
 for contract in contracts:
     name = contract["name"]
-    current_hash = contract.get("contract_hash", "")
+    current_hash = contract.get("schema_hash", "")
     if state.get(name) == current_hash:
         skipped += 1
         continue

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -65,12 +65,16 @@ range failures, …); the `RULE_NAME` segment lets you route on the specific rul
       "rule": "valid_email",
       "message": "email must match pattern ^[\\w.+-]+@[\\w-]+\\.[\\w.]+$",
       "severity": "error",
-      "error_code": "OPENDQV_REGEX_VALID_EMAIL"
+      "error_code": "OPENDQV_REGEX_VALID_EMAIL",
+      "suggested_fix": "Check the expected format in the error message and match it exactly.",
+      "counterpart_missing": null
     }
   ],
   "warnings": []
 }
 ```
+
+`counterpart_missing` is `true` on a cross-field failure (`compare`, `field_sum`, `ratio_check`, `date_diff`, `cross_field_range`, …) whose counterpart field was absent or blank; `null` otherwise.
 
 ---
 
@@ -128,4 +132,4 @@ Code matching `OPENDQV_<TYPE>_001` no longer exists.
 
 ## `OPENDQV_ADDITIONAL_PROPERTIES`
 
-Emitted once per record by a contract with `strict_schema: true` when the record carries fields the contract does not declare. `field` is empty, `rule` is `additional_properties`, and the message names every unknown field. Fix the producer, add a rule for the field, or list it under the contract's `fields:` allow-list. See `docs/strict_schema.md`.
+Emitted once per record by a contract with `strict_schema: true` when the record carries fields the contract does not declare. `field` is empty, `rule` is `additional_properties`, and the message names every unknown field. Fix the producer, add a rule for the field, or list it under the contract's `allowed_fields:` allow-list. See `docs/strict_schema.md`.

--- a/docs/gx_integration.md
+++ b/docs/gx_integration.md
@@ -39,7 +39,7 @@ If your team already has GX expectation suites, use them to bootstrap OpenDQV co
 curl -s -X POST http://localhost:8000/api/v1/import/gx \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
-  -d '{"suite_json": "<contents of your GX expectation suite JSON>"}' \
+  -d @path/to/expectation_suite.json \
   | jq .yaml
 
 # Via CLI
@@ -263,9 +263,9 @@ See [`webhooks.md`](webhooks.md) for full webhook configuration options.
 
 ---
 
-## Approach 5 — Incremental via `contract_hash`
+## Approach 5 — Incremental via `schema_hash`
 
-Avoid re-exporting GX suites for contracts that have not changed. Poll `GET /api/v1/registry` and compare `contract_hash`:
+Avoid re-exporting GX suites for contracts that have not changed. Poll `GET /api/v1/registry` and compare `schema_hash`:
 
 ```python
 import requests, json, subprocess
@@ -275,11 +275,11 @@ REGISTRY_URL = "http://localhost:8000/api/v1/registry"
 HASH_STORE = Path(".gx_export_hashes.json")
 
 known_hashes = json.loads(HASH_STORE.read_text()) if HASH_STORE.exists() else {}
-contracts = requests.get(REGISTRY_URL, headers={"Authorization": "Bearer <token>"}).json()
+contracts = requests.get(REGISTRY_URL, headers={"Authorization": "Bearer <token>"}).json()["registry"]
 
 for contract in contracts:
     name = contract["name"]
-    current_hash = contract["contract_hash"]
+    current_hash = contract["schema_hash"]
 
     if known_hashes.get(name) == current_hash:
         continue  # unchanged — skip
@@ -312,7 +312,7 @@ for region, base_url in INSTANCES.items():
     contracts = requests.get(
         f"{base_url}/api/v1/registry",
         headers={"Authorization": "Bearer <token>"},
-    ).json()
+    ).json()["registry"]
     for contract in contracts:
         subprocess.run(
             ["opendqv", "--url", base_url,

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,17 @@ Short visual walkthroughs of OpenDQV in action across the integrations it suppor
 | `unique` | No duplicate values in batch (batch mode only) |
 | `min_age` / `max_age` | Date field implies age constraint |
 | `compare` | **Cross-field:** `field` op `compare_to` (gt, lt, gte, lte, eq, neq) |
-| `required_if` | **Conditional:** field required when another field equals a value |
+| `required_if` / `forbidden_if` | **Conditional:** field required (or forbidden) when another field equals a value |
+| `conditional_value` | **Conditional:** field must hold a given value when another field holds a given value |
 | `lookup` | **Reference:** value must appear in a file (txt, CSV) or HTTP endpoint |
+| `allowed_values` | Value must be in a fixed list |
+| `checksum` | Check-digit integrity: IBAN, GTIN/GS1, NHS, ISIN, LEI, VIN, CPF, ISRC |
+| `cross_field_range` | Value must lie between two other fields in the same record |
+| `field_sum` | Sum of named fields must equal a target (within optional tolerance) |
+| `ratio_check` | Ratio of two numeric fields within a range |
+| `date_diff` | Difference between two date fields within a range |
+| `age_match` | Declared age consistent with a date-of-birth field |
+| `geospatial_bounds` | Lat/lon pair within a bounding box |
 
 ### Cross-Field Rules
 
@@ -108,12 +117,12 @@ seconds (default 300). Mount local files via Docker volume for production use.
 | `description` | no | Human-readable summary |
 | `owner` | no | Team or individual responsible — surfaced in error responses for escalation routing |
 | `owner_team` | no | Team identifier for BCBS 239 / governance audit. Synced to Marmot as `contractOwnerTeam` in the OpenLineage quality facet. |
-| `status` | no | `active` (default), `draft`, or `archived` |
+| `status` | no | `active` (default), `draft`, `review`, or `archived` — ACTIVE and REVIEW are immutable |
 | `asset_id` | no | Catalog reference — link to Collibra, Atlan, DataHub, Marmot, or dbt model ref. Required for Marmot lineage push. |
 | `downstream_consumers` | no | List of Marmot MRNs for downstream consumers of this asset (e.g. dashboards, dbt models). `push_quality_lineage.py` stitches direct lineage edges to each consumer automatically. Target MRNs must exist in Marmot. |
 | `catalog_visible` | no | Boolean, default `true`. Set to `false` to exclude this contract from `push_quality_lineage.py` pushes and from Marmot `discover_data` responses via the proxy filter. |
 | `rules` | yes | List of validation rules |
-| `contexts` | no | Per-source-system or per-region rule overrides |
+| `contexts` | no | Per-source-system or per-region rule overrides. No bundled contract declares one; the worked example is `examples/contexts/customer.yaml` |
 
 ### `asset_id` — Catalog Linkage
 
@@ -185,9 +194,9 @@ GET /api/v1/contracts/{name}/history
 
 | Document | Purpose |
 |----------|---------|
-| [API Reference](api_reference.md) | All 50 REST endpoints, batch validation, importers |
+| [API Reference](api_reference.md) | REST endpoints, batch validation, importers |
 | [Python SDK](sdk.md) | Sync/async clients, LocalValidator, guard decorator |
-| [CLI Reference](cli.md) | All 18 CLI commands — validate, import, export, lifecycle, code generation |
+| [CLI Reference](cli.md) | Every CLI command — validate, import, export, lifecycle, code generation |
 | [MCP Server](mcp.md) | Claude Desktop and Cursor integration; contract discovery; write guardrails |
 
 ## Getting Started
@@ -210,7 +219,7 @@ rules, lookup rules, and the `allowed_values` pattern.
 |----------|---------|
 | [Administration](administration.md) | Auth modes, RBAC roles, token management, maker-checker workflow |
 | [Production Deployment](production_deployment.md) | Token auth, TLS, Docker Compose, hardening |
-| [Streamlit Workbench](ui.md) | Governance UI — 12 sections, monitoring, code export, import |
+| [Streamlit Workbench](ui.md) | Governance UI — 13 sections, monitoring, code export, import |
 | [Code Generation](code_generation.md) | Push-down validation for Salesforce, JS, Snowflake, Spark SQL, BigQuery |
 | [Observability](observability.md) | Prometheus metrics, alert rules, trace log, Grafana starter panels |
 | [Runbook](runbook.md) | Deployment, day-2 operations, incident response |
@@ -232,13 +241,14 @@ See [SECURITY.md](../SECURITY.md) for the vulnerability disclosure policy and de
 
 ### CI Security Pipeline
 
-Every push and pull request runs four security layers automatically:
+Every push and pull request runs five security layers automatically:
 
 | Layer | Tool | What it catches |
 |---|---|---|
 | Static analysis | bandit | Insecure Python patterns (hardcoded secrets, `eval`, subprocess injection) |
 | Dependency CVEs | pip-audit | Known CVEs in Python packages at install time |
 | Container image scan | **Trivy** | OS-layer CVEs in `python:3.11-slim` + secrets accidentally baked into the image |
+| Container image scan | **grype** | Second opinion on image CVEs (`--fail-on high --only-fixed`) |
 | SBOM | cyclonedx-bom | Full software bill of materials, archived as a CI artifact |
 
 Trivy results are uploaded to the **GitHub Security tab** (SARIF format) after every run. CRITICAL findings with an available fix block the build; HIGH findings without a fix are surfaced as warnings only (`--ignore-unfixed`). This matches the approach recommended in the [Vulnerability Response Playbook](security/vulnerability_response_playbook.md).
@@ -279,4 +289,4 @@ OpenDQV Core is the source-layer anchor of the modern data quality stack — des
 
 ## Strict schema
 
-Set `strict_schema: true` on a contract to reject records that carry fields the contract does not declare (`OPENDQV_ADDITIONAL_PROPERTIES`). Add `fields: [..]` for names allowed without a rule. Default is permissive. Full description: [strict_schema.md](strict_schema.md).
+Set `strict_schema: true` on a contract to reject records that carry fields the contract does not declare (`OPENDQV_ADDITIONAL_PROPERTIES`). Add `allowed_fields: [..]` for names allowed without a rule. Default is permissive. Full description: [strict_schema.md](strict_schema.md).

--- a/docs/integrations/martyns-law-compliance.md
+++ b/docs/integrations/martyns-law-compliance.md
@@ -1,12 +1,12 @@
 # Martyn's Law — Venue Terrorism Preparedness Compliance
 
-> **Last reviewed:** 2026-03-21.
+> **Last reviewed:** 2026-09-03 (contracts `martyns_law_venue` v1.1, `martyns_law_event` v1.2).
 
 Martyn's Law (the Terrorism (Protection of Premises) Act 2025) received Royal Assent
-on 3 April 2025. It requires venues and events above a capacity threshold to have
-documented emergency procedures, trained staff, and — at the enhanced tier — a named
-Senior Responsible Person, a formal Terrorism Protection Plan, and registration with
-the Security Industry Authority (SIA).
+on 3 April 2025. It requires every qualifying premises to have documented public
+protection procedures and to notify the Security Industry Authority (SIA), and — at the
+enhanced tier, and for every qualifying event — a named senior responsible person and a
+formal terrorism protection plan.
 
 OpenDQV enforces these obligations at the point of write — before a compliance record
 reaches a safety management system, property management platform, or back-office tool —
@@ -38,9 +38,11 @@ Any venue or qualifying event with a **capacity of 200 or more persons**:
 - Places of worship (200–799: standard duty)
 - Nightclubs, hotels, conference centres
 - Shopping centres, sports stadia, arenas (800+: enhanced duty)
-- Temporary or qualifying events (e.g. festivals) where 800+ attend
+- Qualifying events (e.g. festivals) where 800+ may be present at once — events have
+  **no 200-person tier**; see [Events](#events--martyns_law_event) below
 
-If your premises or event can hold 200 or more people, you are in scope.
+If your premises can hold 200 or more people, or your event may have 800 or more
+present, you are in scope.
 
 ---
 
@@ -48,8 +50,8 @@ If your premises or event can hold 200 or more people, you are in scope.
 
 | Tier | Capacity threshold | Obligations |
 |------|--------------------|-------------|
-| **Standard duty** | 200–799 persons | Document evacuation, invacuation, and lockdown procedures; train all staff |
-| **Enhanced duty** | 800+ persons | Standard duty PLUS: named Senior Responsible Person, Terrorism Protection Plan, SIA registration, formal audit |
+| **Standard duty** | 200–799 persons | Document evacuation, invacuation, lockdown and communication procedures (s.5(3)); notify the SIA (s.9) |
+| **Enhanced duty** | 800+ persons | Standard duty PLUS: named Senior Responsible Person (s.10), Terrorism Protection Plan / s.7 compliance document, formal audit |
 
 ### Standard duty obligations
 
@@ -59,19 +61,25 @@ All venues in scope must:
 2. **Document an invacuation procedure** — shelter-in-place protocol (where evacuation
    is not possible or would increase risk)
 3. **Document a lockdown procedure** — securing the premises during an active threat
-4. **Train all staff** on those procedures, and record the date training was completed
+4. **Document a communication procedure** — how individuals on the premises are given
+   information during an incident (s.5(3)(d))
+5. **Notify the SIA** — any person who becomes responsible for qualifying premises,
+   standard or enhanced, must notify the regulator (s.9)
+
+The Act as passed imposes **no staff-training mandate**. The contract still captures
+`staff_training_completed` (and the date, when true) as good practice — it records
+whether people working on the premises know the procedures they must follow.
 
 ### Enhanced duty obligations (in addition to standard)
 
 Enhanced-duty venues must also:
 
 1. **Appoint a Senior Responsible Person (SRP)** — a named senior individual who takes
-   personal accountability for terrorism preparedness
-2. **Create and maintain a Terrorism Protection Plan (TTP)** — a formal documented
-   plan more comprehensive than the standard procedures
-3. **Register with and notify the SIA** — the Security Industry Authority is the
-   statutory regulator under the Act
-4. **Meet more formal training and audit requirements**
+   personal accountability for terrorism preparedness (s.10 — required where the
+   responsible person is not an individual)
+2. **Create and maintain a Terrorism Protection Plan (TPP)** — the formal s.7
+   compliance document, more comprehensive than the standard procedures
+3. **Meet more formal audit requirements**
 
 ---
 
@@ -91,12 +99,13 @@ POST /api/v1/validate/martyns_law_venue
               ├── evacuation_procedure missing?        → 422 (not_empty)
               ├── invacuation_procedure missing?       → 422 (not_empty)
               ├── lockdown_procedure missing?          → 422 (not_empty)
+              ├── communication_procedure missing?     → 422 (not_empty)
+              ├── sia_registration_number missing?    → 422 (not_empty — all tiers, s.9)
               ├── staff_training_completed = true
               │   but staff_training_date missing?    → 422 (required_if)
               │
               │   [enhanced duty only]
               ├── senior_responsible_person missing?  → 422 (required_if)
-              ├── sia_registration_number missing?    → 422 (required_if)
               ├── terrorism_protection_plan missing?  → 422 (required_if)
               └── all required fields present?        → valid: true
                           │
@@ -114,7 +123,8 @@ fill that in." OpenDQV prevents omission structurally.
 ## Why the operator declares the tier (not auto-derived from capacity)
 
 The `duty_tier` field is explicitly declared by the operator rather than computed from
-`capacity`. This is a deliberate design choice: OpenDQV's `condition` blocks support
+`capacity`. This is a deliberate design choice: OpenDQV's `condition` / `required_if`
+blocks have a closed vocabulary — `{field, value | not_value, present: true|false}` —
 exact string matching, not numeric range comparisons. The operator knows their tier;
 the contract enforces tier-conditional completeness.
 
@@ -127,9 +137,43 @@ reading their capacity from a database field.
 "duty_tier": "enhanced"
 
 # The contract then enforces:
-- senior_responsible_person    (required_if duty_tier = enhanced)
-- sia_registration_number      (required_if duty_tier = enhanced)
+- senior_responsible_person             (required_if duty_tier = enhanced)
+- senior_responsible_person_role        (required_if duty_tier = enhanced)
 - terrorism_protection_plan_documented  (required_if duty_tier = enhanced)
+
+# sia_registration_number is not_empty for BOTH tiers — SIA notification is a s.9
+# duty on every qualifying premises, not an enhanced-only obligation.
+```
+
+---
+
+## Events — `martyns_law_event`
+
+Qualifying events (s.3(1)(d)) are a separate contract, `martyns_law_event`, because the
+Act treats them differently from premises:
+
+- **800+ only, no tiers.** The threshold is `expected_attendance` ≥ 800 (`min: 800`);
+  there is no 200-person standard tier for events, so the contract has **no `duty_tier`
+  field** — every qualifying event carries the enhanced-level duties (ss.6–7).
+- **SRP and plan are unconditional.** `senior_responsible_person`,
+  `senior_responsible_person_role`, `sia_notification_reference` and
+  `terrorism_protection_plan_documented` are all plain `not_empty` — no `required_if`.
+- **Event-specific, time-bounded.** `event_id`, `event_name`, `event_location`,
+  `event_organiser`, `event_type` (lookup against `martyns_law_event_types.txt`),
+  `event_start_date` and `event_end_date` (`date_format`) replace the venue fields.
+- **Same four procedures** — evacuation, invacuation, lockdown, communication — plus
+  `staff_briefing_completed` / `staff_briefing_date` (good practice, as for venues).
+- An 800+ event held *at* an enhanced-duty venue is governed through the premises
+  duties (s.3(1)(b)) — validate it against `martyns_law_venue`, not both.
+
+```
+POST /api/v1/validate/martyns_law_event
+              ├── expected_attendance < 800?          → 422 (min — not a qualifying event)
+              ├── any of the four procedures missing? → 422 (not_empty)
+              ├── senior_responsible_person missing?  → 422 (not_empty)
+              ├── sia_notification_reference missing? → 422 (not_empty)
+              ├── terrorism_protection_plan missing?  → 422 (not_empty)
+              └── all required fields present?        → valid: true
 ```
 
 ---
@@ -152,13 +196,13 @@ operators to declare every required field before the law comes into force.
 
 | Pattern | Fields |
 |---------|--------|
-| `not_empty` | `venue_id`, `venue_name`, `venue_address`, `capacity`, `venue_type`, `duty_tier`, all four standard-duty boolean fields, audit trail |
+| `not_empty` | `venue_id`, `venue_name`, `venue_address`, `capacity`, `venue_type`, `duty_tier`, `sia_registration_number` (both tiers, s.9), the four procedure booleans, `staff_training_completed`, audit trail |
 | `min: 200` | `capacity` — below threshold = out of scope |
 | `lookup` against `martyns_law_venue_types.txt` | `venue_type` |
 | `lookup` against `martyns_law_duty_tiers.txt` | `duty_tier` |
 | `lookup` against `allergen_boolean.txt` | All `*_documented` and `*_completed` boolean fields |
 | `required_if staff_training_completed = true` | `staff_training_date` |
-| `required_if duty_tier = enhanced` | `senior_responsible_person`, `senior_responsible_person_role`, `sia_registration_number`, `terrorism_protection_plan_documented` |
+| `required_if duty_tier = enhanced` | `senior_responsible_person`, `senior_responsible_person_role`, `terrorism_protection_plan_documented` |
 | `required_if terrorism_protection_plan_documented = true` | `terrorism_protection_plan_review_date` |
 | `date_format` | `staff_training_date`, `terrorism_protection_plan_review_date`, `compliance_review_date` |
 
@@ -212,6 +256,7 @@ arena_record = {
     "evacuation_procedure_documented": "true",
     "invacuation_procedure_documented": "true",
     "lockdown_procedure_documented": "true",
+    "communication_procedure_documented": "true",
     "staff_training_completed": "true",
     "staff_training_date": "2026-01-15",
     "senior_responsible_person": "David Clarke",
@@ -276,7 +321,7 @@ saving the record. It cannot verify that:
 - The documented evacuation procedure is adequate or tested
 - The Terrorism Protection Plan meets SIA standards
 - The Senior Responsible Person has the authority the Act requires
-- The SIA registration number is valid
+- The SIA notification reference is genuine
 
 Those verifications require an SIA inspection or a human review step. The audit trail
 (`compliance_reviewed_by` + `compliance_review_date`) creates an accountability
@@ -287,12 +332,12 @@ time of review.
 
 ## Related resources
 
-- Contract: `contracts/martyns_law_venue.yaml`
-- Contract: `contracts/martyns_law_event.yaml`
-- Starter contract: `examples/martyns_law/martyns_law_venue.yaml`
+- Contract: `opendqv/contracts/martyns_law_venue.yaml`
+- Contract: `opendqv/contracts/martyns_law_event.yaml`
+- Starter contracts: `examples/martyns_law/martyns_law_venue.yaml`, `examples/martyns_law_event/martyns_law_event.yaml`
 - Sample records: `examples/martyns_law/`, `examples/martyns_law_event/`
-- Reference files: `contracts/ref/martyns_law_duty_tiers.txt`,
-  `contracts/ref/martyns_law_venue_types.txt`
+- Reference files: `opendqv/contracts/ref/martyns_law_duty_tiers.txt`,
+  `opendqv/contracts/ref/martyns_law_venue_types.txt`, `opendqv/contracts/ref/martyns_law_event_types.txt`
 - UK legislation: [legislation.gov.uk — Terrorism (Protection of Premises) Act 2025](https://www.legislation.gov.uk/ukpga/2025/14)
 - SIA: [sia.homeoffice.gov.uk](https://www.sia.homeoffice.gov.uk)
 - Natasha's Law parallel: [docs/integrations/natasha-law-compliance.md](natasha-law-compliance.md)

--- a/docs/integrations/odoo.md
+++ b/docs/integrations/odoo.md
@@ -80,7 +80,7 @@ cp -r odoo_modules/odoo_opendqv_gdpr /path/to/odoo/addons/
 ### 2. Install opendqv
 
 ```bash
-pip install opendqv>=1.4.0
+pip install "opendqv>=<engine-version>"   # strict-schema / explicit-presence semantics need 2.5.0+
 ```
 
 ### 3. Install in Odoo

--- a/docs/iq_dimension_mapping.md
+++ b/docs/iq_dimension_mapping.md
@@ -114,7 +114,7 @@ rules:
     field: email
     pattern: "^[^@]+@[^@]+\\.[^@]+$"
     error_message: Invalid email format
-    # Optional metadata for IQ dimension reporting:
+    # Proposed metadata for IQ dimension reporting (not an engine key — see note below):
     iq_dimensions: [accuracy, validity]
 
   - name: date_not_future
@@ -126,7 +126,7 @@ rules:
     iq_dimensions: [timeliness, accuracy]
 ```
 
-These tags are passed through in validation responses and can be used by downstream BI tools to aggregate quality failures by IQ dimension.
+**Honest note:** `iq_dimensions` is a proposal, not an engine feature. The `Rule` model has no such field; an unknown key is silently dropped at load and never appears in validation responses. Until it is implemented, keep IQ dimension tags in the rule's `description` (which `/explain` surfaces) or in your own mapping table keyed on rule `name`, and aggregate by rule name downstream.
 
 ---
 

--- a/docs/llm_integration.md
+++ b/docs/llm_integration.md
@@ -220,11 +220,11 @@ The MCP server gives Claude Desktop and Cursor native access to all six OpenDQV 
 **Start the server:**
 
 ```bash
-# Install the MCP extra
-pip install opendqv[mcp]
+# Install the MCP extra (requires the mcp 2.x SDK; pulled in by the extra)
+pip install "opendqv[mcp]"
 
 # Start the MCP server
-python mcp_server.py
+python -m opendqv.mcp_server
 ```
 
 **Register in Claude Desktop** (`~/.claude/claude_desktop_config.json`):
@@ -234,7 +234,7 @@ python mcp_server.py
   "mcpServers": {
     "OpenDQV": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"]
+      "args": ["-m", "opendqv.mcp_server"]
     }
   }
 }
@@ -242,20 +242,19 @@ python mcp_server.py
 
 **Register in Cursor** (Settings → MCP → Add Server):
 - Name: `OpenDQV`
-- Command: `python /path/to/OpenDQV/mcp_server.py`
+- Command: `python -m opendqv.mcp_server`
 
-> **Path note:** The `args` path is machine-specific. Update it when cloning on a new machine.
-> In Cursor you can use `${workspaceFolder}/mcp_server.py` if your project root is the OpenDQV repo.
+> **Interpreter note:** `python` must resolve to the environment where `opendqv[mcp]` is installed. Use the venv's absolute interpreter path in `command` if it does not.
 
-Once registered, Claude and Cursor can call `validate_record`, `validate_batch`, `list_contracts`, `get_contract`, `explain_error`, and `create_contract_draft` as native tools — no API key or extra configuration needed.
+Once registered, Claude and Cursor see all 15 tools as native tools — `validate_record`, `validate_batch`, `list_contracts`, `get_contract`, `list_versions`, `get_contract_jsonschema`, `compare_contracts`, `explain_error`, `get_quality_metrics`, `get_quality_trend`, `get_rule_velocity`, `list_agents`, `list_audit_events`, `get_audit_event`, and `create_contract_draft` — no API key or extra configuration needed. See [`docs/mcp.md`](mcp.md) for the full table.
 
 **Verify your connection:**
 
 After registering, confirm the server is reachable by asking Claude Desktop to call `list_contracts`. You should receive a list of available contracts (e.g. `customer`, `banking_transaction`, etc.).
 
 - **Success:** A list of contracts is returned — the MCP server is connected and the tools are live.
-- **Failure — no tools appear:** Claude Desktop does not show any OpenDQV tools in the tool picker. Check that `mcp_server.py` is running (`python mcp_server.py` in a separate terminal), that the path in `claude_desktop_config.json` is correct, and that you restarted Claude Desktop after editing the config.
-- **Failure — empty response or error:** Run `python mcp_server.py` manually and check the output for import errors. Ensure `opendqv[mcp]` is installed in the same Python environment the config points to.
+- **Failure — no tools appear:** Claude Desktop does not show any OpenDQV tools in the tool picker. Check that the server starts (`python -m opendqv.mcp_server` in a separate terminal), that the path in `claude_desktop_config.json` is correct, and that you restarted Claude Desktop after editing the config.
+- **Failure — empty response or error:** Run `python -m opendqv.mcp_server` manually and check the output for import errors. Ensure `opendqv[mcp]` is installed in the same Python environment the config points to.
 
 **Attribution (required for write tools):**
 
@@ -272,7 +271,7 @@ In Claude Desktop, add it to the `env` block in `claude_desktop_config.json`:
   "mcpServers": {
     "OpenDQV": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {
         "OPENDQV_AGENT_IDENTITY": "your.email@example.com"
       }
@@ -294,7 +293,7 @@ Before writing any record to a database, file, or external API:
 2. If the response has "valid": false, do NOT write the record.
 3. For each error in the errors list, call:
    GET http://localhost:8000/api/v1/contracts/<contract>/explain/<field>/<rule>
-   to understand how to fix it.
+   (e.g. .../contracts/customer/explain/email/valid_email) to understand how to fix it.
 4. Fix the record and re-validate before writing.
 
 Available contracts: GET http://localhost:8000/api/v1/contracts
@@ -438,7 +437,7 @@ if __name__ == "__main__":
 5. Escalate — after `MAX_RETRIES` the record is handed to a human review queue, not silently dropped or written corrupt
 
 **Why `explain_error` makes the difference:**
-Without it, the prompt to Claude is "here's a record, it failed validation, fix it." With it, Claude receives `"valid examples: [0.01, 0.02, 0.1]"` and `"common cause: failed type coercion from a string (e.g. '£0.01' instead of 0.01)"` — the model has the exact constraint and a likely cause. Fix rate on attempt 1 is dramatically higher.
+Without it, the prompt to Claude is "here's a record, it failed validation, fix it." With it, Claude receives `explanation`, `valid_examples`, `invalid_examples`, `constraint` and — when the contract author wrote one — `curated_message` (e.g. `"valid_examples": [0.01, 0.02, 0.1]`) — the model has the exact constraint and the human-authored remediation. Fix rate on attempt 1 is dramatically higher.
 
 ---
 
@@ -449,37 +448,55 @@ Every validation response has the same shape:
 ```json
 {
   "valid": false,
+  "event_id": "01a06810-13d1-7fe2-b944-8ea42a8d59ee",
+  "record_id": null,
   "errors": [
     {
       "field": "amount",
       "rule": "amount_min",
       "message": "amount must be > 0",
-      "severity": "error"
+      "severity": "error",
+      "error_code": "OPENDQV_MIN_AMOUNT_MIN",
+      "suggested_fix": "Provide a value of at least 0.",
+      "counterpart_missing": null
     }
   ],
   "warnings": [],
   "contract": "banking_transaction",
-  "version": "1.0",
-  "contract_hash": "sha256:abc123...",
-  "engine_version": "<engine-version>"
+  "version": "1.2",
+  "owner": "...",
+  "engine_version": "<engine-version>",
+  "contract_hash": "632d10cc…",
+  "entry_hash": "632d10cc…",
+  "content_hash": "9c6caec3…",
+  "effective_rule_hash": "f6aa2752…",
+  "validated_at": "2026-09-03T16:17:59.251637+00:00",
+  "latency_ms": 0.1,
+  "caller_principal": "anonymous",
+  "mode": "enforcement",
+  "would_have_failed": true,
+  "persisted": true
 }
 ```
 
 - `valid: false` means at least one `error`-severity rule failed. Do not write the record.
 - `valid: true` with non-empty `warnings` means the record passed but has quality concerns. Write it, but review the warnings.
-- `contract_hash` is the SHA-256 hash of the exact ruleset used. Store this alongside the record for point-in-time audit evidence.
-- To understand any error: `GET /api/v1/contracts/{contract}/explain/{field}/{rule}`
+- `contract_hash` is the bare hex SHA-256 of the exact contract entry used (it equals `entry_hash`; `content_hash` covers the rule body only, `effective_rule_hash` the rules actually applied after context/filter scoping). Store it alongside the record for point-in-time audit evidence.
+- Each error carries a stable `error_code` and a `suggested_fix`. `counterpart_missing: true` marks a cross-field rule that failed because its counterpart field was absent or blank (otherwise `null`).
+- To understand any error: `GET /api/v1/contracts/{contract}/explain/{field}/{rule}` (e.g. `/contracts/customer/explain/email/valid_email`) — returns `rule_type`, `explanation`, `valid_examples`, `invalid_examples`, `constraint`, `curated_message`; the MCP `explain_error` tool returns the same shape.
 
-**MCP tool responses include two additional fields:**
+**MCP tool responses differ from the REST envelope:**
 
-When calling `validate_record` or `validate_batch` through the MCP server (Claude Desktop, Cursor, or any MCP-compatible agent), the response includes two extra keys not present in the REST API:
+When calling `validate_record` or `validate_batch` through the MCP server (Claude Desktop, Cursor, or any MCP-compatible agent), the response is a slimmer envelope — `valid`, `errors`, `warnings`, `contract`, `version`, `effective_rule_hash` — plus two agent-facing keys not present in the REST API. MCP error entries carry `severity` and `error_code` (and `counterpart_missing: true` on cross-field failures) but not `suggested_fix`:
 
 ```json
 {
   "valid": true,
   "errors": [],
+  "warnings": [],
   "contract": "banking_transaction",
-  "version": "1.0",
+  "version": "1.2",
+  "effective_rule_hash": "f6aa2752…",
   "governance_tip": "Empty required fields cause silent NULL propagation into analytics — catching them at ingestion is 10× cheaper than tracing them downstream.",
   "draft_notice": "This contract is in DRAFT. Validate freely here, but activate it before relying on results in production."
 }
@@ -556,7 +573,7 @@ if not result["valid"]:
         print(hint["explanation"])
 ```
 
-The `mcp` package is only needed if you run `mcp_server.py`. You do not need it to call the REST API.
+The `mcp` package (2.x) is only needed if you run `python -m opendqv.mcp_server`. You do not need it to call the REST API.
 
 ---
 
@@ -611,7 +628,7 @@ review_resp = requests.post(
 # → contract transitions to REVIEW status
 
 # Step 5: Human approves via workbench UI or REST
-# POST /api/v1/contracts/MCP_satellite_telemetry/approve
+# POST /api/v1/contracts/MCP_satellite_telemetry/1.0/approve
 # {"approved_by": "governance@acme.example.com"}
 # → contract becomes ACTIVE, visible in shared library
 

--- a/docs/marmot_integration.md
+++ b/docs/marmot_integration.md
@@ -12,7 +12,7 @@ OpenDQV and Marmot serve complementary roles: OpenDQV validates data at the writ
 ## Design Goals
 
 1. **Contract-first** — OpenDQV contracts are the source of truth; Marmot reflects their state, not the reverse
-2. **Incremental** — use `contract_hash` to skip unchanged contracts and avoid redundant API calls
+2. **Incremental** — use `schema_hash` to skip unchanged contracts and avoid redundant API calls
 3. **Non-invasive** — no changes to OpenDQV internals; integration lives in a thin sync script
 4. **MCP-native** — both tools expose MCP servers; AI agents can query both in a single workflow
 
@@ -56,7 +56,7 @@ contract:
 | `name` | Asset name / `metadata.name` |
 | `description` | Asset description |
 | `version` | Custom metadata `contract_version` |
-| `contract_hash` | Custom metadata `contract_hash` (used for skip logic) |
+| `schema_hash` | Custom metadata `schema_hash` (used for skip logic) |
 | `status` | Custom metadata `contract_status`; `archived` contracts skipped |
 | `owner` | Custom metadata `contract_owner` |
 | `owner_email` | Custom metadata `contract_owner_email` |
@@ -82,7 +82,7 @@ headers_marmot = {
 contracts = requests.get(
     f"{OPENDQV_URL}/api/v1/registry",
     headers=headers_dqv,
-).json()
+).json()["registry"]
 
 for contract in contracts:
     if contract.get("status") == "archived":
@@ -95,7 +95,7 @@ for contract in contracts:
         "type": "dataset",
         "metadata": {
             "contract_version":     contract.get("version", ""),
-            "contract_hash":        contract.get("contract_hash", ""),
+            "schema_hash":        contract.get("schema_hash", ""),
             "contract_status":      contract.get("status", ""),
             "contract_owner":       contract.get("owner", ""),
             "contract_owner_email": contract.get("owner_email", ""),
@@ -301,10 +301,10 @@ validation failures in the last 24 hours. Top failing rule: email_format."
   "mcpServers": {
     "opendqv": {
       "command": "python",
-      "args": ["-m", "mcp_server"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {
-        "OPENDQV_URL": "http://localhost:8000",
-        "OPENDQV_TOKEN": "<OPENDQV_TOKEN>"
+        "OPENDQV_MCP_API_URL": "http://localhost:8000",
+        "OPENDQV_MCP_TOKEN": "<OPENDQV_TOKEN>"
       }
     },
     "marmot": {
@@ -336,7 +336,7 @@ This means the MCP server can run on a laptop with no OpenDQV contracts installe
   "mcpServers": {
     "opendqv": {
       "command": "python3",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {
         "OPENDQV_AGENT_IDENTITY": "your.email@example.com",
         "OPENDQV_MCP_API_URL": "http://<linux-ip>:8000"
@@ -351,7 +351,7 @@ This means the MCP server can run on a laptop with no OpenDQV contracts installe
 }
 ```
 
-On Mac: `pip install mcp httpx` — only two dependencies needed for remote mode.
+On Mac: `pip install "opendqv[mcp]"` — installs the package plus the mcp 2.x SDK and httpx; nothing else is needed for remote mode.
 Find your Linux IP: `ip route get 1 | awk '{print $7; exit}'`
 
 ---
@@ -374,7 +374,7 @@ Postgres (source)
     │  every INSERT validated against customer_master v1.2 ✓
     ▼
 [OpenDQV contract: customer_master]   ← visible in Marmot lineage
-    │  contract_hash: a3f9...  status: active
+    │  schema_hash: a3f9...  status: active
     │  12 rules  last_validated: 2026-03-23T14:32:00Z
     ▼
 Snowflake (analytics.public.customers)
@@ -416,7 +416,7 @@ lineage_node = {
     "metadata": {
         "contract_name":    contract["name"],
         "contract_version": contract.get("version", ""),
-        "contract_hash":    contract.get("contract_hash", ""),
+        "schema_hash":    contract.get("schema_hash", ""),
         "contract_status":  contract.get("status", ""),
         "rule_count":       str(len(contract.get("rules", []))),
         "opendqv_url":      f"{OPENDQV_URL}/api/v1/contracts/{contract['name']}",
@@ -473,7 +473,7 @@ This is the pattern that closes the loop between write-time enforcement (OpenDQV
 
 ---
 
-## Incremental Sync with `contract_hash`
+## Incremental Sync with `schema_hash`
 
 Avoid pushing unchanged contracts by persisting the last-seen hash in a local state file. Add this wrapper around any of the approaches above.
 
@@ -496,12 +496,12 @@ state = load_state()
 contracts = requests.get(
     f"{OPENDQV_URL}/api/v1/registry",
     headers={"Authorization": f"Bearer {OPENDQV_TOKEN}"},
-).json()
+).json()["registry"]
 
 synced, skipped = 0, 0
 for contract in contracts:
     name = contract["name"]
-    current_hash = contract.get("contract_hash", "")
+    current_hash = contract.get("schema_hash", "")
     if state.get(name) == current_hash:
         skipped += 1
         continue
@@ -632,7 +632,7 @@ Both MCP servers must be registered in your agent's config:
   "mcpServers": {
     "opendqv": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {"OPENDQV_AGENT_IDENTITY": "your.email@example.com"}
     },
     "marmot": {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -139,7 +139,7 @@ Write tools:
 
 | Tool | What it does |
 |------|--------------|
-| `create_contract_draft` | Propose a new DRAFT contract. The name must match the contract-name charset (letters, digits, hyphens, underscores; 1–100 chars) **and** start with `MCP_`; `created_by` (or `OPENDQV_AGENT_IDENTITY`) is required; review required before activation. |
+| `create_contract_draft` | *(in-process server only — the standalone REST-bridge proxy does not expose it; a good first issue)* Propose a new DRAFT contract. The name must match the contract-name charset (letters, digits, hyphens, underscores; 1–100 chars) **and** start with `MCP_`; `created_by` (or `OPENDQV_AGENT_IDENTITY`) is required; review required before activation. |
 
 ## Write guardrails
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -25,7 +25,7 @@ OpenDQV's MCP server and FastAPI are **not** the same thing — they are two sep
 
 ```
 FastAPI  :  HTTP client  →  FastAPI (:8000)  →  core/  →  contracts DB
-MCP      :  Claude Desktop  →  (stdio subprocess)  →  mcp_server.py  →  core/  →  contracts
+MCP      :  Claude Desktop  →  (stdio subprocess)  →  opendqv/mcp_server.py  →  core/  →  contracts
 ```
 
 The MCP server is spawned by Claude Desktop as a subprocess (stdio transport). It never listens on a port. MCP and FastAPI are peers, not a wrapper/wrappee relationship.
@@ -43,7 +43,7 @@ No env var set. MCP reads contracts from the local filesystem and validates in-p
 Set `OPENDQV_MCP_API_URL` to point the MCP server at your central OpenDQV API. All tool calls are proxied to the API over HTTP:
 
 ```
-Claude Desktop  →  (stdio)  →  mcp_server.py (laptop)  →  (HTTP)  →  FastAPI (central server)
+Claude Desktop  →  (stdio)  →  opendqv.mcp_server (laptop)  →  (HTTP)  →  FastAPI (central server)
                                                                              ↑
                                                                   UI monitoring sees ALL events
 ```
@@ -60,7 +60,7 @@ Claude Desktop  →  (stdio)  →  mcp_server.py (laptop)  →  (HTTP)  →  Fas
   "mcpServers": {
     "OpenDQV": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {
         "OPENDQV_AGENT_IDENTITY": "your.email@example.com",
         "OPENDQV_MCP_API_URL": "https://opendqv.internal.company.com",
@@ -73,7 +73,7 @@ Claude Desktop  →  (stdio)  →  mcp_server.py (laptop)  →  (HTTP)  →  Fas
 
 The MCP transport (stdio) does not change — only the backend. Claude Desktop config is identical; just add the two env vars. `OPENDQV_MCP_TOKEN` is a Personal Access Token issued by the central API (`POST /api/v1/tokens/generate`).
 
-**Note on `create_contract_draft` in remote mode:** The draft YAML is still written to the MCP server machine's local `contracts/` directory, and the API is signalled to reload. For this to work, the MCP server and the API must share the same contracts directory (e.g., via a mounted volume or shared filesystem). If they do not share the directory, the draft will exist locally but will not be visible on the central server until manually synced.
+**Note on `create_contract_draft` in remote mode:** The draft YAML is still written to the MCP server machine's local contracts directory (`OPENDQV_CONTRACTS_DIR`, default the bundled `opendqv/contracts/`), and the API is signalled to reload. For this to work, the MCP server and the API must share the same contracts directory (e.g., via a mounted volume or shared filesystem). If they do not share the directory, the draft will exist locally but will not be visible on the central server until manually synced.
 
 ## Getting started
 
@@ -82,7 +82,8 @@ The MCP transport (stdio) does not change — only the backend. Claude Desktop c
 The MCP server is self-contained — it reads contracts directly from disk and does not require the OpenDQV HTTP API or Docker stack to be running:
 
 ```bash
-python mcp_server.py
+pip install "opendqv[mcp]"     # pulls in the mcp 2.x SDK
+python -m opendqv.mcp_server
 ```
 
 ### 2. Connect your agent
@@ -93,7 +94,7 @@ Point your MCP-compatible client at the server. For Claude Desktop, add to `~/.c
   "mcpServers": {
     "OpenDQV": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {
         "OPENDQV_AGENT_IDENTITY": "your.email@example.com"
       }
@@ -114,25 +115,31 @@ Once connected, the agent will see these tools:
 
 | Tool | What it does |
 |------|--------------|
-| `list_contracts` | List all active contracts with name, version, status, rule count |
-| `get_contract` | Get full contract detail including all rules. Each rule includes constraint fields: `allowed_values`, `pattern`, `min_value`, `max_value`, `min_length`, `max_length` (null when not applicable for that rule type). |
-| `validate_record` | Validate a single JSON record against a named contract. Supports `agent_id` (attribution), `dry_run` (skip metrics), `context`, `observe_only` (bool, optional, default false) — when true, violations are logged but the record is accepted. Response includes `mode="observation_only"` and `would_have_failed`. Returns `latency_ms` and `suggested_fix` inline on errors. |
-| `validate_batch` | Validate multiple records in one call; returns per-row results and a summary. Same `agent_id`, `dry_run`, `context` params as `validate_record`. Supports `observe_only` (bool, optional, default false) — when true, violations are logged but records are accepted. Response includes `mode="observation_only"` and `would_have_failed`. Returns `latency_ms` on the batch envelope. |
-| `explain_error` | Get a plain-English explanation of a rule failure with valid/invalid examples |
+| `list_contracts` | List all contracts with name, version, status, rule count. Default includes active, draft and review; `include_all=true` adds archived. Only `active` contracts can be used for production validation. |
+| `get_contract` | Get full contract detail including all rules. Each rule includes constraint fields: `allowed_values`, `pattern`, `min_value`, `max_value`, `min_length`, `max_length` (null when not applicable for that rule type). Accepts `version`, `context` and `hash`. |
+| `list_versions` | Version history for a contract — metadata only, no rule bodies. Returns `version`, `status`, `entry_hash`, `content_hash`, `created_at`, `owner`. Use it to drive a version picker, audit a lineage, or pin a `content_hash` for `validate_record`. |
+| `get_contract_jsonschema` | Emit a JSON Schema (draft 2020-12) document for a contract, for producer-side structural validation or typed code generation. Cross-field rules are not expressible in JSON Schema and are listed separately. Accepts `context` and `strict`. |
+| `compare_contracts` | Diff two historical snapshots of the same contract. Call `list_versions` first, then pass any two `entry_hash` values as `hash_a` / `hash_b`. |
+| `validate_record` | Validate a single JSON record against a named contract. Supports `agent_id` (attribution), `dry_run` (skip metrics), `context`, `record_id` (caller correlation ID echoed back and recorded in the audit trail) and `hash` (a `content_hash` from `list_versions` — pins validation to that historical version; 404 if no match). Errors carry `field`, `rule`, `message`, `severity`, `error_code`, and `counterpart_missing: true` when a cross-field rule failed because its counterpart field was absent or blank. The envelope carries `effective_rule_hash` and `governance_tip`. |
+| `validate_batch` | Validate up to 10,000 records in one call; returns per-row results and a summary. Same `agent_id`, `dry_run`, `context`, `hash` params as `validate_record`. Fixed setup cost (~70ms) — for batches under ~70 records, individual `validate_record` calls are cheaper. |
+| `explain_error` | Plain-English explanation of a rule failure: `rule_type`, `explanation`, `valid_examples`, `invalid_examples`, `constraint`, and `curated_message` (the contract author's `error_message`, when set). |
 
 Observability tools:
 
 | Tool | What it does |
 |------|--------------|
-| `get_quality_metrics` | Return rejection rates, top failing rules, and per-contract latency histogram (`avg_ms`, `p50_ms`, `p95_ms`, `p99_ms`) per contract. Accepts `window_hours` to scope stats and optional `agent_id` to filter metrics to a single data source (e.g. `"broadsign-prod"`). Each entry includes `data_confidence` (`no_data` / `low` / `medium` / `high`), `confidence_note`, and a `catalog_hint` for chaining to Marmot or any catalog MCP server. |
-| `get_quality_trend` | Return daily pass-rate trend for a single contract over the last N days. Shows whether quality is improving, declining, or stable, and which rules are driving the change. Each data point includes `total_records`, `passed`, `failed`, `pass_rate`, and `top_failing_rules`. Accepts `contract` (required), `days` (default 7, max 90), and optional `context`. |
+| `get_quality_metrics` | Return rejection rates, top failing rules, and per-contract latency histogram (`avg_ms`, `p50_ms`, `p95_ms`, `p99_ms`) per contract. Accepts `window_hours` to scope stats, optional `agent_id` to filter metrics to a single data source (e.g. `"broadsign-prod"`), and `include_system`. Each entry includes `data_confidence` (`no_data` / `low` / `medium` / `high`), `confidence_note`, and a `catalog_hint` for chaining to Marmot or any catalog MCP server. |
+| `get_quality_trend` | Return daily pass-rate trend for a single contract over the last N days. Shows whether quality is improving, declining, or stable, and which rules are driving the change. Each data point includes `total_records`, `passed`, `failed`, `pass_rate`, and `top_failing_rules`. Accepts `contract` (required), `days` (default 7, max 90), optional `context`, `by` and `include_system`. |
 | `get_rule_velocity` | Return a time-series breakdown of rule failure counts bucketed by time interval. Useful for spotting which rules are spiking. Accepts `contract`, `window_hours`, and `bucket_minutes`. Returns a `series` dict keyed by rule name, each with a list of `{bucket, failures}` points. |
+| `list_agents` | List the agents (source systems) that emitted validation traffic in the window: `agent_id`, totals, `pass_rate_pct`, `last_seen`, `is_system_agent`, sorted by volume. Accepts `window_hours`, `include_system`. |
+| `list_audit_events` | List validation audit events (one row per `/validate` or `/validate/batch` call) with filters (`contract`, `contract_version`, `agent_id`, `caller_principal`, `context`, `mode`, `valid`, `since`, `until`) and cursor pagination (`cursor`, `limit`). For replay, dispute resolution, or regulatory evidence. |
+| `get_audit_event` | Retrieve a single persisted audit event by `event_id` (the UUID v7 returned in the original validate response). 404 when no audit row exists — typically a `dry_run` call. |
 
 Write tools:
 
 | Tool | What it does |
 |------|--------------|
-| `create_contract_draft` | Propose a new DRAFT contract (requires `MCP_` prefix; review required before activation) |
+| `create_contract_draft` | Propose a new DRAFT contract. The name must match the contract-name charset (letters, digits, hyphens, underscores; 1–100 chars) **and** start with `MCP_`; `created_by` (or `OPENDQV_AGENT_IDENTITY`) is required; review required before activation. |
 
 ## Write guardrails
 
@@ -141,7 +148,7 @@ Write access is disabled by default. This is intentional.
 When write access is enabled, OpenDQV enforces strict guardrails to prevent agents from silently corrupting data contracts:
 
 - **Agent-created contracts are always DRAFT.** They cannot be activated without a human review cycle (submit → approve).
-- **ACTIVE contracts are immutable.** No agent can add, update, or delete rules on an ACTIVE contract. To modify an ACTIVE contract, fork it via `POST /contracts/{name}/version` — this creates a new DRAFT at the next version number.
+- **ACTIVE and REVIEW contracts are immutable.** No agent can add, update, or delete rules on an ACTIVE or REVIEW contract — rule mutations return 409 (a REVIEW contract must be rejected back to DRAFT to edit). To modify an ACTIVE contract, create a new version with `POST /contracts/{name}/version` — this writes a new DRAFT as `{name}_v{version}.yaml` and rejects an existing version with 400.
 - **All agent writes are attributed.** The `source` field is set to `"mcp"` on any contract or rule created by an agent. This attribution is permanent and auditable.
 
 These guardrails exist because "trust is easier to build than to repair." A contract silently mutated by an agent is a trust failure. The design makes that impossible by construction.
@@ -151,7 +158,7 @@ These guardrails exist because "trust is easier to build than to repair." A cont
 | Can do | Cannot do |
 |--------|-----------|
 | Read any contract | Activate a contract |
-| Validate any record (single or batch) | Mutate an ACTIVE contract |
+| Validate any record (single or batch) | Mutate an ACTIVE or REVIEW contract |
 | Explain any validation error | Bypass the review workflow |
 | Query quality metrics, trends, and rule velocity | Remove or weaken inherited rules |
 | Propose new DRAFT contracts (if writes enabled) | |
@@ -174,8 +181,8 @@ Tool: list_contracts()
 ```
 ```json
 [
-  { "name": "social_media_age_compliance", "status": "active", "rule_count": 14,
-    "description": "Social media user age compliance — age gate, DOB format, and identity verification audit trail" },
+  { "name": "social_media_age_compliance", "version": "1.0", "status": "active", "rule_count": 14,
+    "description": "..." },
   ...
 ]
 ```
@@ -191,13 +198,25 @@ Tool: validate_record(
 {
   "valid": false,
   "errors": [
-    { "field": "age",  "rule": "age_minimum_13",  "message": "Declared age must be 13 or above for platform access" },
-    { "field": "dob",  "rule": "dob_age_gate",    "message": "Date of birth indicates user is under 13. Platform access denied regardless of declared age (UK Online Safety Act minimum age)." }
+    { "field": "age", "rule": "age_minimum_13", "message": "Declared age must be 13 or above for platform access",
+      "severity": "error", "error_code": "OPENDQV_RANGE_AGE_MINIMUM_13" },
+    { "field": "age", "rule": "age_dob_consistent", "message": "Declared age is inconsistent with date of birth — possible data integrity issue or falsified age declaration",
+      "severity": "error", "error_code": "OPENDQV_AGE_MATCH_AGE_DOB_CONSISTENT" },
+    { "field": "dob", "rule": "dob_age_gate", "message": "Date of birth indicates user is under 13. Platform access denied regardless of declared age (UK Online Safety Act minimum age).",
+      "severity": "error", "error_code": "OPENDQV_DATE_FORMAT_DOB_AGE_GATE" }
+  ],
+  "warnings": [
+    { "field": "verified_identity", "rule": "verified_identity_advisory", "message": "Identity is self-declared (verified_identity=FALSE). Apply enhanced content restrictions per Ofcom age assurance guidance.",
+      "severity": "warning", "error_code": "OPENDQV_LOOKUP_VERIFIED_IDENTITY_ADVISORY" }
   ],
   "contract": "social_media_age_compliance",
-  "version": "1.0.0-draft.280"
+  "version": "1.0",
+  "effective_rule_hash": "9ef29a7c…",
+  "governance_tip": "Out-of-range values often signal upstream bugs; catching them early avoids expensive data recalls."
 }
 ```
+
+`age_dob_consistent` fires because 11 does not match a 2014 date of birth — a cross-field rule. Cross-field rules also fail when the counterpart field is absent or blank; those error entries carry `counterpart_missing: true`.
 
 **Step 3 — explain a failing rule**
 ```
@@ -213,10 +232,11 @@ Tool: explain_error(
   "field": "age",
   "rule": "age_minimum_13",
   "rule_type": "range",
-  "explanation": "age must be between 13.0 and 150.0",
-  "valid_examples": [13, 25, 150],
-  "invalid_examples": [12, 0, -1],
-  "constraint": { "min": 13.0, "max": 150.0 }
+  "explanation": "The 'age' field must be a number between 13.0 and 150.0 (inclusive). Values below 13.0 or above 150.0 will fail. Check the value is numeric and within the allowed range.",
+  "valid_examples": [13.0, 81.5, 150.0],
+  "invalid_examples": [12.0, 151.0, null],
+  "constraint": { "min": 13.0, "max": 150.0 },
+  "curated_message": "Declared age must be 13 or above for platform access"
 }
 ```
 
@@ -225,7 +245,7 @@ Tool: explain_error(
 Tool: validate_record(
   contract = "social_media_age_compliance",
   record   = {
-    "user_id": "USR-0089", "age": 25, "dob": "2000-06-15",
+    "user_id": "USR-0089", "age": 26, "dob": "2000-06-15",
     "verified_identity": "TRUE",
     "verification_method": "GOVERNMENT_ID",
     "verification_timestamp": "2026-03-14T09:30:00Z"
@@ -233,8 +253,11 @@ Tool: validate_record(
 )
 ```
 ```json
-{ "valid": true, "errors": [], "warnings": [], "contract": "social_media_age_compliance" }
+{ "valid": true, "errors": [], "warnings": [], "contract": "social_media_age_compliance", "version": "1.0",
+  "effective_rule_hash": "9ef29a7c…", "governance_tip": "..." }
 ```
+
+> `age` must agree with `dob` as of today — a record born 2000-06-15 is 26 in 2026. Pass an age that is consistent with the date of birth or `age_dob_consistent` fails.
 
 ---
 
@@ -263,12 +286,12 @@ Tool: create_contract_draft(
 {
   "created": true,
   "name": "MCP_my_app_users",
-  "version": "1.0.0",
+  "version": "1.0",
   "status": "draft",
   "source": "mcp",
   "proposed_by": "engineer@example.com",
   "rule_count": 3,
-  "message": "Draft contract 'MCP_my_app_users' created with 3 rule(s). You can now call validate_record against it (draft status allows testing)."
+  "message": "Draft contract 'MCP_my_app_users' created with 3 rule(s). You can now call validate_record against it (draft status allows testing). ..."
 }
 ```
 
@@ -283,17 +306,23 @@ Tool: validate_record(
 {
   "valid": false,
   "errors": [
-    { "field": "email",    "rule": "email_format",        "message": "Must be a valid email address" },
-    { "field": "username", "rule": "username_min_length",  "message": "Username must be at least 3 characters" }
+    { "field": "email",    "rule": "email_format",       "message": "Must be a valid email address",
+      "severity": "error", "error_code": "OPENDQV_REGEX_EMAIL_FORMAT" },
+    { "field": "username", "rule": "username_min_length", "message": "Username must be at least 3 characters",
+      "severity": "error", "error_code": "OPENDQV_MIN_LENGTH_USERNAME_MIN_LENGTH" }
   ],
+  "warnings": [],
+  "contract": "MCP_my_app_users",
+  "version": "1.0",
+  "effective_rule_hash": "7d425a72…",
   "draft_notice": "This contract is in DRAFT. Validate freely here, but activate it before relying on results in production.",
-  "contract": "MCP_my_app_users"
+  "governance_tip": "Format rules stop malformed data from corrupting partner APIs and export pipelines."
 }
 ```
 
 **Step 3 — human approves → ACTIVE**
 
-A human submits the contract for review via the API and approves it. Once ACTIVE, the contract appears in `list_contracts()` for all agents — no code change required on the agent side.
+A human submits the contract for review (`POST /api/v1/contracts/{name}/{version}/submit-review`) and approves it (`POST /api/v1/contracts/{name}/{version}/approve`). While it sits in REVIEW it is immutable — reject it back to DRAFT to edit. Once ACTIVE, the contract appears in `list_contracts()` for all agents — no code change required on the agent side.
 
 > The contract name (`MCP_my_app_users`) stays the same across DRAFT → REVIEW → ACTIVE, so agent code written against the DRAFT works unchanged in production.
 
@@ -337,12 +366,12 @@ You have access to two MCP servers: OpenDQV and Marmot.
 
 OpenDQV stays pure enforcement. The catalog stays pure governance. The agent composes them at runtime.
 
-### Marmot proxy (`Marmot_proxy.py`)
+### Marmot proxy (`marmot_proxy.py`)
 
-For Claude Desktop setups where Marmot's MCP endpoint is on a remote machine, `Marmot_proxy.py` acts as a stdio-to-HTTP bridge. It also applies two filters automatically:
+For Claude Desktop setups where Marmot's MCP endpoint is on a remote machine, `marmot_proxy.py` (repo root) acts as a stdio-to-HTTP bridge. It also applies two filters automatically:
 
 1. **Provider filter** — injects `providers=["OpenDQV"]` into every `discover_data` call, so catalog discovery returns only OpenDQV assets (not OpenLineage job nodes or other providers).
-2. **Visibility filter** — contracts with `catalog_visible: false` in their YAML are excluded from `discover_data` responses. `Marmot_proxy.py` loads hidden contract names from the local `contracts/` directory at startup (configurable via `OPENDQV_CONTRACTS_DIR`).
+2. **Visibility filter** — contracts with `catalog_visible: false` in their YAML are excluded from `discover_data` responses. `marmot_proxy.py` loads hidden contract names from the local contracts directory at startup (configurable via `OPENDQV_CONTRACTS_DIR`).
 
 Claude Desktop config using the proxy:
 
@@ -351,11 +380,11 @@ Claude Desktop config using the proxy:
   "mcpServers": {
     "Marmot": {
       "command": "python3",
-      "args": ["/path/to/OpenDQV/Marmot_proxy.py"],
+      "args": ["/path/to/OpenDQV/marmot_proxy.py"],
       "env": {
         "MARMOT_URL": "http://<linux-ip>:8080",
         "MARMOT_API_KEY": "<your-Marmot-api-key>",
-        "OPENDQV_CONTRACTS_DIR": "/path/to/OpenDQV/contracts"
+        "OPENDQV_CONTRACTS_DIR": "/path/to/OpenDQV/opendqv/contracts"
       }
     }
   }

--- a/docs/openmetadata_integration.md
+++ b/docs/openmetadata_integration.md
@@ -12,7 +12,7 @@ OpenDQV and OpenMetadata serve complementary roles: OpenDQV validates data at th
 
 1. **Contract-first** — OpenDQV contracts are the source of truth; OpenMetadata reflects their state, not the reverse
 2. **Native DQ** — use OpenMetadata's Test Case / Test Suite model for quality scores rather than custom properties, keeping quality data first-class in the catalog
-3. **Incremental** — read back `contract_hash` from OpenMetadata before writing to skip unchanged contracts and avoid redundant API calls
+3. **Incremental** — read back `schema_hash` from OpenMetadata before writing to skip unchanged contracts and avoid redundant API calls
 4. **Non-invasive** — no changes to OpenDQV internals; integration lives entirely in a thin sync script or connector
 
 ---
@@ -38,7 +38,7 @@ Before any sync can run, create 8 custom properties on the `Table` entity type i
 | `contract_name` | `string` | OpenDQV contract identifier |
 | `contract_version` | `string` | Semantic version string |
 | `contract_status` | `string` | `active`, `draft`, or `archived` |
-| `contract_hash` | `string` | SHA-256 hash of the contract YAML |
+| `schema_hash` | `string` | SHA-256 `entry_hash` of the contract's latest audit-chain entry |
 | `rule_count` | `string` | Total number of active rules |
 | `owner_team` | `string` | Owning team name |
 | `owner_email` | `string` | Owner contact email |
@@ -57,7 +57,7 @@ Push every active OpenDQV contract into the OpenMetadata `Table` entity that the
 | `name` | `contract_name` |
 | `version` | `contract_version` |
 | `status` | `contract_status` |
-| `contract_hash` | `contract_hash` |
+| `schema_hash` | `schema_hash` |
 | `rule_count` | `rule_count` |
 | `owner_team` | `owner_team` |
 | `owner_email` | `owner_email` |
@@ -91,7 +91,7 @@ metadata = OpenMetadata(server_config)
 contracts = requests.get(
     f"{OPENDQV_URL}/api/v1/registry",
     headers={"Authorization": f"Bearer {OPENDQV_TOKEN}"},
-).json()
+).json()["registry"]
 
 for contract in contracts:
     asset_id = contract.get("asset_id", "")
@@ -109,7 +109,7 @@ for contract in contracts:
             "contract_name":       contract["name"],
             "contract_version":    contract.get("version", ""),
             "contract_status":     contract.get("status", ""),
-            "contract_hash":       contract.get("contract_hash", ""),
+            "schema_hash":       contract.get("schema_hash", ""),
             "rule_count":          str(contract.get("rule_count", 0)),
             "owner_team":          contract.get("owner_team", ""),
             "owner_email":         contract.get("owner_email", ""),
@@ -421,7 +421,7 @@ for rule in contract_detail.get("rules", []):
 
 ## Approach 5 — Incremental Sync via Read-Back
 
-Instead of a local state file, read the `contract_hash` currently stored in OpenMetadata's `extension` and skip the write if it matches the OpenDQV hash. OpenMetadata is the source of state.
+Instead of a local state file, read the `schema_hash` currently stored in OpenMetadata's `extension` and skip the write if it matches the OpenDQV hash. OpenMetadata is the source of state.
 
 ```python
 # pip install openmetadata-ingestion requests
@@ -437,8 +437,8 @@ for contract in contracts:
     try:
         table = metadata.get_by_name(entity=Table, fqn=asset_id)
         if table and table.extension:
-            stored_hash = table.extension.__root__.get("contract_hash", "")
-            if stored_hash == contract.get("contract_hash", ""):
+            stored_hash = table.extension.__root__.get("schema_hash", "")
+            if stored_hash == contract.get("schema_hash", ""):
                 print(f"Skipping {contract['name']}: hash unchanged")
                 skipped += 1
                 continue

--- a/docs/postman.md
+++ b/docs/postman.md
@@ -95,7 +95,7 @@ If you're using the [demo Docker Compose](demo.md) (pre-seeded data, ports 8080/
 
 1. In the **OpenDQV Local** environment, change `base_url` to `http://localhost:8080`
 2. Leave `auth_token` blank (demo runs `AUTH_MODE=open`)
-3. Run **Validation statistics** (folder 9) — you should see ~690 total validations pre-seeded
+3. Run **Validation statistics** (folder 9) — you should see the demo's pre-seeded validation totals
 
 ---
 
@@ -107,9 +107,9 @@ If you're using the [demo Docker Compose](demo.md) (pre-seeded data, ports 8080/
 | 2 | Contracts | List, detail, explain, reload, history, quality-trend, diff |
 | 3 | Validate — Single Record | `POST /api/v1/validate` (5 example records) |
 | 4 | Validate — Batch | `POST /api/v1/validate/batch`, file upload |
-| 5 | Contract Lifecycle | submit-review, approve, reject |
-| 6 | Code Generation | Apex, JavaScript, Snowflake UDF |
-| 7 | Tokens | Generate, list, revoke |
-| 8 | Import / Export | GX, dbt, Soda, CSV, ODCS, CSVW, NDC |
+| 5 | Contract Lifecycle | `POST /api/v1/contracts/{name}/{version}/submit-review`, `/approve`, `/reject` |
+| 6 | Code Generation | `POST /api/v1/generate?contract_name=&target=` — salesforce (Apex), js, snowflake |
+| 7 | Tokens | Generate, list, `POST /tokens/revoke` (token value as text body), `POST /tokens/revoke/{username}` |
+| 8 | Import / Export | `POST /import/{gx,dbt,soda,csv,odcs,csvw,ndc}`, `GET /export/odcs/{contract_name}` (ODCS v3.1.0 YAML) |
 | 9 | Monitoring & Registry | stats, registry list, registry item |
 | 10 | GraphQL | List contracts, validation history |

--- a/docs/production_deployment.md
+++ b/docs/production_deployment.md
@@ -93,19 +93,20 @@ OpenDQV enforces a maker-checker model with six roles:
 Key separation of duties:
 - **`editor` and `approver` must be different people.** An editor submits contracts for review; an approver reviews and promotes them. Neither can do both — this is the maker-checker principle.
 - **`approver` cannot author.** Approvers can only review and approve/reject. They cannot add or edit rules. If they have concerns, they reject with a reason and return the contract to the editor.
-- **ACTIVE contracts are immutable.** No role — including `admin` — may add, update, or delete rules on an ACTIVE contract. Attempts return `409 Conflict`.
+- **ACTIVE and REVIEW contracts are immutable.** No role — including `admin` — may add, update, or delete rules on an ACTIVE or REVIEW contract. Attempts return `409 Conflict` (a registry-level gate, so REST, GraphQL, MCP and CLI all see it). To edit a REVIEW contract, reject it back to DRAFT.
 - Use separate tokens for each source system (`validator` role) — one token per integration for clean audit trails and independent revocation.
 
 ## 4a. Contract Mutation Security Model
 
-ACTIVE contracts enforce structural immutability for rule sets. This protects production validation behaviour from silent in-place changes — whether from misconfigured agents, compromised credentials, or bulk migration scripts.
+ACTIVE and REVIEW contracts enforce structural immutability for rule sets. This protects production validation behaviour from silent in-place changes — whether from misconfigured agents, compromised credentials, or bulk migration scripts.
 
 ### The fork workflow (canonical path for rule changes)
 
 To change the rules on an ACTIVE contract:
 
 ```bash
-# 1. Create a new draft version (bumps version string, resets status to DRAFT)
+# 1. Create a new DRAFT version — a NEW object written to {name}_v1.1.yaml.
+#    The ACTIVE base version is not touched. 400 if version 1.1 already exists.
 curl -X POST "http://localhost:8000/api/v1/contracts/{name}/version?new_version=1.1" \
   -H "Authorization: Bearer $APPROVER_TOKEN"
 
@@ -115,12 +116,14 @@ curl -X POST "http://localhost:8000/api/v1/contracts/{name}/rules" \
   -H "Content-Type: application/json" \
   -d '{"name": "new_rule", "field": "amount", "type": "min", "min_value": 0, ...}'
 
-# 3. Activate the new version (maker-checker — requires approver role)
-curl -X POST "http://localhost:8000/api/v1/contracts/{name}/status?status=active" \
-  -H "Authorization: Bearer $APPROVER_TOKEN"
+# 3. Submit for review (editor), then approve (maker-checker — requires approver role)
+curl -X POST "http://localhost:8000/api/v1/contracts/{name}/1.1/submit-review" \
+  -H "Authorization: Bearer $EDITOR_TOKEN"
+curl -X POST "http://localhost:8000/api/v1/contracts/{name}/1.1/approve" \
+  -H "Authorization: Bearer $APPROVER_TOKEN" -H "Content-Type: application/json" -d '{}'
 ```
 
-The old ACTIVE version is automatically set to ARCHIVED at step 1. Both versions remain in the history table with full hash-chained audit trails.
+Step 1 never mutates the base version: `create_version` deep-copies it, strips the approval trail, and writes a separate `{name}_v{version}.yaml` in DRAFT. The old ACTIVE version keeps serving `/validate` until step 3 — activation is the moment the previous ACTIVE version is set to ARCHIVED (at most one version of a name is ACTIVE). Both versions remain in the history table with full hash-chained audit trails. The version string must match `[A-Za-z0-9][A-Za-z0-9._-]{0,49}`.
 
 ### Draft patch counter
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,7 +38,7 @@ Docker will download the necessary components (about 400 MB on the first run —
 
 ```
 ✔ Container opendqv-api-1       Started
-✔ Container opendqv-workbench-1 Started
+✔ Container opendqv-ui-1        Started
 ```
 
 **If you don't have Docker (Python 3.11+ only):** use the bootstrap script. The first run takes 2–3 minutes to install dependencies.
@@ -104,7 +104,7 @@ If you prefer the terminal, this single command validates the same record via th
 ```bash
 curl -s -X POST http://localhost:8000/api/v1/validate \
   -H "Content-Type: application/json" \
-  -d '{"contract": "customer", "version": "1.0", "record": {"id": "cust-001", "name": "Joe Bloggs", "email": "joe@example.com", "age": 32}}'
+  -d '{"contract": "customer", "record": {"id": "cust-001", "name": "Joe Bloggs", "email": "joe@example.com", "age": 32}}'
 ```
 
 > This assumes `AUTH_MODE=open` (the default for local dev). For `AUTH_MODE=token` deployments, add `-H "Authorization: Bearer <your-token>"` to the request.
@@ -115,7 +115,7 @@ The response will tell you whether the record is valid and list any rule violati
 
 ## Troubleshooting
 
-Five issues come up most often.
+Six issues come up most often.
 
 1. **"Docker is not running"** — Open Docker Desktop and wait for the whale icon in your menu bar to stop animating, then retry `docker compose up`.
 
@@ -125,7 +125,7 @@ Five issues come up most often.
 
 4. **"API not reachable" banner in the workbench** — Run `docker compose logs api` in your terminal to see what went wrong. The most common causes are a port conflict (see above) or Docker not having fully started yet.
 
-5. **Blank workbench or no contracts listed** — Run `docker compose restart workbench`. On the very first start, the workbench may come up before the contracts are fully loaded. A restart fixes this.
+5. **Blank workbench or no contracts listed** — Run `docker compose restart ui`. On the very first start, the workbench may come up before the contracts are fully loaded. A restart fixes this.
 
 6. **Workbench changes not appearing after editing `ui/app.py`** — The UI image is
    baked at build time. After editing any file under `ui/`, rebuild the image before

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,7 +1,9 @@
 # OpenDQV Rule Types — Documentation Index
 
 ## Core rules
+- [Presence is explicit](core_rules.md#presence-is-explicit-250) — blank is absent (D6), cross-field counterpart failures (D10), `condition` vocabulary
 - [not_empty](core_rules.md#1-not_empty) — field must be present and non-empty
+- [not_empty_string](core_rules.md#14-not_empty_string) — field must be present, a JSON string, and non-empty
 - [regex](core_rules.md#2-regex) — field must match a pattern (supports `negate: true` and `builtin:` shorthands)
 - [min](core_rules.md#3-min) — numeric field must be >= minimum
 - [max](core_rules.md#4-max) — numeric field must be <= maximum
@@ -15,7 +17,7 @@
 - [required_if](core_rules.md#12-required_if) — field required when another field equals a value
 - [unique](core_rules.md#13-unique) — field must be unique (supports `group_by`)
 - [Common Pitfalls](core_rules.md#common-pitfalls) — `min:` vs `min_length:` and other traps
-- min_age / max_age — date field implies an age constraint (see Rule model)
+- min_age / max_age — optional add-on keys (typically on a `date_format` rule) constraining the age implied by a date; not standalone rule types
 
 - [age_match](age_match.md) — declared age must be consistent with date of birth
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -45,7 +45,7 @@
 - [REVIEW lifecycle](review_lifecycle.md) — maker-checker approval workflow
 - [/explain endpoint](explain_endpoint.md) — plain-English contract descriptions for compliance officers
 - [validate_in_states](../../README.md#rules) — restrict validation to specific contract statuses
-- [federation_tier](../federation.md#federation-tier) — REGULATORY/COMMERCIAL/COMMUNITY classification
+- [federation_tier](../federation.md) — REGULATORY/COMMERCIAL/COMMUNITY classification
 
 ## Patterns
 - [distribution_check](../patterns/distribution_check.md) — out of scope; use OpenDQV + Evidently

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -45,7 +45,7 @@
 - [REVIEW lifecycle](review_lifecycle.md) — maker-checker approval workflow
 - [/explain endpoint](explain_endpoint.md) — plain-English contract descriptions for compliance officers
 - [validate_in_states](../../README.md#rules) — restrict validation to specific contract statuses
-- [federation_tier](../core/federation.md#federation-tier) — REGULATORY/COMMERCIAL/COMMUNITY classification
+- [federation_tier](../federation.md#federation-tier) — REGULATORY/COMMERCIAL/COMMUNITY classification
 
 ## Patterns
 - [distribution_check](../patterns/distribution_check.md) — out of scope; use OpenDQV + Evidently

--- a/docs/rules/compare_to_today.md
+++ b/docs/rules/compare_to_today.md
@@ -2,7 +2,7 @@
 
 **Rule type:** `compare`
 **Released:** v1.0.0
-**Applies to:** All 15 industry starter contracts
+**Applies to:** Most starter contracts (14 of the 17 in `examples/starter_contracts/`)
 
 ## Overview
 

--- a/docs/rules/core_rules.md
+++ b/docs/rules/core_rules.md
@@ -1,48 +1,79 @@
 # Core Rule Types Reference
 
-Last reviewed: 2026-04-16
+Last reviewed: 2026-09-03 (engine 2.7.0)
 
-OpenDQV ships 13 core rule types. Each rule lives under `contract.rules[]` in
-a YAML data contract.
+OpenDQV ships 24 rule types (the `_RULE_HANDLERS` table in
+`opendqv/core/validator.py`). The 14 core ones are documented on this page;
+the rest have their own pages — see the [index](README.md). Each rule lives
+under `contract.rules[]` in a YAML data contract.
 
 Every rule requires these fields:
 
 ```yaml
 - name: rule_name          # unique within the contract
   field: target_field      # the record field to validate
-  type: rule_type          # one of the 13 types below
+  type: rule_type          # one of the types below (or in README.md)
   severity: error          # error (block) or warning (allow but flag)
   error_message: "..."     # returned when validation fails
 ```
 
-Optional on any rule: `description`, `condition` (conditional application).
+Optional on any rule: `description`, `condition` (conditional application —
+vocabulary below), `optional` (accepted for round-trip with the managed
+engine; inert on Core, see below).
 
 ---
 
-## Null handling (current v2.2.x behaviour)
+## Presence is explicit (2.5.0+)
 
-Rule handlers are not yet fully consistent about missing values:
+A format rule never implies that its field is present. The rules below are
+the conformance decisions from `docs/contract_conformance.md` (D2, D6, D10)
+and hold identically on the single-record and batch paths:
 
-- Most format rules (`regex`, `min`, `max`, `range`, `date_format`, `checksum`,
-  `compare`, `geospatial_bounds`, `conditional_value`, `cross_field_range`,
-  `conditional_lookup`, `age_match`) **fail** when the target field is `None`
-  or absent.
-- A few (`max_length`, `allowed_values`, single-record `lookup`,
-  single-record `date_diff`) **pass silently** on missing values.
-- `field_sum` and `ratio_check` silently **coerce** missing operands to `0`.
-- In a handful of cases the single-record path and the batch path disagree.
+- **Blank is absent (D6).** Every rule that is not a presence rule skips a
+  value that is missing, `null`, or a whitespace-only string — `min`, `max`,
+  `range`, `regex`, `min_length`, `max_length`, `date_format`, `checksum`,
+  `compare`, `allowed_values`, `lookup`, `date_diff`, and the rest all
+  **pass** on an absent field. This is enforced structurally in
+  `_check_rule()` before any handler runs, not handler by handler.
+- **Presence is its own rule.** To require a field, add `not_empty`
+  (any non-blank value), `not_empty_string` (must be a JSON string, and
+  non-blank — section 14), or `required_if` (presence conditioned on another
+  field). This is how the 41 bundled contracts do it.
+- **`optional` is accepted but inert.** `optional: true` loads and
+  round-trips so that contracts authored for the managed engine (where an
+  error-severity single-field rule implies presence) are byte-identical on
+  Core. Core already skips absent values, so the key changes nothing here.
+- **Cross-field rules fail on a missing counterpart (D10).** `compare`,
+  `date_diff`, `field_sum`, `cross_field_range`, `ratio_check`, `age_match` —
+  when the *other* field the rule reads (the counterpart, not a `condition` trigger) is
+  absent or blank the rule **fails** with the rule's `error_message`, and the
+  error entry carries `counterpart_missing: true` (REST, GraphQL and MCP).
+  The rule's own `field` being absent is still D6 (skipped).
+- **Unknown rule types load with a warning and pass** every record. Run
+  `opendqv lint` — `UNKNOWN_RULE_TYPE` is a lint error — before deploying a
+  contract.
+- **`regex` is an unanchored search** (since 2.5.0; it was `match`). A
+  pattern without `^…$` matches anywhere in the value. Anchor deliberately;
+  `opendqv lint` flags `REGEX_NOT_START_ANCHORED` as an advisory.
 
-**Safe pattern today:** if you want guaranteed presence enforcement on a
-field, add an explicit `not_empty` rule alongside any format rule. This is
-how most of the 43 shipped contracts already handle it.
+### `condition` vocabulary
 
-**Planned for v2.3.0** (breaking change, tracked to ship after the
-April 2026 demo window): every rule handler will fail on missing values by
-default, with a new `optional: true` flag for authors who want
-"format-validate-if-present, pass-if-absent". Single and batch paths will
-agree in every case. Unknown rule types will be rejected at contract load
-rather than silently passing at runtime. See `CHANGELOG.md` when v2.3.0
-ships for the full migration guide.
+`condition` can sit on any rule and gates whether it applies to a record. The
+keys are a closed set — anything else is rejected at load:
+
+```yaml
+condition:
+  field: transaction_type   # the field inspected (required)
+  value: CHARGE             # apply only when field == value (string compare)
+  not_value: CREDIT         # apply only when field != not_value
+  present: true             # apply only when field is present / absent (bool)
+```
+
+`field` is required; the predicates conjoin, so `present: true` combined with
+`value:` means "present *and* equal". `present` uses the D6 reading of absence
+(missing, `null`, or blank), so `condition: {field: <counterpart>, present: true}`
+is how to say "compare only when both fields are present". A rule whose
+condition is not met is skipped for that record (no error, no warning).
 
 ---
 
@@ -114,7 +145,8 @@ pattern: builtin:isbn13
 
 **Gotchas:**
 - A regex rule with no `pattern` fails every record (by design -- fail visible, not silent).
-- Value is coerced to string via `str(value)` before matching; `None` becomes `""`.
+- Absent/blank values are skipped before matching (D6) — add `not_empty` if the field is required.
+- Matching is an unanchored **search**: `pattern: '\d{6}'` accepts `"ref-123456-x"`. Anchor with `^…$` when you mean the whole value; `opendqv lint` reports `REGEX_NOT_START_ANCHORED` on patterns that do not start with `^`.
 - Uses the `regex` library (not `re`) for ReDoS timeout protection (SEC-001).
 
 ---
@@ -140,7 +172,8 @@ Numeric field must be >= a minimum value.
 
 `min` is a YAML alias for `min_value`. Both are accepted.
 
-**Behaviour:** fails if value is `None`, non-numeric, or `float(value) < min_value`.
+**Behaviour:** fails if the value is non-numeric or `float(value) < min_value`.
+Absent/blank values pass (D6) — add `not_empty` for presence.
 
 ---
 
@@ -165,7 +198,8 @@ Numeric field must be <= a maximum value.
 
 `max` is a YAML alias for `max_value`. Both are accepted.
 
-**Behaviour:** fails if value is `None`, non-numeric, or `float(value) > max_value`.
+**Behaviour:** fails if the value is non-numeric or `float(value) > max_value`.
+Absent/blank values pass (D6) — add `not_empty` for presence.
 
 ---
 
@@ -193,7 +227,8 @@ Numeric field must be between min and max (inclusive).
 Either bound can be omitted for a one-sided range, but then you should use
 `type: min` or `type: max` instead for clarity.
 
-**Behaviour:** fails if value is `None`, non-numeric, or outside `[min_value, max_value]`.
+**Behaviour:** fails if the value is non-numeric or outside `[min_value, max_value]`.
+Absent/blank values pass (D6) — add `not_empty` for presence.
 
 ---
 
@@ -216,8 +251,8 @@ String length must be >= a minimum.
 |--------------|--------------------|------|
 | `min_length` | `rule.min_length`  | int  |
 
-**Behaviour:** coerces value to string via `str(value)` (`None` becomes `""`), then
-checks `len(str_val) < min_length`.
+**Behaviour:** absent/blank values pass (D6). Otherwise coerces the value to
+string via `str(value)` and checks `len(str_val) < min_length`.
 
 **WARNING:** do NOT use `min:` here. See [Common Pitfalls](#common-pitfalls).
 
@@ -242,7 +277,8 @@ String length must be <= a maximum.
 |--------------|--------------------|------|
 | `max_length` | `rule.max_length`  | int  |
 
-**Behaviour:** coerces value to string, then checks `len(str_val) > max_length`.
+**Behaviour:** absent/blank values pass (D6). Otherwise coerces the value to
+string and checks `len(str_val) > max_length`.
 If `max_length` is not set, defaults to 99999 (effectively no limit).
 
 **WARNING:** do NOT use `max:` here. See [Common Pitfalls](#common-pitfalls).
@@ -274,7 +310,12 @@ Field must be a parseable date or datetime string.
 4. `%d/%m/%Y`
 5. `%m/%d/%Y`
 
-Passes on the first successful parse. Fails if none match or value is `None`.
+Passes on the first successful parse. Fails if none match. Absent/blank values
+pass (D6) — add `not_empty` for presence.
+
+`min_age` / `max_age` may be added to a `date_format` rule (or any rule) as an
+add-on check on the age implied by the parsed date; they are keys, not rule
+types.
 
 **Custom format example:**
 
@@ -310,7 +351,7 @@ enumerations; use `lookup` for external reference lists.
 | `allowed_values` | `rule.allowed_values`  | list |
 
 **Behaviour:** coerces both the value and list entries to strings before comparison.
-`None` values pass (use `not_empty` to catch missing values separately).
+Absent/blank values pass (D6) — use `not_empty` to catch missing values separately.
 
 **Gotcha:** a rule with an empty or missing `allowed_values` list silently passes
 all records (logged as a warning).
@@ -373,7 +414,7 @@ Field value must appear in an external reference list (file or HTTP endpoint).
 ```
 
 **Gotchas:**
-- `None` values pass -- combine with `not_empty` if the field is required.
+- Absent/blank values pass (D6) -- combine with `not_empty` if the field is required.
 - Missing `lookup_file` skips validation (logged as warning).
 - Local file paths are subject to path traversal protection (SEC-002).
 - `lookup_auth_header` performs env var substitution at runtime (`${VAR}` syntax).
@@ -426,8 +467,9 @@ symbols are normalised to word form at parse time.
 - `now` -- current UTC datetime as ISO 8601
 
 **Gotchas:**
-- `None` value always fails.
-- If `compare_to` names a field and that field is missing from the record, the rule fails.
+- An absent/blank value in `field` passes (D6) — add `not_empty` for presence.
+- If `compare_to` names a field and that field is absent or blank, the rule **fails**
+  (D10) and the error entry carries `counterpart_missing: true`.
 - Naive datetimes (no timezone offset) are treated as UTC.
 - Missing `compare_to` or `compare_op` skips the rule (logged as warning).
 
@@ -499,6 +541,27 @@ batch validation (`/validate/batch`); single-record mode silently skips this rul
 
 **Gotcha:** this rule is a no-op in single-record `/validate` calls. If you need
 uniqueness enforcement, use `/validate/batch`.
+
+---
+
+## 14. not_empty_string
+
+Like `not_empty`, but the value must also be a JSON **string**. Use it for
+identifiers whose canonical form is lost by numeric coercion (leading zeros,
+account numbers, postcodes).
+
+```yaml
+- name: account_number_present
+  field: account_number
+  type: not_empty_string
+  severity: error
+  error_message: "account_number is required"
+```
+
+**Behaviour:** fails if the value is missing, `null`, or blank after trimming
+(with `error_message`), and fails with an engine message naming the JSON type
+received when the value is present but not a string (e.g. `12345` sent as a
+number).
 
 ---
 

--- a/docs/rules/cross_field_range.md
+++ b/docs/rules/cross_field_range.md
@@ -35,7 +35,7 @@ At least one of `cross_min_field` or `cross_max_field` must be provided.
 - The rule fails if the field value is less than the value of `cross_min_field` (when specified).
 - The rule fails if the field value is greater than the value of `cross_max_field` (when specified).
 - Bounds are inclusive on both sides.
-- If either bound field is absent or null in the record, that bound is skipped (not enforced).
+- If either bound field is absent or blank in the record the rule fails (D10) and the error entry carries `counterpart_missing: true`. An absent anchor `field` is skipped (D6).
 - Works with numeric fields. Field values are compared as floats.
 
 ## Use cases by industry

--- a/docs/rules/date_diff.md
+++ b/docs/rules/date_diff.md
@@ -64,7 +64,8 @@ At least one of `min_value` or `max_value` must be specified.
 
 ## Notes
 
-- Both fields must be parseable dates. If either is null or unparseable the record fails validation.
+- Both fields must be parseable dates. An absent or blank `field` is skipped (D6 — declare presence with `not_empty` separately); an absent, blank or unparseable `date_diff_field` fails the rule (D10) and the error entry carries `counterpart_missing: true`.
+- The difference is signed and fractional (2.7.0): `field` earlier than `date_diff_field` gives a negative number of days, and timezone offsets are honoured. `max: 0.16667` days is how the bundled `dora_ict_incident` contract encodes a 4-hour window.
 - Use `date_diff_unit: years` for age-style checks (e.g., employee tenure, policy duration).
 - For single-sided checks, omit the bound you do not need (e.g., omit `min_value` to enforce only a maximum).
 - To compare a date field against today rather than another field, use the `compare` rule type with `compare_to: today`.

--- a/docs/rules/field_sum.md
+++ b/docs/rules/field_sum.md
@@ -34,7 +34,7 @@ The `field_sum` rule validates that the sum of a named list of fields equals a t
 - All fields listed in `sum_fields` are converted to floats and summed.
 - The rule passes if `|sum - sum_equals| <= sum_tolerance`.
 - If `sum_tolerance` is omitted or 0.0, the sum must equal `sum_equals` exactly. In practice, always set a small tolerance (e.g. `0.01`) to handle floating-point rounding.
-- If any field in `sum_fields` is absent or null, it is treated as `0.0`.
+- If any field in `sum_fields` is absent or blank the rule fails (D10) and the error entry carries `counterpart_missing: true`. An absent anchor `field` is skipped (D6).
 - Errors are attributed to the `field` specified in the rule (the anchor field).
 
 ## Use cases by industry

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -170,7 +170,7 @@ Operational notes:
 - The counter is **per-process** — a multi-worker deployment (`WEB_CONCURRENCY=4`) gives each worker its own independent counter. This is the expected behaviour for the current single-node deployment.
 - The counter is **not persisted** — a process restart clears it.
 - There is no admin API to inspect or reset counters. If a legitimate agent hits the cap prematurely (e.g. from a retry loop or test harness), restart the API process to clear it: `docker compose restart api`.
-- The limit is intentionally conservative for the v1.0 release. It will be configurable in a future release.
+- The limit is hard-coded (`_DRAFT_RATE_LIMIT = 10` in `opendqv/mcp_server.py`) and intentionally conservative; making it configurable is a roadmap item.
 
 ### Checking Rate Limit Status
 
@@ -467,6 +467,8 @@ done && echo "Postgres ready"
 ### Schema initialisation
 
 `PostgresContractHistoryBackend` auto-creates the `contract_history` table on first use via `_init_db()`. No manual DDL is required.
+
+**Migration note:** on every start the backend also runs `ALTER TABLE contract_history ADD COLUMN IF NOT EXISTS …` for columns added since the table was first created (`owner_email`, `owner_team`, `asset_id`, `downstream_consumers`, `content_hash`, `domain_version`, and the 2.5.0 `strict_schema` / `allowed_fields`). The database role OpenDQV connects with must therefore hold `ALTER` on that table; a locked-down role that only has DML will fail at startup after an upgrade.
 
 ### SQLite → Postgres migration
 

--- a/docs/salesforce_integration.md
+++ b/docs/salesforce_integration.md
@@ -8,7 +8,7 @@ OpenDQV integrates with Salesforce across a spectrum — from zero infrastructur
 
 ### 1. Use the built-in salesforce_contact contract
 
-OpenDQV ships `contracts/salesforce_contact.yaml` with 18 production-grade validation rules out of the box — no setup required. To write your own:
+OpenDQV ships `opendqv/contracts/salesforce_contact.yaml` (v1.1, 19 production-grade validation rules) out of the box — no setup required. The bundled contract carries no `contexts:` block; the worked context example below is `examples/contexts/salesforce_contact.yaml`, which you can copy over the bundled file (or into your own contracts directory) to enable `salesforce_prod` / `salesforce_sandbox`. To write your own:
 
 ```yaml
 contract:
@@ -61,7 +61,9 @@ curl -X POST http://localhost:8000/api/v1/contracts/reload
 ### 3. Validate a record
 
 ```bash
-# Production context — enforces 18+ age
+# Production context — enforces 18+ age (requires the examples/contexts contract;
+# against the bundled contract the context is undeclared and the response
+# carries a context_warning and applies base rules only)
 curl -X POST http://localhost:8000/api/v1/validate \
   -H "Content-Type: application/json" \
   -d '{
@@ -71,12 +73,22 @@ curl -X POST http://localhost:8000/api/v1/validate \
   }'
 ```
 
-Response (blocked — contact is under 18):
+Response (blocked — contact is under 18; abridged, the envelope also carries `event_id`, `contract_hash`, `engine_version` etc.):
 ```json
 {
   "valid": false,
-  "errors": [{"field": "Birthdate", "rule": "birthdate_format", "message": "Contact must be 18+ in production.", "severity": "error"}],
-  "warnings": []
+  "errors": [
+    {"field": "LastName", "rule": "last_name_required", "message": "LastName is required.", "severity": "error",
+     "error_code": "OPENDQV_NOT_EMPTY_LAST_NAME_REQUIRED", "suggested_fix": "Provide a non-empty value.", "counterpart_missing": null},
+    {"field": "Birthdate", "rule": "birthdate_format", "message": "Contact must be 18+ in production.", "severity": "error",
+     "error_code": "OPENDQV_DATE_FORMAT_BIRTHDATE_FORMAT", "suggested_fix": "Use ISO 8601 format: YYYY-MM-DD (e.g. 2026-03-24)", "counterpart_missing": null},
+    {"field": "AccountName", "rule": "account_name_not_empty", "message": "AccountName is required in production — no orphan contacts allowed.", "severity": "error",
+     "error_code": "OPENDQV_NOT_EMPTY_ACCOUNT_NAME_NOT_EMPTY", "suggested_fix": "Provide a non-empty value.", "counterpart_missing": null}
+  ],
+  "warnings": [{"field": "MailingStreet", "rule": "mailing_street_required", "message": "MailingStreet is recommended for contacts.", "severity": "warning", "error_code": "OPENDQV_NOT_EMPTY_MAILING_STREET_REQUIRED", "suggested_fix": "Provide a non-empty value.", "counterpart_missing": null}],
+  "contract": "salesforce_contact",
+  "version": "1.1",
+  "engine_version": "<engine-version>"
 }
 ```
 
@@ -301,7 +313,8 @@ public class OpenDQVCallout {
      * before DML commits.
      *
      * Pass an optional context (e.g. 'salesforce_prod', 'salesforce_sandbox') to
-     * apply context-specific validation rules from the contract.
+     * apply context-specific validation rules from the contract. The bundled
+     * contract declares no contexts — see examples/contexts/salesforce_contact.yaml.
      *
      * Returns the 'results' array from the OpenDQV batch response, or null on failure.
      * Caller must check each result's 'valid' field and call record.addError() as needed.
@@ -377,7 +390,8 @@ trigger OpenDQVContactTrigger on Contact (before insert, before update) {
     }
 
     // Pass a context to apply environment-specific rules (e.g. 18+ age in prod).
-    // Use 'salesforce_sandbox' for test orgs, 'salesforce_prod' for production.
+    // Use 'salesforce_sandbox' for test orgs, 'salesforce_prod' for production
+    // (contexts from examples/contexts/salesforce_contact.yaml; undeclared contexts fall back to base rules).
     List<Object> results = OpenDQVCallout.validate('salesforce_contact', records, 'salesforce_prod');
 
     if (results == null) {

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -45,17 +45,17 @@ Roles are embedded in the JWT payload at token creation time. Elevation requires
 
 ## Known limitations
 
-### `passlib` — `crypt` deprecation warning on Python 3.11+
+### `passlib` — unmaintained; `crypt` deprecation and `bcrypt` 5.x incompatibility
 
 **Severity:** None (warning only, no functional impact)
 
-OpenDQV uses `passlib[bcrypt]` for password hashing. Passlib 1.7.4 (the latest release) unconditionally imports Python's built-in `crypt` module at load time, even when the bcrypt scheme is the only one configured. Python deprecated `crypt` in 3.11 and removed it in 3.13.
+OpenDQV declares `passlib[bcrypt]` and constructs a `CryptContext(schemes=["bcrypt"])` in `security/auth.py`. Passlib 1.7.4 (the latest release) tries to import Python's built-in `crypt` module at load time; Python deprecated `crypt` in 3.11 and removed it in 3.13. Separately, passlib's bcrypt backend self-test breaks against `bcrypt` ≥ 5.0 (`ValueError: password cannot be longer than 72 bytes`) on the first `hash()` call.
 
-**Impact:** A `DeprecationWarning` appears in test output on Python 3.11. On Python 3.13, passlib's unconditional `crypt` import raises an `ImportError` at startup — use Python 3.11 or 3.12 for production deployments until this is resolved upstream.
+**Impact:** None in practice. A `DeprecationWarning` may appear in test output on Python 3.11/3.12. On Python 3.13 the `crypt` import is trapped and the module loads normally — the project is verified on 3.13 (Linux and Windows) and Python 3.11+ is supported for production. Authentication is JWT PAT based; `pwd_context.hash()` is never called on any request path, so the bcrypt 5.x self-test failure is never reached.
 
 **Root cause:** Passlib has been effectively unmaintained since 2020 and the fix has not been released. This is a known community issue.
 
-**Mitigation:** OpenDQV's `CryptContext` is configured with `schemes=["bcrypt"]` only — the `crypt` code path is never invoked at runtime. The warning is cosmetic. A drop-in replacement (`passlib` fork or migration to `bcrypt` directly) is planned for a future release.
+**Mitigation:** OpenDQV's `CryptContext` is configured with `schemes=["bcrypt"]` only and is not exercised at runtime. The warning is cosmetic. Removing the `passlib` dependency (or migrating to `bcrypt` directly) is planned for a future release.
 
 ---
 
@@ -89,12 +89,16 @@ Revokes all tokens for a given username. Requires the `admin` role. This endpoin
 | SEC-001 | ReDoS timeout | All regex rules evaluated via the `regex` library with a 0.5 s per-pattern timeout (configurable: `OPENDQV_REGEX_TIMEOUT`). Prevents catastrophic backtracking. |
 | SEC-002 | Path traversal — contract files | `pathlib.resolve()` + containment check against `config.CONTRACTS_DIR`. Rejects any path that resolves outside the contracts directory. |
 | SEC-003 | Authentication | JWT PATs with configurable expiry. `AUTH_MODE=open` disables auth for local development only. |
-| SEC-004 | SQL injection — field names | DuckDB batch queries use `$param` binding for all user-supplied values. Field names are validated against the contract schema before use. |
+| SEC-004 | SQL injection — field references | DuckDB batch queries use `$param` binding for all user-supplied values. Every field reference a rule carries (`field`, trigger fields, `compare_to`, cross-field names) is charset-checked at parse time and quoted as an identifier; `date_format.format` is a bound SQL parameter. |
 | SEC-005 | RBAC enforcement | Role claims are verified on every authenticated request. No role elevation is possible without re-issuing a token. |
 | SEC-006 | Path traversal — importers | Importer endpoints resolve file paths and verify containment before reading. |
 | SEC-007 | Input size limits | Request body size is capped. Batch validation payloads are bounded by `OPENDQV_MAX_BATCH_SIZE`. |
 | SEC-008 | Webhook SSRF protection | Outbound webhook URLs are validated against a blocklist: RFC 1918 private ranges, loopback (`127.0.0.0/8`, `::1`), and link-local (`169.254.0.0/16`, `fe80::/10`) are all rejected. |
 | SEC-009 | Token role whitelist | `/tokens/generate` validates the `role` parameter against an enumerated set (`validator`, `reader`, `auditor`, `editor`, `approver`, `admin`). Unknown roles return HTTP 422. Prevents phantom roles from appearing in the audit log. |
+| SEC-010 | Role guards | `POST /import/*`, `POST /webhooks`, `DELETE /webhooks` require `editor` or `admin`; `POST /contracts/reload` and `GET/POST /tokens/*` require `admin`. Enforced in `api/deps.py` helpers shared by every sub-router. |
+| SEC-011 | `lookup_auth_header` secret exfiltration | `${VAR}` substitution in a lookup rule's auth header is gated by three fail-closed controls: only `OPENDQV_LOOKUP_`-prefixed env vars are substitutable; substitution is disabled entirely under `AUTH_MODE=open` unless `OPENDQV_ALLOW_LOOKUP_SECRETS` is set; a secret-bearing lookup may only target a host on `OPENDQV_LOOKUP_EGRESS_ALLOWLIST` (empty ⇒ none permitted). Redirects on credential-bearing lookups are refused. |
+| — | Contract name charset | `CONTRACT_NAME_RE` in `core/contracts.py` is the single contract-name charset (`[A-Za-z0-9_-]{1,100}`). Every core write path that takes a caller-supplied name — REST, GraphQL, MCP `create_contract_draft`, CLI — checks it before touching the filesystem. |
+| — | ACTIVE / REVIEW immutability | Rule mutations on an ACTIVE or REVIEW contract return `409 Conflict` at the registry level (`ContractImmutableError`), so every surface is covered. To edit a REVIEW contract, reject it back to DRAFT. |
 
 ---
 

--- a/docs/security/hardening.md
+++ b/docs/security/hardening.md
@@ -67,12 +67,8 @@ If your proxy sets `X-Forwarded-For`, set `TRUST_PROXY_HEADERS=true` in the Open
 
 ### Docker Compose (production profile)
 
-```yaml
-services:
-  api:
-    environment:
-      - OPENDQV_BASE_URL=https://opendqv.example.com
-```
+OpenDQV does not terminate TLS itself and has no public-URL setting — put the API
+behind a TLS-terminating reverse proxy (nginx, Caddy, an ALB) and forward to port 8000.
 
 ---
 
@@ -307,14 +303,13 @@ services:
     user: "1000:1000"                        # Run as non-root
     environment:
       - AUTH_MODE=token
-      - OPENDQV_TRACE_HMAC_KEY_FILE=/run/secrets/hmac_key
-    secrets:
-      - hmac_key
-
-secrets:
-  hmac_key:
-    external: true
+      - OPENDQV_TRACE_HMAC_KEY=${OPENDQV_TRACE_HMAC_KEY}   # inject from your secrets manager
 ```
+
+OpenDQV reads `OPENDQV_TRACE_HMAC_KEY` (and `SECRET_KEY`) from the environment only —
+there is no `*_FILE` variant. Inject secrets via the orchestrator's environment
+mechanism (Compose `.env` with restricted permissions, Kubernetes `secretKeyRef`,
+ECS secrets) rather than baking them into the compose file.
 
 ---
 

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -103,7 +103,7 @@ This document covers the seven primary attack surfaces identified during the ini
 - Sensitive field **names** are moved to `sensitive_fields_suppressed`; their validation outcomes are suppressed from `failed_rules`.
 - HTTP Authorization headers are never passed to any logger call.
 - The hash chain detects any modification, reordering, or truncation.
-- **HMAC signing (SEC-004):** When `OPENDQV_TRACE_HMAC_KEY` is set, each entry is signed with HMAC-SHA256. An attacker without the key cannot forge valid entries.
+- **HMAC signing:** When `OPENDQV_TRACE_HMAC_KEY` is set, each entry is signed with HMAC-SHA256. An attacker without the key cannot forge valid entries.
 - A startup WARNING is emitted if TRACE_LOG is enabled without an HMAC key.
 
 **Residual risk:** Low (with HMAC key set) to Medium (without). Without HMAC, an adversary with filesystem write access could reconstruct a valid chain after deleting entries. The field names and contract names visible in the log may assist reconnaissance.
@@ -138,8 +138,8 @@ This document covers the seven primary attack surfaces identified during the ini
 - `AUTH_MODE=token` enforces Bearer token authentication on all protected endpoints.
 - `AUTH_MODE=open` is documented as unsafe for public-facing deployments and triggers a `maker_checker_enforced: false` flag in `/health`.
 - Rate limiting via `slowapi` is applied to all validation and default endpoints.
-- `/trace/verify` requires authentication (SEC-005).
-- `/explain` is auth-gated by default; `OPENDQV_EXPLAIN_PUBLIC=true` allows unauthenticated access if explicitly configured (SEC-010).
+- `/trace/verify` requires authentication and the `auditor`/`approver`/`admin` role.
+- `/explain` is auth-gated by default; `OPENDQV_EXPLAIN_PUBLIC=true` allows unauthenticated access if explicitly configured.
 
 **Residual risk:** Medium. The in-memory rate limiter has a known 4× effective rate with multiple Gunicorn workers (see SECURITY.md section 1). JWT tokens do not support revocation without a database check; revoked tokens may be accepted until expiry if the DB is unavailable.
 
@@ -160,8 +160,8 @@ This document covers the seven primary attack surfaces identified during the ini
 2. The batch endpoint generates a query: `SELECT __idx__ FROM data WHERE "target"--" IS NULL ...`
 3. The double-quote terminates the identifier; `--` comments out the remainder, altering query semantics.
 
-**Current mitigation (fixed 2026-03-10):**
-- `Rule._post_parse()` in `core/rule_parser.py` validates field names at contract parse time.
+**Current mitigation (fixed 2026-03-10; widened 2026-09-02, v2.4.1 — SEC-004):**
+- `Rule._post_parse()` in `core/rule_parser.py` validates every field reference a rule carries — `field`, `required_if`/`condition` trigger fields, `compare_to`, and cross-field names — at contract parse time. `date_format.format` is passed as a bound SQL parameter, never interpolated.
 - Field names containing `"`, `\`, `;`, null bytes (`\x00`), or other control characters raise a `ValueError` and prevent the contract from loading.
 - Allowed characters: letters, digits, underscore, hyphen, space, dot — all safe when double-quoted as SQL identifiers.
 - 7 regression tests added in `TestFieldNameSQLInjection` in `tests/test_security.py`.

--- a/docs/security/vulnerability_response_playbook.md
+++ b/docs/security/vulnerability_response_playbook.md
@@ -149,13 +149,22 @@ advisory within 24 hours regardless of timeline position.
 
 ### 6.2 Release steps
 
-1. Merge the private security branch to `main` (force-push to avoid pre-disclosure history)
-2. Tag a patch release: `git tag vX.Y.Z-patch`
-3. Push the Docker image to registry
-4. Publish the GitHub Security Advisory — this auto-creates a CVE
-5. Update `SECURITY.md` to move the item from "Known Limitations" to "Fixed in release vX.Y.Z"
-6. Post to `#announcements` Slack and notify known deployers via mailing list
-7. Credit the reporter in the release notes (unless anonymity requested)
+1. Merge the private security branch to `main` and add a `## [X.Y.Z]` section to
+   `CHANGELOG.md` (the release workflow refuses to run without one). Security fixes
+   ship as a normal patch/minor version — there is no `-patch` suffix.
+2. Get the maintainer's explicit "ship it" — the release action is never taken
+   autonomously by tooling or agents.
+3. Run **Actions → Create Release → Run workflow** (`.github/workflows/release.yml`,
+   `workflow_dispatch`, choose the bump). It computes the version from the latest tag,
+   creates and pushes `vX.Y.Z`, and publishes the GitHub release from the CHANGELOG
+   notes with `library_manifest.json` attached.
+4. The workflow then dispatches `publish.yml` (PyPI trusted publisher, `pypi`
+   environment); the tag push triggers `docker-publish.yml` (multi-arch image to GHCR).
+   Confirm both under Actions before announcing.
+5. Publish the GitHub Security Advisory — this auto-creates a CVE
+6. Update `SECURITY.md` to move the item from "Known Limitations" to "Fixed in release vX.Y.Z"
+7. Post to `#announcements` Slack and notify known deployers via mailing list
+8. Credit the reporter in the release notes (unless anonymity requested)
 
 ### 6.3 Advisory template
 

--- a/docs/strict_schema.md
+++ b/docs/strict_schema.md
@@ -76,7 +76,8 @@ first; the declared set is computed from the resolved rules.
 - **JSON Schema export** emits `additionalProperties: false` for a strict
   contract and a bare property entry for every `allowed_fields:` name.
 - **ODCS export** carries both as custom properties (`opendqv.strict_schema`,
-  `opendqv.fields`); ODCS import restores them. The standard has no native
+  `opendqv.allowed_fields`); ODCS import restores them, and still reads the
+  older `opendqv.fields` key for back-compatibility. The standard has no native
   construct for "reject undeclared fields".
 - **Linter** rejects a non-boolean `strict_schema` or a non-string-list
   `allowed_fields`, warns when it is set without `strict_schema`, and warns on the deprecated `fields:` spelling.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,19 +120,17 @@ python -c "import yaml; yaml.safe_load(open('contracts/mycontract.yaml'))"
 
 ---
 
-## 5. `409 Conflict: Contract is ACTIVE — create a new version to modify rules`
+## 5. `409 Conflict: Contract 'x' is ACTIVE. Rule mutations are not permitted`
 
 **Symptom:** An API call to add, update, or delete a rule returns 409.
 
-**Cause:** ACTIVE contracts are immutable by design. This is an intentional write guardrail.
+**Cause:** ACTIVE and REVIEW contracts are immutable by design. This is an intentional write guardrail. (A REVIEW contract can be rejected back to DRAFT and edited there.)
 
 **Fix:** To modify rules on an ACTIVE contract, fork it first:
 ```bash
-curl -X POST http://localhost:8000/api/v1/contracts/<name>/version \
-  -H "Content-Type: application/json" \
-  -d '{"bump": "minor", "created_by": "your-name"}'
+curl -X POST "http://localhost:8000/api/v1/contracts/<name>/version?new_version=2.0"
 ```
-This creates a new DRAFT at the next version number. Edit the DRAFT, then submit for review and approve.
+This writes `<name>_v2.0.yaml` as a new DRAFT (an existing version number is rejected with 400). Edit the DRAFT, then submit for review and approve.
 
 ---
 
@@ -142,13 +140,13 @@ This creates a new DRAFT at the next version number. Edit the DRAFT, then submit
 
 **Check 1:** Is the MCP server running?
 ```bash
-python mcp_server.py
+python -m opendqv.mcp_server
 ```
 It must be running as a separate process from the main API.
 
-**Check 2:** Is the API reachable from the MCP server? The MCP server calls the OpenDQV REST API internally. Ensure `API_URL` is correctly set in the environment (default: `http://localhost:8000`).
+**Check 2:** Is the API reachable from the MCP server? The MCP server calls the OpenDQV REST API internally. In remote mode, ensure `OPENDQV_MCP_API_URL` (and `OPENDQV_MCP_TOKEN` if the API runs in token mode) is set; without it the server runs self-contained against the local contracts directory.
 
-**Check 3:** For write operations, confirm the MCP server is configured with `ALLOW_MCP_WRITES=true` and that you have reviewed the write guardrail documentation before enabling writes.
+**Check 3:** For write operations (`create_contract_draft`), the contract name must start with `MCP_` and `OPENDQV_AGENT_IDENTITY` (or `created_by`) must be set — otherwise the write is refused. Review the write guardrail documentation before enabling writes.
 
 ---
 

--- a/examples/starter_contracts/README.md
+++ b/examples/starter_contracts/README.md
@@ -1,34 +1,68 @@
 # Starter Contracts
 
-Example data contracts to help you get started with OpenDQV.
+Industry starter templates to help you get started with OpenDQV. Each file is a
+complete, loadable contract in the current rule shape (`name` / `type` / `field` /
+`severity` / `error_message` on every rule) with regulatory context and adaptation
+notes in the comments.
 
-These are **not** loaded by the API by default — they live here as templates.
-Copy the files you need into your `contracts/` directory (and the `ref/` files
-into `contracts/ref/`) before deploying.
+These are **not** loaded by the API by default — they live here as templates. Copy
+the files you need into your contracts directory (`$OPENDQV_CONTRACTS_DIR`; the
+default is the bundled `opendqv/contracts/`) and the `ref/` files into its `ref/`
+subdirectory, then restart or `POST /contracts/reload`.
+
+`tests/test_starter_templates_load.py` pins that every file here loads through the
+registry and passes `opendqv lint` with zero errors.
 
 ## Contracts in this directory
 
-| File | Description | Industry |
-|------|-------------|----------|
-| `universal_benchmark.yaml` | 14-rule contract covering all core rule types. Used as the canonical performance benchmark. | General |
-| `social_media_age_compliance.yaml` | Age-gate and identity verification audit trail for online platforms. Ofcom/ICO UK context (Online Safety Act 2023, Children's Code). | Social Media / Online Platforms |
+| File | Contract name | Description | Industry |
+|------|---------------|-------------|----------|
+| `banking.yaml` | `bank_transaction` | Retail bank transaction — identifiers, amounts, AML screening, payment channel; PSD2 / FCA / FATF | Banking |
+| `energy.yaml` | `meter_reading` | Smart meter reading — MPRN/MPAN format, read type, consumption plausibility, settlement period | Energy |
+| `financial_services.yaml` | `trade_record` | Investment trade record — ISIN, LEI, MiFID II trade reporting fields, execution venue, asset class | Financial services |
+| `healthcare.yaml` | `patient_record` | Patient record — format, clinical codes (ICD-10, NHS number), physiological plausibility | Healthcare |
+| `insurance.yaml` | `insurance_claim` | Insurance claim — claim identification, financials, fraud indicators; Solvency II | Insurance |
+| `logistics.yaml` | `shipment_event` | Shipment tracking event — carrier, routing, customs, hazmat; Incoterms 2020 | Logistics |
+| `manufacturing.yaml` | `sensor_reading` | Industrial sensor reading — physical plausibility, tolerance bands, quality flags, asset identification | Manufacturing |
+| `pharma.yaml` | `clinical_trial_observation` | Clinical trial observation — CDISC SDTM-aligned, GCP-compliant, reference-range checks | Pharma |
+| `public_sector.yaml` | `citizen_service_record` | Citizen service record — identity, eligibility, case management, maker-checker approval | Public sector |
+| `real_estate.yaml` | `property_listing` | Property listing and transaction — identifiers, pricing, physical attributes, EPC, tenure, SDLT | Real estate |
+| `retail.yaml` | `product_catalogue` | Retail product catalogue — SKU format, GTIN check digit, pricing, inventory, reorder point | Retail |
+| `social_media_age_compliance.yaml` | `social_media_age_compliance` | Age gate and identity verification audit trail for online platforms. Ofcom / ICO UK context (Online Safety Act 2023, Children's Code) | Social media / online platforms |
+| `technology.yaml` | `tech_incident` | Technology incident — ITIL 4 severity, GDPR breach notification, SOC 2 availability, SLA compliance | Technology |
+| `telecoms.yaml` | `cdr_record` | Call Detail Record — number formats, duration, charge, classification | Telecoms |
+| `travel.yaml` | `travel_booking` | Travel booking — PNR, IATA codes, pricing, passenger details, booking status, GDPR consent, PCI DSS | Travel |
+| `universal.yaml` | `universal` | Universal starter — one worked example of each core rule type, with comments on when to use it | General |
+| `universal_benchmark.yaml` | `universal_benchmark` | 14-rule contract covering all core rule types. Used as the canonical performance benchmark (Core-only; not in the Cloud library) | General |
+
+The flat-format files (everything except `universal_benchmark.yaml`) take their
+contract name from the filename stem when loaded, so `banking.yaml` is served as
+`banking` — rename the file if you want the name shown in the table.
 
 ## Reference data
 
 | File | Description |
 |------|-------------|
 | `ref/universal_status.txt` | Valid values for the `status` field: ACTIVE, INACTIVE, PENDING, SUSPENDED |
-| `ref/universal_currency.txt` | ISO 4217 currency codes used by the benchmark contract |
+| `ref/universal_currency.txt` | A 12-code starter subset of ISO 4217 currency codes used by the benchmark contract — extend it for your markets |
 | `ref/verification_methods.txt` | Approved age verification methods used by `social_media_age_compliance.yaml` |
+
+`sample_records/` holds sample records for the **bundled library** contracts of the same
+industries (`opendqv/contracts/`, exercised by the test suite) — their field names follow the
+library contracts, not these templates, except `social_media_age_compliance.json` and
+`universal.json` which match the templates here.
 
 ## Quick start
 
 ```bash
 # Copy the benchmark contract and its reference data into your contracts directory
-cp examples/starter_contracts/universal_benchmark.yaml contracts/
-cp -r examples/starter_contracts/ref contracts/
+cp examples/starter_contracts/universal_benchmark.yaml "$OPENDQV_CONTRACTS_DIR/"
+cp -r examples/starter_contracts/ref "$OPENDQV_CONTRACTS_DIR/"
 
-# The API will pick them up on next restart (or SIGHUP)
+# Check it before you deploy it
+opendqv lint "$OPENDQV_CONTRACTS_DIR/universal_benchmark.yaml"
+
+# The API will pick it up on next restart (or POST /contracts/reload)
 ```
 
 ## Rule types demonstrated
@@ -43,3 +77,12 @@ The `universal_benchmark.yaml` contract demonstrates:
 - `range` — numeric bounds check
 - `unique` — uniqueness within a batch
 - `required_if` — conditional required field
+
+The industry templates add `allowed_values` (inline lists), `min` / `max`,
+`checksum` (GTIN), `cross_field_range` (tolerance bands and reference ranges),
+`date_format` with `min_age`, and `age_match`.
+
+Remember that a format rule never implies presence: an absent or blank field
+passes `regex`, `range`, `lookup` and the rest (see
+[docs/rules/core_rules.md](../../docs/rules/core_rules.md#presence-is-explicit-250)).
+Every template therefore pairs its format rules with an explicit `not_empty`.

--- a/examples/starter_contracts/README.md
+++ b/examples/starter_contracts/README.md
@@ -15,29 +15,29 @@ registry and passes `opendqv lint` with zero errors.
 
 ## Contracts in this directory
 
-| File | Contract name | Description | Industry |
+| File | Served as | Description | Industry |
 |------|---------------|-------------|----------|
-| `banking.yaml` | `bank_transaction` | Retail bank transaction — identifiers, amounts, AML screening, payment channel; PSD2 / FCA / FATF | Banking |
-| `energy.yaml` | `meter_reading` | Smart meter reading — MPRN/MPAN format, read type, consumption plausibility, settlement period | Energy |
-| `financial_services.yaml` | `trade_record` | Investment trade record — ISIN, LEI, MiFID II trade reporting fields, execution venue, asset class | Financial services |
-| `healthcare.yaml` | `patient_record` | Patient record — format, clinical codes (ICD-10, NHS number), physiological plausibility | Healthcare |
-| `insurance.yaml` | `insurance_claim` | Insurance claim — claim identification, financials, fraud indicators; Solvency II | Insurance |
-| `logistics.yaml` | `shipment_event` | Shipment tracking event — carrier, routing, customs, hazmat; Incoterms 2020 | Logistics |
-| `manufacturing.yaml` | `sensor_reading` | Industrial sensor reading — physical plausibility, tolerance bands, quality flags, asset identification | Manufacturing |
-| `pharma.yaml` | `clinical_trial_observation` | Clinical trial observation — CDISC SDTM-aligned, GCP-compliant, reference-range checks | Pharma |
-| `public_sector.yaml` | `citizen_service_record` | Citizen service record — identity, eligibility, case management, maker-checker approval | Public sector |
-| `real_estate.yaml` | `property_listing` | Property listing and transaction — identifiers, pricing, physical attributes, EPC, tenure, SDLT | Real estate |
-| `retail.yaml` | `product_catalogue` | Retail product catalogue — SKU format, GTIN check digit, pricing, inventory, reorder point | Retail |
+| `banking.yaml` | `banking` | Retail bank transaction — identifiers, amounts, AML screening, payment channel; PSD2 / FCA / FATF | Banking |
+| `energy.yaml` | `energy` | Smart meter reading — MPRN/MPAN format, read type, consumption plausibility, settlement period | Energy |
+| `financial_services.yaml` | `financial_services` | Investment trade record — ISIN, LEI, MiFID II trade reporting fields, execution venue, asset class | Financial services |
+| `healthcare.yaml` | `healthcare` | Patient record — format, clinical codes (ICD-10, NHS number), physiological plausibility | Healthcare |
+| `insurance.yaml` | `insurance` | Insurance claim — claim identification, financials, fraud indicators; Solvency II | Insurance |
+| `logistics.yaml` | `logistics` | Shipment tracking event — carrier, routing, customs, hazmat; Incoterms 2020 | Logistics |
+| `manufacturing.yaml` | `manufacturing` | Industrial sensor reading — physical plausibility, tolerance bands, quality flags, asset identification | Manufacturing |
+| `pharma.yaml` | `pharma` | Clinical trial observation — CDISC SDTM-aligned, GCP-compliant, reference-range checks | Pharma |
+| `public_sector.yaml` | `public_sector` | Citizen service record — identity, eligibility, case management, maker-checker approval | Public sector |
+| `real_estate.yaml` | `real_estate` | Property listing and transaction — identifiers, pricing, physical attributes, EPC, tenure, SDLT | Real estate |
+| `retail.yaml` | `retail` | Retail product catalogue — SKU format, GTIN check digit, pricing, inventory, reorder point | Retail |
 | `social_media_age_compliance.yaml` | `social_media_age_compliance` | Age gate and identity verification audit trail for online platforms. Ofcom / ICO UK context (Online Safety Act 2023, Children's Code) | Social media / online platforms |
-| `technology.yaml` | `tech_incident` | Technology incident — ITIL 4 severity, GDPR breach notification, SOC 2 availability, SLA compliance | Technology |
-| `telecoms.yaml` | `cdr_record` | Call Detail Record — number formats, duration, charge, classification | Telecoms |
-| `travel.yaml` | `travel_booking` | Travel booking — PNR, IATA codes, pricing, passenger details, booking status, GDPR consent, PCI DSS | Travel |
-| `universal.yaml` | `universal` | Universal starter — one worked example of each core rule type, with comments on when to use it | General |
-| `universal_benchmark.yaml` | `universal_benchmark` | 14-rule contract covering all core rule types. Used as the canonical performance benchmark (Core-only; not in the Cloud library) | General |
+| `technology.yaml` | `technology` | Technology incident — ITIL 4 severity, GDPR breach notification, SOC 2 availability, SLA compliance | Technology |
+| `telecoms.yaml` | `telecoms` | Call Detail Record — number formats, duration, charge, classification | Telecoms |
+| `travel.yaml` | `travel` | Travel booking — PNR, IATA codes, pricing, passenger details, booking status, GDPR consent, PCI DSS | Travel |
+| `universal.yaml` | `universal` | Universal starter — 16 rules exercising 9 of the 24 rule types (allowed_values, compare, max_length, min, not_empty, range, regex, required_if, unique), with comments on when to use each | General |
+| `universal_benchmark.yaml` | `universal_benchmark` | 14 rules exercising 8 of the 24 rule types (compare, lookup, max_length, not_empty, range, regex, required_if, unique). The canonical performance benchmark (Core-only; not in the Cloud library) | General |
 
-The flat-format files (everything except `universal_benchmark.yaml`) take their
-contract name from the filename stem when loaded, so `banking.yaml` is served as
-`banking` — rename the file if you want the name shown in the table.
+The flat-format files (everything except `universal_benchmark.yaml`) are served
+under the filename stem — the `name:` inside them is not read by the loader, so
+rename the file if you want a different contract name.
 
 ## Reference data
 
@@ -59,8 +59,9 @@ library contracts, not these templates, except `social_media_age_compliance.json
 cp examples/starter_contracts/universal_benchmark.yaml "$OPENDQV_CONTRACTS_DIR/"
 cp -r examples/starter_contracts/ref "$OPENDQV_CONTRACTS_DIR/"
 
-# Check it before you deploy it
-opendqv lint "$OPENDQV_CONTRACTS_DIR/universal_benchmark.yaml"
+# Check it before you deploy it — lint takes the contract NAME (the file is
+# already in $OPENDQV_CONTRACTS_DIR); flat-format files are named by their stem
+opendqv lint universal_benchmark
 
 # The API will pick it up on next restart (or POST /contracts/reload)
 ```
@@ -85,4 +86,6 @@ The industry templates add `allowed_values` (inline lists), `min` / `max`,
 Remember that a format rule never implies presence: an absent or blank field
 passes `regex`, `range`, `lookup` and the rest (see
 [docs/rules/core_rules.md](../../docs/rules/core_rules.md#presence-is-explicit-250)).
-Every template therefore pairs its format rules with an explicit `not_empty`.
+The templates declare `not_empty` where a field is mandatory; a format-only field
+accepts blank, and `opendqv lint` reports `FORMAT_ONLY_FIELD_ACCEPTS_EMPTY` (info)
+for each such field — add `not_empty` for the fields your producers must always send.

--- a/examples/starter_contracts/banking.yaml
+++ b/examples/starter_contracts/banking.yaml
@@ -50,17 +50,21 @@ rules:
   # ── TRANSACTION IDENTIFICATION ───────────────────────────────────────────────
   # transaction_id is the primary idempotency key.  Duplicate IDs indicate
   # replay attacks or upstream system errors — catch them at ingestion.
-  - field: transaction_id
-    rule: not_empty
+  - name: transaction_id_not_empty
+    type: not_empty
+    field: transaction_id
     severity: error
     description: "Transaction ID is mandatory. A missing ID prevents deduplication and idempotency checks."
+    error_message: "Transaction ID is mandatory. A missing ID prevents deduplication and idempotency checks."
 
-  - field: transaction_id
-    rule: regex
+  - name: transaction_id_regex
+    type: regex
+    field: transaction_id
     # Alphanumeric, 8–20 characters. Covers most core banking ID schemes.
     pattern: "^[A-Z0-9]{8,20}$"
     severity: error
     description: "Transaction ID must be 8–20 uppercase alphanumeric characters."
+    error_message: "Transaction ID must be 8–20 uppercase alphanumeric characters."
 
   # ── ACCOUNT NUMBER ───────────────────────────────────────────────────────────
   # Two formats are provided — comment out the one that does not apply.
@@ -70,17 +74,21 @@ rules:
   #
   # Current default: UK sort-code format.
   # To switch to IBAN, comment out the UK rule and uncomment the IBAN rule below.
-  - field: account_number
-    rule: not_empty
+  - name: account_number_not_empty
+    type: not_empty
+    field: account_number
     severity: error
     description: "Account number is mandatory."
+    error_message: "Account number is mandatory."
 
-  - field: account_number
-    rule: regex
+  - name: account_number_regex
+    type: regex
+    field: account_number
     # UK: 6-digit sort code + hyphen + 8-digit account number
     pattern: "^[0-9]{6}-[0-9]{8}$"
     severity: error
     description: "Account number must be UK sort-code format: XXXXXX-XXXXXXXX (e.g., 200000-12345678)."
+    error_message: "Account number must be UK sort-code format: XXXXXX-XXXXXXXX (e.g., 200000-12345678)."
 
   # IBAN alternative (ISO 13616). Uncomment to use instead of UK sort-code:
   #
@@ -93,9 +101,10 @@ rules:
   # ── TRANSACTION TYPE ─────────────────────────────────────────────────────────
   # These codes align with SWIFT ISO 20022 camt.053 (bank-to-customer statement)
   # and are required for Basel III transaction classification.
-  - field: transaction_type
-    rule: lookup
-    lookup_values:
+  - name: transaction_type_allowed_values
+    type: allowed_values
+    field: transaction_type
+    allowed_values:
       - CREDIT
       - DEBIT
       - TRANSFER
@@ -113,29 +122,35 @@ rules:
       - REVERSAL
     severity: error
     description: "Transaction type must be a recognised payment instrument code (ISO 20022 / Basel III classification)."
+    error_message: "Transaction type must be a recognised payment instrument code (ISO 20022 / Basel III classification)."
 
   # ── AMOUNT ──────────────────────────────────────────────────────────────────
   # Retail banking ceiling: GBP/EUR 10,000,000 per transaction.
   # For wholesale/corporate banking, raise max to 1,000,000,000.
   # A zero-amount transaction is valid (e.g., a fee reversal to zero).
-  - field: amount
-    rule: not_empty
+  - name: amount_not_empty
+    type: not_empty
+    field: amount
     severity: error
     description: "Amount is mandatory."
+    error_message: "Amount is mandatory."
 
-  - field: amount
-    rule: range
+  - name: amount_range
+    type: range
+    field: amount
     min: 0
     max: 10000000
     severity: error
     description: "Transaction amount must be between 0 and 10,000,000 (retail ceiling). Adjust max for wholesale banking."
+    error_message: "Transaction amount must be between 0 and 10,000,000 (retail ceiling). Adjust max for wholesale banking."
 
   # ── CURRENCY ─────────────────────────────────────────────────────────────────
   # ISO 4217 currency codes for supported markets.
   # Extend this list to add emerging market currencies relevant to your operations.
-  - field: currency
-    rule: lookup
-    lookup_values:
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values:
       - USD
       - EUR
       - GBP
@@ -159,54 +174,68 @@ rules:
       - GHS
     severity: error
     description: "Currency must be a supported ISO 4217 code."
+    error_message: "Currency must be a supported ISO 4217 code."
 
   # ── TRANSACTION DATETIME ─────────────────────────────────────────────────────
   # ISO 8601 with timezone offset is required for cross-border payment
   # reconciliation and PSD2 audit trail obligations.
-  - field: transaction_datetime
-    rule: not_empty
+  - name: transaction_datetime_not_empty
+    type: not_empty
+    field: transaction_datetime
     severity: error
     description: "Transaction datetime is mandatory for audit trail and settlement."
+    error_message: "Transaction datetime is mandatory for audit trail and settlement."
 
-  - field: transaction_datetime
-    rule: regex
+  - name: transaction_datetime_regex
+    type: regex
+    field: transaction_datetime
     # ISO 8601 datetime with mandatory timezone (Z or ±HH:MM)
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Transaction datetime must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z or 2026-03-09T14:30:00+00:00)."
+    error_message: "Transaction datetime must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z or 2026-03-09T14:30:00+00:00)."
 
-  - field: transaction_datetime
-    rule: compare
+  - name: transaction_datetime_compare
+    type: compare
+    field: transaction_datetime
     compare_op: lte
     compare_to: now
     severity: error
     description: "Transaction datetime cannot be in the future. Required for PSD2 audit trail integrity."
+    error_message: "Transaction datetime cannot be in the future. Required for PSD2 audit trail integrity."
 
   # ── BENEFICIARY ACCOUNT ───────────────────────────────────────────────────────
   # PSD2 Article 45 requires beneficiary account details for credit transfers.
   # FATF Recommendation 16 (Wire Transfer Rule) requires originator and
   # beneficiary information for all cross-border wire transfers.
-  - field: beneficiary_account
-    rule: required_if
-    when_field: transaction_type
-    when_value: TRANSFER
+  - name: beneficiary_account_required_if
+    type: required_if
+    field: beneficiary_account
     severity: error
     description: "Beneficiary account is required for TRANSFER transactions (PSD2 Article 45 / FATF Recommendation 16)."
+    required_if:
+      field: transaction_type
+      value: TRANSFER
+    error_message: "Beneficiary account is required for TRANSFER transactions (PSD2 Article 45 / FATF Recommendation 16)."
 
-  - field: beneficiary_account
-    rule: required_if
-    when_field: transaction_type
-    when_value: SWIFT
+  - name: beneficiary_account_required_if_2
+    type: required_if
+    field: beneficiary_account
     severity: error
     description: "Beneficiary account is required for SWIFT transactions (FATF Recommendation 16 — Wire Transfer Rule)."
+    required_if:
+      field: transaction_type
+      value: SWIFT
+    error_message: "Beneficiary account is required for SWIFT transactions (FATF Recommendation 16 — Wire Transfer Rule)."
 
   # ── CHANNEL ──────────────────────────────────────────────────────────────────
   # Payment channel drives PSD2 SCA exemption logic:
   # BRANCH and TELEPHONE may be exempt from SCA; ONLINE/MOBILE/API require it
   # for transactions above EUR 30.
-  - field: channel
-    rule: lookup
-    lookup_values:
+  - name: channel_allowed_values
+    type: allowed_values
+    field: channel
+    allowed_values:
       - ONLINE
       - MOBILE
       - BRANCH
@@ -216,11 +245,13 @@ rules:
       - BATCH
     severity: error
     description: "Channel is required for PSD2 Strong Customer Authentication (SCA) exemption logic."
+    error_message: "Channel is required for PSD2 Strong Customer Authentication (SCA) exemption logic."
 
   # ── STATUS ───────────────────────────────────────────────────────────────────
-  - field: status
-    rule: lookup
-    lookup_values:
+  - name: status_allowed_values
+    type: allowed_values
+    field: status
+    allowed_values:
       - PENDING
       - AUTHORISED
       - CLEARED
@@ -231,51 +262,63 @@ rules:
       - FRAUD_HOLD
     severity: error
     description: "Transaction status must be a recognised lifecycle state."
+    error_message: "Transaction status must be a recognised lifecycle state."
 
   # ── AML SCREENING ─────────────────────────────────────────────────────────────
   # FATF Recommendation 10 — Customer Due Diligence.
   # Every transaction must carry an AML screening result before settlement.
   # SUSPICIOUS and BLOCKED transactions must be escalated to the MLRO
   # (Money Laundering Reporting Officer) before funds are released.
-  - field: aml_flag
-    rule: lookup
-    lookup_values:
+  - name: aml_flag_allowed_values
+    type: allowed_values
+    field: aml_flag
+    allowed_values:
       - CLEAR
       - REVIEW
       - SUSPICIOUS
       - BLOCKED
     severity: error
     description: "AML flag is mandatory. SUSPICIOUS/BLOCKED transactions must be escalated to the MLRO before settlement (FATF Recommendation 10)."
+    error_message: "AML flag is mandatory. SUSPICIOUS/BLOCKED transactions must be escalated to the MLRO before settlement (FATF Recommendation 10)."
 
   # ── TRANSACTION REFERENCE ────────────────────────────────────────────────────
   # SWIFT field 70 (Remittance Information): maximum 35 characters.
   # Used on camt.054 credit notifications and MT103 payment messages.
-  - field: transaction_reference
-    rule: not_empty
+  - name: transaction_reference_not_empty
+    type: not_empty
+    field: transaction_reference
     severity: error
     description: "Transaction reference is required for payment reconciliation."
+    error_message: "Transaction reference is required for payment reconciliation."
 
-  - field: transaction_reference
-    rule: max_length
-    max: 35
+  - name: transaction_reference_max_length
+    type: max_length
+    field: transaction_reference
+    max_length: 35
     severity: error
     description: "Transaction reference must not exceed 35 characters (SWIFT field 70 — MT103 / camt.054 limit)."
+    error_message: "Transaction reference must not exceed 35 characters (SWIFT field 70 — MT103 / camt.054 limit)."
 
   # ── MERCHANT CATEGORY CODE ───────────────────────────────────────────────────
   # ISO 18245 MCC: 4-digit numeric code assigned by card scheme.
   # Required for POS transactions for interchange fee determination
   # and Basel III retail exposure classification.
   # Only required when channel is POS (card-present transaction).
-  - field: merchant_category_code
-    rule: required_if
-    when_field: channel
-    when_value: POS
+  - name: merchant_category_code_required_if
+    type: required_if
+    field: merchant_category_code
     severity: error
     description: "Merchant Category Code (ISO 18245) is required for POS transactions — used for interchange and Basel III retail exposure classification."
+    required_if:
+      field: channel
+      value: POS
+    error_message: "Merchant Category Code (ISO 18245) is required for POS transactions — used for interchange and Basel III retail exposure classification."
 
-  - field: merchant_category_code
-    rule: regex
+  - name: merchant_category_code_regex
+    type: regex
+    field: merchant_category_code
     # ISO 18245: exactly 4 decimal digits
     pattern: "^[0-9]{4}$"
     severity: error
     description: "Merchant Category Code must be exactly 4 digits (ISO 18245, e.g., 5411 for grocery stores)."
+    error_message: "Merchant Category Code must be exactly 4 digits (ISO 18245, e.g., 5411 for grocery stores)."

--- a/examples/starter_contracts/energy.yaml
+++ b/examples/starter_contracts/energy.yaml
@@ -42,16 +42,20 @@ rules:
 
   # Ireland MPRN: exactly 11 digits. No spaces or separators.
   # Example: 10123456789
-  - field: mprn
-    rule: not_empty
+  - name: mprn_not_empty
+    type: not_empty
+    field: mprn
     severity: error
     description: "MPRN (Meter Point Reference Number) is mandatory. An invalid MPRN cannot be assigned to a supply point."
+    error_message: "MPRN (Meter Point Reference Number) is mandatory. An invalid MPRN cannot be assigned to a supply point."
 
-  - field: mprn
-    rule: regex
+  - name: mprn_regex
+    type: regex
+    field: mprn
     pattern: "^[0-9]{11}$"
     severity: error
     description: "MPRN must be exactly 11 digits with no spaces or separators."
+    error_message: "MPRN must be exactly 11 digits with no spaces or separators."
 
   # GB MPAN: 21 digits in 3 groups of 2 + 13 core.
   # Structure: [2 profile class][2 MTC][2 LLFC][13 core MPAN]
@@ -70,96 +74,119 @@ rules:
   #   description: "MPAN must be exactly 21 digits."
 
   # ── METER IDENTIFICATION ─────────────────────────────────────────────────────
-  - field: meter_serial
-    rule: not_empty
+  - name: meter_serial_not_empty
+    type: not_empty
+    field: meter_serial
     severity: error
     description: "Meter serial number is required for asset tracking and dispute resolution."
+    error_message: "Meter serial number is required for asset tracking and dispute resolution."
 
-  - field: meter_serial
-    rule: regex
+  - name: meter_serial_regex
+    type: regex
+    field: meter_serial
     # Alphanumeric, 8–15 characters (covers SMETS1 and SMETS2 formats)
     pattern: "^[A-Z0-9]{8,15}$"
     severity: error
     description: "Meter serial number must be 8–15 alphanumeric characters."
+    error_message: "Meter serial number must be 8–15 alphanumeric characters."
 
   # ── READ TIMESTAMP ───────────────────────────────────────────────────────────
-  - field: read_timestamp
-    rule: not_empty
+  - name: read_timestamp_not_empty
+    type: not_empty
+    field: read_timestamp
     severity: error
     description: "Read timestamp is mandatory — required for settlement period assignment."
+    error_message: "Read timestamp is mandatory — required for settlement period assignment."
 
-  - field: read_timestamp
-    rule: regex
+  - name: read_timestamp_regex
+    type: regex
+    field: read_timestamp
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Read timestamp must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z)."
+    error_message: "Read timestamp must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z)."
 
-  - field: read_timestamp
-    rule: compare
+  - name: read_timestamp_compare
+    type: compare
+    field: read_timestamp
     compare_op: lte
     compare_to: now
     severity: error
     description: "Read timestamp cannot be in the future. BSC settlement requirement."
+    error_message: "Read timestamp cannot be in the future. BSC settlement requirement."
 
   # ── READ TYPE ────────────────────────────────────────────────────────────────
   # Industry standard codes for the reliability of a meter read.
   # Estimated and substituted reads must be reported to regulators (CRU/Ofgem)
   # as a percentage of total reads — a key data quality metric.
-  - field: read_type
-    rule: lookup
-    lookup_values: [A, E, D, N]
+  - name: read_type_allowed_values
+    type: allowed_values
+    field: read_type
+    allowed_values: [A, E, D, "N"]
     severity: error
     description: "Read type: A=Actual, E=Estimated, D=Data Substitution, N=Null. Required for CRU/Ofgem data quality reporting."
+    error_message: "Read type: A=Actual, E=Estimated, D=Data Substitution, N=Null. Required for CRU/Ofgem data quality reporting."
 
   # ── CONSUMPTION ──────────────────────────────────────────────────────────────
   # Residential meter: 0–200 kWh per half-hour period is generous but safe.
   # Irish average is ~0.23 kWh per half-hour (11 kWh/day ÷ 48).
   # For industrial/commercial meters, adjust max significantly (up to 50,000+).
-  - field: consumption_kwh
-    rule: range
+  - name: consumption_kwh_range
+    type: range
+    field: consumption_kwh
     min: 0.0
     max: 200.0
     severity: error
     description: "Consumption for a residential meter must be between 0 and 200 kWh per half-hour period. Values above this threshold suggest a unit error or industrial meter — adjust max for your meter class."
+    error_message: "Consumption for a residential meter must be between 0 and 200 kWh per half-hour period. Values above this threshold suggest a unit error or industrial meter — adjust max for your meter class."
 
   # Negative consumption is physically possible for export meters (solar/wind).
   # For supply-only meters, consumption must be >= 0.
   # For meters that can export, change min to -200.
-  - field: consumption_kwh
-    rule: compare
-    compare_op: gte
-    compare_to: 0
+  - name: consumption_kwh_min
+    type: min
+    field: consumption_kwh
+    min: 0
     severity: error
     description: "Consumption cannot be negative for supply-only meters. For export meters, set min: -200 in the range rule."
+    error_message: "Consumption cannot be negative for supply-only meters. For export meters, set min: -200 in the range rule."
 
   # ── SETTLEMENT PERIOD ────────────────────────────────────────────────────────
   # BSC settlement periods: 1–48 for standard days, 1–46 for BST change-back,
   # 1–50 for BST change-forward. Upper bound 50 covers all cases.
-  - field: settlement_period
-    rule: range
+  - name: settlement_period_range
+    type: range
+    field: settlement_period
     min: 1
     max: 50
     severity: error
     description: "Settlement period must be between 1 and 50. Standard days have 48 periods; clock-change days have 46 or 50."
+    error_message: "Settlement period must be between 1 and 50. Standard days have 48 periods; clock-change days have 46 or 50."
 
   # ── DATA SOURCE ──────────────────────────────────────────────────────────────
-  - field: data_source
-    rule: lookup
-    lookup_values: [SMETS1, SMETS2, AMR, MANUAL, HH, PREPAYMENT, ALF]
+  - name: data_source_allowed_values
+    type: allowed_values
+    field: data_source
+    allowed_values: [SMETS1, SMETS2, AMR, MANUAL, HH, PREPAYMENT, ALF]
     severity: error
     description: "Data source identifies the metering technology. Required for settlement validation class assignment."
+    error_message: "Data source identifies the metering technology. Required for settlement validation class assignment."
 
-  - field: supply_type
-    rule: lookup
-    lookup_values: [ELECTRICITY, GAS]
+  - name: supply_type_allowed_values
+    type: allowed_values
+    field: supply_type
+    allowed_values: [ELECTRICITY, GAS]
     severity: error
     description: "Supply type is required — electricity and gas settlement run on separate systems."
+    error_message: "Supply type is required — electricity and gas settlement run on separate systems."
 
   # ── DISTRIBUTION NETWORK ─────────────────────────────────────────────────────
-  - field: dno_code
-    rule: not_empty
+  - name: dno_code_not_empty
+    type: not_empty
+    field: dno_code
     severity: warning
     description: "Distribution Network Operator code is required for loss factor application in settlement."
+    error_message: "Distribution Network Operator code is required for loss factor application in settlement."
 
   # ── QUALITY TRACKING ─────────────────────────────────────────────────────────
   # Use the OpenDQV quality trend API to track your ratio of estimated vs

--- a/examples/starter_contracts/financial_services.yaml
+++ b/examples/starter_contracts/financial_services.yaml
@@ -52,17 +52,21 @@ rules:
   # ── TRADE IDENTIFICATION ──────────────────────────────────────────────────────
   # trade_id is the OMS-assigned unique trade identifier.
   # MiFID II RTS 22 field 3 requires a unique transaction reference number.
-  - field: trade_id
-    rule: not_empty
+  - name: trade_id_not_empty
+    type: not_empty
+    field: trade_id
     severity: error
     description: "Trade ID is mandatory. Required as the unique transaction reference under MiFID II RTS 22 field 3."
+    error_message: "Trade ID is mandatory. Required as the unique transaction reference under MiFID II RTS 22 field 3."
 
-  - field: trade_id
-    rule: regex
+  - name: trade_id_regex
+    type: regex
+    field: trade_id
     # 8–20 uppercase alphanumeric characters (covers FIX, Bloomberg, and OMS formats)
     pattern: "^[A-Z0-9]{8,20}$"
     severity: error
     description: "Trade ID must be 8–20 uppercase alphanumeric characters."
+    error_message: "Trade ID must be 8–20 uppercase alphanumeric characters."
 
   # ── INSTRUMENT IDENTIFICATION ─────────────────────────────────────────────────
   # ISIN — ISO 6166: 2-letter country code, 9 alphanumeric NSIN digits, 1 check digit.
@@ -71,61 +75,76 @@ rules:
   #   GB0002634946 — BP plc (ordinary shares, LSE)
   #   US0378331005 — Apple Inc (NASDAQ)
   #   DE0005140008 — Deutsche Bank AG (XETRA)
-  - field: isin
-    rule: not_empty
+  - name: isin_not_empty
+    type: not_empty
+    field: isin
     severity: error
     description: "ISIN is mandatory. MiFID II RTS 22 field 41 requires an ISIN for all instruments admitted to trading on a regulated venue."
+    error_message: "ISIN is mandatory. MiFID II RTS 22 field 41 requires an ISIN for all instruments admitted to trading on a regulated venue."
 
-  - field: isin
-    rule: regex
+  - name: isin_regex
+    type: regex
+    field: isin
     # ISO 6166: 2-letter country code + 9 uppercase alphanumeric NSIN + 1 check digit
     pattern: "^[A-Z]{2}[A-Z0-9]{9}[0-9]$"
     severity: error
     description: "ISIN must follow ISO 6166 format: 2-letter country code + 9 alphanumeric characters + 1 check digit (e.g., GB0002634946)."
+    error_message: "ISIN must follow ISO 6166 format: 2-letter country code + 9 alphanumeric characters + 1 check digit (e.g., GB0002634946)."
 
   # ── TRADE DATE ────────────────────────────────────────────────────────────────
   # MiFID II RTS 22 field 31: trading date/time.
   # ISO 8601 date (YYYY-MM-DD) — time captured separately in trade_datetime
   # if your OMS separates them.
-  - field: trade_date
-    rule: not_empty
+  - name: trade_date_not_empty
+    type: not_empty
+    field: trade_date
     severity: error
     description: "Trade date is mandatory (MiFID II RTS 22 field 31)."
+    error_message: "Trade date is mandatory (MiFID II RTS 22 field 31)."
 
-  - field: trade_date
-    rule: regex
+  - name: trade_date_regex
+    type: regex
+    field: trade_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Trade date must be in YYYY-MM-DD format."
+    error_message: "Trade date must be in YYYY-MM-DD format."
 
-  - field: trade_date
-    rule: compare
+  - name: trade_date_compare
+    type: compare
+    field: trade_date
     compare_op: lte
     compare_to: today
     severity: error
     description: "Trade date cannot be in the future (MiFID II RTS 22 — trade date integrity)."
+    error_message: "Trade date cannot be in the future (MiFID II RTS 22 — trade date integrity)."
 
   # ── SETTLEMENT DATE ───────────────────────────────────────────────────────────
   # Standard settlement cycles: T+2 for equities (EU CSDR), T+1 for US equities
   # (SEC rule effective May 2024). Money market instruments typically T+0 or T+1.
-  - field: settlement_date
-    rule: not_empty
+  - name: settlement_date_not_empty
+    type: not_empty
+    field: settlement_date
     severity: error
     description: "Settlement date is mandatory. Required for CSD (Central Securities Depository) instruction generation."
+    error_message: "Settlement date is mandatory. Required for CSD (Central Securities Depository) instruction generation."
 
-  - field: settlement_date
-    rule: regex
+  - name: settlement_date_regex
+    type: regex
+    field: settlement_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Settlement date must be in YYYY-MM-DD format."
+    error_message: "Settlement date must be in YYYY-MM-DD format."
 
   # ── ASSET CLASS ───────────────────────────────────────────────────────────────
   # MiFID II RTS 2 defines financial instrument categories.
   # Asset class determines reporting template, margining rules, and
   # capital treatment under Basel III.
-  - field: asset_class
-    rule: lookup
-    lookup_values:
+  - name: asset_class_allowed_values
+    type: allowed_values
+    field: asset_class
+    allowed_values:
       - EQUITY
       - FIXED_INCOME
       - DERIVATIVE
@@ -138,12 +157,14 @@ rules:
       - STRUCTURED_PRODUCT
     severity: error
     description: "Asset class must be a recognised MiFID II instrument category."
+    error_message: "Asset class must be a recognised MiFID II instrument category."
 
   # ── TRADE TYPE ────────────────────────────────────────────────────────────────
   # Drives allocation logic, position keeping, and T+1 MiFID II report content.
-  - field: trade_type
-    rule: lookup
-    lookup_values:
+  - name: trade_type_allowed_values
+    type: allowed_values
+    field: trade_type
+    allowed_values:
       - BUY
       - SELL
       - SHORT_SELL
@@ -156,35 +177,41 @@ rules:
       - CORPORATE_ACTION
     severity: error
     description: "Trade type must be a recognised instruction type. SHORT_SELL triggers MiFID II short-selling disclosure obligations."
+    error_message: "Trade type must be a recognised instruction type. SHORT_SELL triggers MiFID II short-selling disclosure obligations."
 
   # ── QUANTITY ──────────────────────────────────────────────────────────────────
   # Upper bound covers large institutional block trades.
   # For bond face value (notional), this field represents units/nominal amount
   # in the instrument's minimum denomination.
-  - field: quantity
-    rule: range
+  - name: quantity_range
+    type: range
+    field: quantity
     min: 0
     max: 1000000000
     severity: error
     description: "Quantity must be between 0 and 1,000,000,000. For bonds, this is the face value / nominal amount in minimum denomination units."
+    error_message: "Quantity must be between 0 and 1,000,000,000. For bonds, this is the face value / nominal amount in minimum denomination units."
 
   # ── PRICE ─────────────────────────────────────────────────────────────────────
   # Price per unit in the instrument's currency.
   # Upper bound of 1,000,000 covers high-price equities (e.g., Berkshire Hathaway Class A).
   # For bonds, price is typically expressed as a percentage of par (e.g., 99.75).
-  - field: price
-    rule: range
+  - name: price_range
+    type: range
+    field: price
     min: 0
     max: 1000000
     severity: error
     description: "Price per unit must be between 0 and 1,000,000. For bonds, this is percentage of par; for equities, this is the execution price per share."
+    error_message: "Price per unit must be between 0 and 1,000,000. For bonds, this is percentage of par; for equities, this is the execution price per share."
 
   # ── CURRENCY ──────────────────────────────────────────────────────────────────
   # Settlement currency for the trade leg.
   # MiFID II RTS 22 field 49: price currency.
-  - field: currency
-    rule: lookup
-    lookup_values:
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values:
       - USD
       - EUR
       - GBP
@@ -199,6 +226,7 @@ rules:
       - DKK
     severity: error
     description: "Currency must be a supported ISO 4217 code for trade settlement."
+    error_message: "Currency must be a supported ISO 4217 code for trade settlement."
 
   # ── COUNTERPARTY IDENTIFIER (LEI) ─────────────────────────────────────────────
   # LEI — ISO 17442: 20-character identifier for legal entities in financial markets.
@@ -207,31 +235,39 @@ rules:
   # LEIs are issued by accredited Local Operating Units (LOUs) such as
   # GLEIF, London Stock Exchange, and DTCC.
   # Look up LEIs: https://search.gleif.org
-  - field: counterparty_id
-    rule: not_empty
+  - name: counterparty_id_not_empty
+    type: not_empty
+    field: counterparty_id
     severity: error
     description: "Counterparty LEI is mandatory. MiFID II Article 26(6) requires the counterparty Legal Entity Identifier on all trade reports."
+    error_message: "Counterparty LEI is mandatory. MiFID II Article 26(6) requires the counterparty Legal Entity Identifier on all trade reports."
 
-  - field: counterparty_id
-    rule: regex
+  - name: counterparty_id_regex
+    type: regex
+    field: counterparty_id
     # ISO 17442: 18 uppercase alphanumeric chars (LOU prefix + entity chars) + 2 numeric check digits
     pattern: "^[A-Z0-9]{18}[0-9]{2}$"
     severity: error
     description: "Counterparty ID must be a valid LEI (ISO 17442): 18 uppercase alphanumeric characters followed by 2 numeric check digits (e.g., 549300TRUWO2CD2G5692)."
+    error_message: "Counterparty ID must be a valid LEI (ISO 17442): 18 uppercase alphanumeric characters followed by 2 numeric check digits (e.g., 549300TRUWO2CD2G5692)."
 
   # ── PORTFOLIO IDENTIFICATION ──────────────────────────────────────────────────
-  - field: portfolio_id
-    rule: not_empty
+  - name: portfolio_id_not_empty
+    type: not_empty
+    field: portfolio_id
     severity: error
     description: "Portfolio ID is required for position keeping and fund-level reporting."
+    error_message: "Portfolio ID is required for position keeping and fund-level reporting."
 
   # ── TRADER IDENTIFICATION ─────────────────────────────────────────────────────
   # MiFID II RTS 22 field 12: investment decision maker identifier.
   # For algorithmic trades, this is the algorithm ID.
-  - field: trader_id
-    rule: not_empty
+  - name: trader_id_not_empty
+    type: not_empty
+    field: trader_id
     severity: error
     description: "Trader ID is required. MiFID II RTS 22 field 12 requires the investment decision maker identifier for all transactions."
+    error_message: "Trader ID is required. MiFID II RTS 22 field 12 requires the investment decision maker identifier for all transactions."
 
   # ── EXECUTION VENUE ───────────────────────────────────────────────────────────
   # MiFID II RTS 22 field 36: trading venue (MIC code or internal identifier).
@@ -239,9 +275,10 @@ rules:
   # Full MIC codes (ISO 10383) should be used in production — e.g., XLON for LSE,
   # XNYS for NYSE. This lookup covers the most common venues for starter use.
   # For production, replace with a lookup_file pointing to the full MIC code list.
-  - field: execution_venue
-    rule: lookup
-    lookup_values:
+  - name: execution_venue_allowed_values
+    type: allowed_values
+    field: execution_venue
+    allowed_values:
       - LSE
       - NYSE
       - NASDAQ
@@ -253,18 +290,21 @@ rules:
       - INTERNAL
     severity: error
     description: "Execution venue must be a recognised trading venue (MiFID II RTS 22 field 36). Use ISO 10383 MIC codes in production."
+    error_message: "Execution venue must be a recognised trading venue (MiFID II RTS 22 field 36). Use ISO 10383 MIC codes in production."
 
   # ── MiFID II REPORTING STATUS ─────────────────────────────────────────────────
   # Tracks the trade report lifecycle to the NCA (National Competent Authority).
   # MiFID II RTS 22: reports must be submitted by close of T+1 business day.
   # AMENDED covers corrections submitted under RTS 22 Article 3.
   # CANCELLED covers trade cancellations under RTS 22 Article 4.
-  - field: reporting_status
-    rule: lookup
-    lookup_values:
+  - name: reporting_status_allowed_values
+    type: allowed_values
+    field: reporting_status
+    allowed_values:
       - PENDING
       - REPORTED
       - AMENDED
       - CANCELLED
     severity: error
     description: "Reporting status tracks the MiFID II trade report lifecycle. PENDING reports not submitted by T+1 are a regulatory breach."
+    error_message: "Reporting status tracks the MiFID II trade report lifecycle. PENDING reports not submitted by T+1 are a regulatory breach."

--- a/examples/starter_contracts/healthcare.yaml
+++ b/examples/starter_contracts/healthcare.yaml
@@ -35,146 +35,188 @@ rules:
   # The NHS Number has a modulo-11 check digit (digit 10).
   # This regex validates format only. Full checksum validation available
   # via the checksum rule type (see roadmap — HC-3).
-  - field: nhs_number
-    rule: not_empty
+  - name: nhs_number_not_empty
+    type: not_empty
+    field: nhs_number
     severity: error
     description: "NHS Number is mandatory for all patient records."
+    error_message: "NHS Number is mandatory for all patient records."
 
-  - field: nhs_number
-    rule: regex
+  - name: nhs_number_regex
+    type: regex
+    field: nhs_number
     # Accepts 10 digits with optional spaces: "943 476 5919" or "9434765919"
     pattern: "^[0-9]{3}\\s?[0-9]{3}\\s?[0-9]{4}$"
     severity: error
     description: "NHS Number must be 10 digits (spaces optional: '943 476 5919')."
+    error_message: "NHS Number must be 10 digits (spaces optional: '943 476 5919')."
 
   # ── DEMOGRAPHICS ────────────────────────────────────────────────────────────
-  - field: date_of_birth
-    rule: not_empty
+  - name: date_of_birth_not_empty
+    type: not_empty
+    field: date_of_birth
     severity: error
     description: "Date of birth is mandatory."
+    error_message: "Date of birth is mandatory."
 
-  - field: date_of_birth
-    rule: regex
+  - name: date_of_birth_regex
+    type: regex
+    field: date_of_birth
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Date of birth must be in YYYY-MM-DD format."
+    error_message: "Date of birth must be in YYYY-MM-DD format."
 
-  - field: date_of_birth
-    rule: compare
+  - name: date_of_birth_compare
+    type: compare
+    field: date_of_birth
     compare_op: lte
     compare_to: today
     severity: error
     description: "Date of birth cannot be in the future."
+    error_message: "Date of birth cannot be in the future."
 
-  - field: gender
-    rule: lookup
+  - name: gender_allowed_values
+    type: allowed_values
+    field: gender
     # NHS Data Dictionary gender codes (SNOMED aligned)
     # 9: Not Specified  1: Male  2: Female  0: Not Known  X: Non-Binary
-    lookup_values: ["1", "2", "9", "0", "X"]
+    allowed_values: ["1", "2", "9", "0", "X"]
     severity: error
     description: "Gender must be an NHS Data Dictionary code (1=Male, 2=Female, 9=Not Specified, 0=Not Known, X=Non-Binary)."
+    error_message: "Gender must be an NHS Data Dictionary code (1=Male, 2=Female, 9=Not Specified, 0=Not Known, X=Non-Binary)."
 
-  - field: first_name
-    rule: not_empty
+  - name: first_name_not_empty
+    type: not_empty
+    field: first_name
     severity: error
     description: "First name is required."
+    error_message: "First name is required."
 
-  - field: last_name
-    rule: not_empty
+  - name: last_name_not_empty
+    type: not_empty
+    field: last_name
     severity: error
     description: "Last name is required."
+    error_message: "Last name is required."
 
   # ── CLINICAL CODING ─────────────────────────────────────────────────────────
   # ICD-10-CM format: letter followed by 2 digits, optional decimal and up to 4 more digits.
   # Examples: J18.9 (pneumonia), I21.0 (STEMI), Z00.00 (general exam)
   # For production, replace with a lookup_file pointing to the full ICD-10-CM code list:
   #   lookup_file: "reference_data/icd10cm_2026.csv"
-  - field: icd10_primary
-    rule: regex
+  - name: icd10_primary_regex
+    type: regex
+    field: icd10_primary
     pattern: "^[A-Z][0-9]{2}(\\.[0-9A-Z]{1,4})?$"
     severity: error
     description: "Primary ICD-10-CM diagnosis code must follow standard format (e.g., J18.9, I21.0)."
+    error_message: "Primary ICD-10-CM diagnosis code must follow standard format (e.g., J18.9, I21.0)."
 
   # ── ADMISSION ────────────────────────────────────────────────────────────────
-  - field: admission_date
-    rule: not_empty
+  - name: admission_date_not_empty
+    type: not_empty
+    field: admission_date
     severity: error
     description: "Admission date is required for inpatient records."
+    error_message: "Admission date is required for inpatient records."
 
-  - field: admission_date
-    rule: regex
+  - name: admission_date_regex
+    type: regex
+    field: admission_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Admission date must be in YYYY-MM-DD format."
+    error_message: "Admission date must be in YYYY-MM-DD format."
 
-  - field: admission_type
-    rule: lookup
+  - name: admission_type_allowed_values
+    type: allowed_values
+    field: admission_type
     # NHS HES (Hospital Episode Statistics) admission type codes
-    lookup_values: [ELECTIVE, EMERGENCY, MATERNITY, OTHER]
+    allowed_values: [ELECTIVE, EMERGENCY, MATERNITY, OTHER]
     severity: error
     description: "Admission type must be a valid HES code."
+    error_message: "Admission type must be a valid HES code."
 
-  - field: ward_code
-    rule: not_empty
+  - name: ward_code_not_empty
+    type: not_empty
+    field: ward_code
     severity: error
     description: "Ward code is required for bed management."
+    error_message: "Ward code is required for bed management."
 
-  - field: ward_code
-    rule: max_length
-    max: 10
+  - name: ward_code_max_length
+    type: max_length
+    field: ward_code
+    max_length: 10
     severity: error
     description: "Ward code must not exceed 10 characters."
+    error_message: "Ward code must not exceed 10 characters."
 
   # ── CLINICAL STAFF ──────────────────────────────────────────────────────────
   # UK GMC (General Medical Council) registration: 7 digits
-  - field: attending_clinician_gmc
-    rule: regex
+  - name: attending_clinician_gmc_regex
+    type: regex
+    field: attending_clinician_gmc
     pattern: "^[0-9]{7}$"
     severity: warning
     description: "Attending clinician GMC number must be 7 digits."
+    error_message: "Attending clinician GMC number must be 7 digits."
 
   # ── PHYSIOLOGICAL PLAUSIBILITY ───────────────────────────────────────────────
   # These range checks catch data entry errors and unit confusion
   # before they reach clinical systems.
-  - field: systolic_bp
-    rule: range
+  - name: systolic_bp_range
+    type: range
+    field: systolic_bp
     min: 50
     max: 250
     severity: warning
     description: "Systolic blood pressure should be between 50 and 250 mmHg. Values outside this range are physiologically implausible."
+    error_message: "Systolic blood pressure should be between 50 and 250 mmHg. Values outside this range are physiologically implausible."
 
-  - field: diastolic_bp
-    rule: range
+  - name: diastolic_bp_range
+    type: range
+    field: diastolic_bp
     min: 30
     max: 150
     severity: warning
     description: "Diastolic blood pressure should be between 30 and 150 mmHg."
+    error_message: "Diastolic blood pressure should be between 30 and 150 mmHg."
 
-  - field: heart_rate
-    rule: range
+  - name: heart_rate_range
+    type: range
+    field: heart_rate
     min: 20
     max: 300
     severity: warning
     description: "Heart rate should be between 20 and 300 bpm. Values outside this range warrant review."
+    error_message: "Heart rate should be between 20 and 300 bpm. Values outside this range warrant review."
 
-  - field: temperature_celsius
-    rule: range
+  - name: temperature_celsius_range
+    type: range
+    field: temperature_celsius
     min: 32.0
     max: 43.0
     severity: warning
     description: "Body temperature should be between 32.0°C and 43.0°C. Check for unit error (Fahrenheit entered instead of Celsius)."
+    error_message: "Body temperature should be between 32.0°C and 43.0°C. Check for unit error (Fahrenheit entered instead of Celsius)."
 
-  - field: weight_kg
-    rule: range
+  - name: weight_kg_range
+    type: range
+    field: weight_kg
     min: 0.3
     max: 500.0
     severity: warning
     description: "Weight should be between 0.3 kg (neonate) and 500 kg. Values outside this range suggest a unit error."
+    error_message: "Weight should be between 0.3 kg (neonate) and 500 kg. Values outside this range suggest a unit error."
 
   # ── CONSENT ─────────────────────────────────────────────────────────────────
   # GDPR Article 9 / HIPAA §164.508: consent status must be recorded.
-  - field: data_sharing_consent
-    rule: lookup
-    lookup_values: [YES, NO, NOT_ASKED, WITHDRAWN]
+  - name: data_sharing_consent_allowed_values
+    type: allowed_values
+    field: data_sharing_consent
+    allowed_values: ["YES", "NO", NOT_ASKED, WITHDRAWN]
     severity: error
     description: "Data sharing consent status must be recorded. Required under GDPR Article 9 and HIPAA §164.508."
+    error_message: "Data sharing consent status must be recorded. Required under GDPR Article 9 and HIPAA §164.508."

--- a/examples/starter_contracts/insurance.yaml
+++ b/examples/starter_contracts/insurance.yaml
@@ -58,32 +58,40 @@ rules:
   # ── CLAIM IDENTIFICATION ─────────────────────────────────────────────────────
   # CLM- prefix followed by 8 digits. Adjust prefix to match your internal
   # claims reference system (e.g., ^[A-Z]{2,4}-[0-9]{6,10}$ for alphanumeric).
-  - field: claim_id
-    rule: not_empty
+  - name: claim_id_not_empty
+    type: not_empty
+    field: claim_id
     severity: error
     description: "Claim ID is mandatory. Every FNOL must receive a unique reference at point of registration."
+    error_message: "Claim ID is mandatory. Every FNOL must receive a unique reference at point of registration."
 
-  - field: claim_id
-    rule: regex
+  - name: claim_id_regex
+    type: regex
+    field: claim_id
     pattern: "^CLM-[0-9]{8}$"
     severity: error
     description: "Claim ID must match format CLM-XXXXXXXX (8 digits). Example: CLM-20240001."
+    error_message: "Claim ID must match format CLM-XXXXXXXX (8 digits). Example: CLM-20240001."
 
   # ── POLICY IDENTIFICATION ────────────────────────────────────────────────────
   # Alphanumeric policy reference: 8–15 characters. Adjust to your scheme's
   # format. For production, replace with a lookup_file against your policy admin
   # system to ensure the policy actually exists.
-  - field: policy_number
-    rule: not_empty
+  - name: policy_number_not_empty
+    type: not_empty
+    field: policy_number
     severity: error
     description: "Policy number is mandatory. A claim cannot be processed without a linked policy."
+    error_message: "Policy number is mandatory. A claim cannot be processed without a linked policy."
 
-  - field: policy_number
-    rule: regex
+  - name: policy_number_regex
+    type: regex
+    field: policy_number
     # 8–15 alphanumeric characters, uppercase letters and digits only
     pattern: "^[A-Z0-9]{8,15}$"
     severity: error
     description: "Policy number must be 8–15 alphanumeric characters (uppercase). Example: POL20240001."
+    error_message: "Policy number must be 8–15 alphanumeric characters (uppercase). Example: POL20240001."
 
   # ── CLAIM TYPE ───────────────────────────────────────────────────────────────
   # ACORD-aligned classification covering personal lines and commercial.
@@ -91,9 +99,10 @@ rules:
   # BUSINESS_INTERRUPTION: commercial line for loss of revenue following
   # an insured peril (e.g., fire, flood). CYBER: covers data breach costs,
   # ransomware, business interruption from IT failure.
-  - field: claim_type
-    rule: lookup
-    lookup_values:
+  - name: claim_type_allowed_values
+    type: allowed_values
+    field: claim_type
+    allowed_values:
       - MOTOR_FAULT
       - MOTOR_NO_FAULT
       - PROPERTY_DAMAGE
@@ -108,76 +117,98 @@ rules:
       - CYBER
     severity: error
     description: "Claim type must be an ACORD-aligned product line classification."
+    error_message: "Claim type must be an ACORD-aligned product line classification."
 
   # ── INCIDENT DATE ────────────────────────────────────────────────────────────
-  - field: incident_date
-    rule: not_empty
+  - name: incident_date_not_empty
+    type: not_empty
+    field: incident_date
     severity: error
     description: "Incident date is mandatory. Required for limitation period calculation (UK Limitation Act 1980)."
+    error_message: "Incident date is mandatory. Required for limitation period calculation (UK Limitation Act 1980)."
 
-  - field: incident_date
-    rule: regex
+  - name: incident_date_regex
+    type: regex
+    field: incident_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Incident date must be in YYYY-MM-DD format."
+    error_message: "Incident date must be in YYYY-MM-DD format."
 
-  - field: incident_date
-    rule: compare
+  - name: incident_date_compare
+    type: compare
+    field: incident_date
     compare_op: lte
     compare_to: today
     severity: error
     description: "Incident date cannot be in the future."
+    error_message: "Incident date cannot be in the future."
 
   # ── REPORT DATE ─────────────────────────────────────────────────────────────
   # The date the claim was reported to the insurer (FNOL date).
   # Must be on or after the incident date. Cross-field validation (report_date
   # >= incident_date) requires the cross_field_range rule — see ROADMAP below.
-  - field: report_date
-    rule: not_empty
+  - name: report_date_not_empty
+    type: not_empty
+    field: report_date
     severity: error
     description: "Report date (FNOL date) is mandatory. FCA ICOBS 8.1 requires acknowledgement within 5 business days of FNOL."
+    error_message: "Report date (FNOL date) is mandatory. FCA ICOBS 8.1 requires acknowledgement within 5 business days of FNOL."
 
-  - field: report_date
-    rule: regex
+  - name: report_date_regex
+    type: regex
+    field: report_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Report date must be in YYYY-MM-DD format."
+    error_message: "Report date must be in YYYY-MM-DD format."
 
-  - field: report_date
-    rule: cross_field_range
-    min_field: incident_date
+  - name: report_date_compare
+    type: compare
+    field: report_date
+    compare_to: incident_date
     severity: error
     description: "Report date cannot be earlier than incident date."
+    compare_op: gte
+    error_message: "Report date cannot be earlier than incident date."
 
   # ── CLAIM FINANCIALS ─────────────────────────────────────────────────────────
   # claim_amount_requested: the gross amount claimed by the policyholder.
   # Max of 50,000,000 (50M) covers standard single-risk limits for most
   # personal and SME commercial lines. Catastrophe or marine/aviation claims
   # may require a higher max — adjust to your treaty reinsurance limit.
-  - field: claim_amount_requested
-    rule: not_empty
+  - name: claim_amount_requested_not_empty
+    type: not_empty
+    field: claim_amount_requested
     severity: error
     description: "Claim amount requested is mandatory. Required for reserve setting and Solvency II technical provisions."
+    error_message: "Claim amount requested is mandatory. Required for reserve setting and Solvency II technical provisions."
 
-  - field: claim_amount_requested
-    rule: range
+  - name: claim_amount_requested_range
+    type: range
+    field: claim_amount_requested
     min: 0
     max: 50000000
     severity: error
     description: "Claim amount requested must be between 0 and 50,000,000. Values above this threshold require escalation to a senior handler."
+    error_message: "Claim amount requested must be between 0 and 50,000,000. Values above this threshold require escalation to a senior handler."
 
-  - field: claim_currency
-    rule: lookup
+  - name: claim_currency_allowed_values
+    type: allowed_values
+    field: claim_currency
     # ISO 4217 codes. Expand for your book of business.
-    lookup_values: [USD, EUR, GBP, AUD, CAD, ZAR, SGD]
+    allowed_values: [USD, EUR, GBP, AUD, CAD, ZAR, SGD]
     severity: error
     description: "Claim currency must be a supported ISO 4217 code."
+    error_message: "Claim currency must be a supported ISO 4217 code."
 
   # ── CLAIMANT ─────────────────────────────────────────────────────────────────
-  - field: claimant_id
-    rule: not_empty
+  - name: claimant_id_not_empty
+    type: not_empty
+    field: claimant_id
     severity: error
     description: "Claimant ID is mandatory. Required to link the claim to a verified party and prevent duplicate FNOL entries."
+    error_message: "Claimant ID is mandatory. Required to link the claim to a verified party and prevent duplicate FNOL entries."
 
   # ── POLICY STATUS AT INCIDENT ────────────────────────────────────────────────
   # Was the policy in force when the incident occurred?
@@ -185,11 +216,13 @@ rules:
   # before incident. SUSPENDED: cover temporarily suspended (e.g., SORN for motor).
   # Claims on LAPSED, CANCELLED, or SUSPENDED policies must be reviewed before
   # any payment is authorised — these are high fraud-risk scenarios.
-  - field: policy_status_at_incident
-    rule: lookup
-    lookup_values: [ACTIVE, LAPSED, CANCELLED, SUSPENDED]
+  - name: policy_status_at_incident_allowed_values
+    type: allowed_values
+    field: policy_status_at_incident
+    allowed_values: [ACTIVE, LAPSED, CANCELLED, SUSPENDED]
     severity: error
     description: "Policy status at time of incident must be recorded. Claims on non-ACTIVE policies require mandatory handler review."
+    error_message: "Policy status at time of incident must be recorded. Claims on non-ACTIVE policies require mandatory handler review."
 
   # ── FRAUD INDICATOR ─────────────────────────────────────────────────────────
   # Output from the fraud scoring engine (e.g., CIFAS National Fraud Database,
@@ -198,11 +231,13 @@ rules:
   #   MEDIUM        → referral to Special Investigations Unit (SIU)
   #   HIGH          → SIU investigation mandatory before any payment
   #   CONFIRMED     → claim denied, refer to IFED (Insurance Fraud Enforcement)
-  - field: fraud_indicator
-    rule: lookup
-    lookup_values: [NONE, LOW, MEDIUM, HIGH, CONFIRMED]
+  - name: fraud_indicator_allowed_values
+    type: allowed_values
+    field: fraud_indicator
+    allowed_values: [NONE, LOW, MEDIUM, HIGH, CONFIRMED]
     severity: error
     description: "Fraud indicator is mandatory. Drives claims workflow routing to Special Investigations Unit. See ABI fraud guidelines."
+    error_message: "Fraud indicator is mandatory. Drives claims workflow routing to Special Investigations Unit. See ABI fraud guidelines."
 
   # ── CLAIM STATUS ─────────────────────────────────────────────────────────────
   # FNOL: First Notice of Loss received, not yet allocated.
@@ -210,9 +245,10 @@ rules:
   # PARTIALLY_APPROVED: some heads of loss approved, others under review.
   # PAID: settlement amount disbursed to claimant.
   # APPEALED: claimant has invoked FCA dispute resolution process.
-  - field: claim_status
-    rule: lookup
-    lookup_values:
+  - name: claim_status_allowed_values
+    type: allowed_values
+    field: claim_status
+    allowed_values:
       - FNOL
       - UNDER_INVESTIGATION
       - APPROVED
@@ -224,6 +260,7 @@ rules:
       - APPEALED
     severity: error
     description: "Claim status must be a valid workflow state. Status transitions must follow the claims lifecycle (FNOL → UNDER_INVESTIGATION → ... → CLOSED)."
+    error_message: "Claim status must be a valid workflow state. Status transitions must follow the claims lifecycle (FNOL → UNDER_INVESTIGATION → ... → CLOSED)."
 
   # ── RESERVE AMOUNT ──────────────────────────────────────────────────────────
   # Initial case reserve set by the claims handler at point of allocation.
@@ -231,52 +268,64 @@ rules:
   # provisions. Systematic under-reserving (setting reserves too low) is a
   # key indicator of deteriorating claims experience and triggers PRA scrutiny.
   # Max of 100,000,000 (100M) covers treaty reinsurance layers.
-  - field: reserve_amount
-    rule: not_empty
+  - name: reserve_amount_not_empty
+    type: not_empty
+    field: reserve_amount
     severity: error
     description: "Reserve amount is mandatory. Solvency II Article 76 requires best-estimate liabilities for all reported claims."
+    error_message: "Reserve amount is mandatory. Solvency II Article 76 requires best-estimate liabilities for all reported claims."
 
-  - field: reserve_amount
-    rule: range
+  - name: reserve_amount_range
+    type: range
+    field: reserve_amount
     min: 0
     max: 100000000
     severity: error
     description: "Reserve amount must be between 0 and 100,000,000. Part of Solvency II technical provisions — accuracy is a regulatory obligation."
+    error_message: "Reserve amount must be between 0 and 100,000,000. Part of Solvency II technical provisions — accuracy is a regulatory obligation."
 
   # ── HANDLER ──────────────────────────────────────────────────────────────────
-  - field: handler_id
-    rule: not_empty
+  - name: handler_id_not_empty
+    type: not_empty
+    field: handler_id
     severity: error
     description: "Handler ID is mandatory once a claim moves beyond FNOL. Required for audit trail and FCA supervisory accountability."
+    error_message: "Handler ID is mandatory once a claim moves beyond FNOL. Required for audit trail and FCA supervisory accountability."
 
   # ── DOCUMENTATION ────────────────────────────────────────────────────────────
   # Solvency II requires evidence of substantiation for all claims payments.
   # PARTIAL: some required documents received (e.g., police report outstanding).
   # Claims should not be approved while documents_received = NO or PARTIAL
   # without documented handler justification.
-  - field: documents_received
-    rule: lookup
-    lookup_values: [YES, NO, PARTIAL]
+  - name: documents_received_allowed_values
+    type: allowed_values
+    field: documents_received
+    allowed_values: ["YES", "NO", PARTIAL]
     severity: warning
     description: "Documentation status must be recorded. Solvency II requires evidential substantiation of claims payments. Incomplete documentation delays settlement and may indicate fraud."
+    error_message: "Documentation status must be recorded. Solvency II requires evidential substantiation of claims payments. Incomplete documentation delays settlement and may indicate fraud."
 
   # ── EXCESS / DEDUCTIBLE ──────────────────────────────────────────────────────
   # The amount the policyholder bears before the insurer pays.
   # Also called the deductible in US terminology.
   # Max 100,000 covers standard compulsory and voluntary excess levels.
-  - field: excess_amount
-    rule: range
+  - name: excess_amount_range
+    type: range
+    field: excess_amount
     min: 0
     max: 100000
     severity: warning
     description: "Excess amount must be between 0 and 100,000. Values above this range suggest a data entry error or an unusual high-net-worth policy structure."
+    error_message: "Excess amount must be between 0 and 100,000. Values above this range suggest a data entry error or an unusual high-net-worth policy structure."
 
   # ── THIRD PARTY ──────────────────────────────────────────────────────────────
   # Was a third party involved in the incident?
   # Relevant for subrogation (recovering costs from a negligent third party),
   # Motor Insurers' Bureau (MIB) notifications, and liability apportionment.
-  - field: third_party_involved
-    rule: lookup
-    lookup_values: [YES, NO, UNKNOWN]
+  - name: third_party_involved_allowed_values
+    type: allowed_values
+    field: third_party_involved
+    allowed_values: ["YES", "NO", UNKNOWN]
     severity: warning
     description: "Third party involvement must be recorded. Required for subrogation assessment and Motor Insurers' Bureau (MIB) notification obligations."
+    error_message: "Third party involvement must be recorded. Required for subrogation assessment and Motor Insurers' Bureau (MIB) notification obligations."

--- a/examples/starter_contracts/logistics.yaml
+++ b/examples/starter_contracts/logistics.yaml
@@ -43,51 +43,63 @@ rules:
   # ── SHIPMENT IDENTIFICATION ──────────────────────────────────────────────────
   # Internal shipment reference. Format: SHP- followed by exactly 10 uppercase
   # alphanumeric characters. Adapt the regex to match your TMS ID scheme.
-  - field: shipment_id
-    rule: not_empty
+  - name: shipment_id_not_empty
+    type: not_empty
+    field: shipment_id
     severity: error
     description: "Shipment ID is mandatory — all downstream systems key on this reference."
+    error_message: "Shipment ID is mandatory — all downstream systems key on this reference."
 
-  - field: shipment_id
-    rule: regex
+  - name: shipment_id_regex
+    type: regex
+    field: shipment_id
     pattern: "^SHP-[A-Z0-9]{10}$"
     severity: error
     description: "Shipment ID must follow the format SHP-XXXXXXXXXX (10 uppercase alphanumeric characters, e.g., SHP-ABCD123456)."
+    error_message: "Shipment ID must follow the format SHP-XXXXXXXXXX (10 uppercase alphanumeric characters, e.g., SHP-ABCD123456)."
 
   # Carrier or freight forwarder tracking number. Format varies by carrier;
   # this rule enforces a maximum length only. For carrier-specific formats,
   # create a derived contract or use required_if + regex per carrier_code.
-  - field: tracking_number
-    rule: not_empty
+  - name: tracking_number_not_empty
+    type: not_empty
+    field: tracking_number
     severity: error
     description: "Carrier tracking number is mandatory for end-to-end shipment visibility."
+    error_message: "Carrier tracking number is mandatory for end-to-end shipment visibility."
 
-  - field: tracking_number
-    rule: max_length
-    max: 50
+  - name: tracking_number_max_length
+    type: max_length
+    field: tracking_number
+    max_length: 50
     severity: error
     description: "Tracking number must not exceed 50 characters."
+    error_message: "Tracking number must not exceed 50 characters."
 
   # ── CARRIER ─────────────────────────────────────────────────────────────────
   # Standard carrier codes used in EDI and TMS integrations. Extend this list
   # with your contracted carriers. Road hauliers (e.g., XPO, GEODIS) and
   # regional last-mile operators can be added here.
-  - field: carrier_code
-    rule: lookup
-    lookup_values: [UPS, FEDEX, DHL, TNT, ROYAL_MAIL, DPWORLD, MAERSK,
+  - name: carrier_code_allowed_values
+    type: allowed_values
+    field: carrier_code
+    allowed_values: [UPS, FEDEX, DHL, TNT, ROYAL_MAIL, DPWORLD, MAERSK,
                     MSC, CMA_CGM, EVERGREEN, AIR_FRANCE_KLM_CARGO,
                     EMIRATES_SKY_CARGO, AMAZON_LOGISTICS, HERMES, DPD]
     severity: error
     description: "Carrier code must be a recognised operator. Add regional carriers to lookup_values as needed."
+    error_message: "Carrier code must be a recognised operator. Add regional carriers to lookup_values as needed."
 
   # ── SHIPMENT MODE ────────────────────────────────────────────────────────────
   # IATA/IMDG mode of transport. MULTIMODAL covers combined road+rail,
   # sea+road, etc. and is common in intermodal container movements.
-  - field: shipment_mode
-    rule: lookup
-    lookup_values: [AIR, SEA, ROAD, RAIL, MULTIMODAL, COURIER]
+  - name: shipment_mode_allowed_values
+    type: allowed_values
+    field: shipment_mode
+    allowed_values: [AIR, SEA, ROAD, RAIL, MULTIMODAL, COURIER]
     severity: error
     description: "Shipment mode must be a valid transport mode. MULTIMODAL covers intermodal container movements."
+    error_message: "Shipment mode must be a valid transport mode. MULTIMODAL covers intermodal container movements."
 
   # ── UN/LOCODE ROUTING ────────────────────────────────────────────────────────
   # UN/LOCODE is the international standard for identifying locations involved
@@ -98,82 +110,107 @@ rules:
   #   DEHAM = Hamburg, Germany     CNSHA = Shanghai, China
   #   NGLOS = Lagos, Nigeria       SGSIN = Singapore
   # Full list: https://unece.org/trade/cefact/UNLOCODE-Download
-  - field: origin_locode
-    rule: not_empty
+  - name: origin_locode_not_empty
+    type: not_empty
+    field: origin_locode
     severity: error
     description: "Origin UN/LOCODE is mandatory for TMS routing and customs filing."
+    error_message: "Origin UN/LOCODE is mandatory for TMS routing and customs filing."
 
-  - field: origin_locode
-    rule: regex
+  - name: origin_locode_regex
+    type: regex
+    field: origin_locode
     pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
     severity: error
     description: "Origin must be a valid UN/LOCODE (2-letter country + 3-character location code, e.g., GBLON, USNYC, DEHAM)."
+    error_message: "Origin must be a valid UN/LOCODE (2-letter country + 3-character location code, e.g., GBLON, USNYC, DEHAM)."
 
-  - field: destination_locode
-    rule: not_empty
+  - name: destination_locode_not_empty
+    type: not_empty
+    field: destination_locode
     severity: error
     description: "Destination UN/LOCODE is mandatory for delivery planning and customs pre-arrival filing."
+    error_message: "Destination UN/LOCODE is mandatory for delivery planning and customs pre-arrival filing."
 
-  - field: destination_locode
-    rule: regex
+  - name: destination_locode_regex
+    type: regex
+    field: destination_locode
     pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
     severity: error
     description: "Destination must be a valid UN/LOCODE (e.g., SGSIN, AESHY, NGLOS)."
+    error_message: "Destination must be a valid UN/LOCODE (e.g., SGSIN, AESHY, NGLOS)."
 
   # ── DATES ────────────────────────────────────────────────────────────────────
-  - field: departure_date
-    rule: not_empty
+  - name: departure_date_not_empty
+    type: not_empty
+    field: departure_date
     severity: error
     description: "Departure date is mandatory for scheduling and transit time calculation."
+    error_message: "Departure date is mandatory for scheduling and transit time calculation."
 
-  - field: departure_date
-    rule: regex
+  - name: departure_date_regex
+    type: regex
+    field: departure_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Departure date must be in YYYY-MM-DD format."
+    error_message: "Departure date must be in YYYY-MM-DD format."
 
-  - field: expected_arrival_date
-    rule: not_empty
+  - name: expected_arrival_date_not_empty
+    type: not_empty
+    field: expected_arrival_date
     severity: error
     description: "Expected arrival date is mandatory for delivery planning and SLA management."
+    error_message: "Expected arrival date is mandatory for delivery planning and SLA management."
 
-  - field: expected_arrival_date
-    rule: regex
+  - name: expected_arrival_date_regex
+    type: regex
+    field: expected_arrival_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Expected arrival date must be in YYYY-MM-DD format."
+    error_message: "Expected arrival date must be in YYYY-MM-DD format."
 
-  - field: expected_arrival_date
-    rule: cross_field_range
-    min_field: departure_date
+  - name: expected_arrival_date_compare
+    type: compare
+    field: expected_arrival_date
+    compare_to: departure_date
     severity: error
     description: "Expected arrival date must be on or after departure date."
+    compare_op: gte
+    error_message: "Expected arrival date must be on or after departure date."
 
   # ── PHYSICAL ATTRIBUTES ──────────────────────────────────────────────────────
   # Weight in kilograms. Upper bound of 200,000 kg = 200 metric tonnes,
   # covering the heaviest project cargo and break-bulk shipments.
   # For standard parcel carriers (e.g., COURIER mode), consider a tighter
   # bound (e.g., max: 70) via a derived contract.
-  - field: weight_kg
-    rule: not_empty
+  - name: weight_kg_not_empty
+    type: not_empty
+    field: weight_kg
     severity: error
     description: "Gross weight is mandatory for carrier booking, freight rate calculation, and dangerous goods declaration."
+    error_message: "Gross weight is mandatory for carrier booking, freight rate calculation, and dangerous goods declaration."
 
-  - field: weight_kg
-    rule: range
+  - name: weight_kg_range
+    type: range
+    field: weight_kg
     min: 0.001
     max: 200000.0
     severity: error
     description: "Gross weight must be between 0.001 kg and 200,000 kg (200 metric tonnes). Values outside this range suggest a unit error (grams entered instead of kg, or a data entry error)."
+    error_message: "Gross weight must be between 0.001 kg and 200,000 kg (200 metric tonnes). Values outside this range suggest a unit error (grams entered instead of kg, or a data entry error)."
 
   # Volume in cubic metres (CBM). Upper bound of 5,000 CBM covers the
   # largest container vessels' individual shipment allocations.
-  - field: volume_cbm
-    rule: range
+  - name: volume_cbm_range
+    type: range
+    field: volume_cbm
     min: 0.0
     max: 5000.0
     severity: warning
     description: "Volume must be between 0 and 5,000 CBM. Values above 5,000 CBM are implausible for a single shipment record."
+    error_message: "Volume must be between 0 and 5,000 CBM. Values above 5,000 CBM are implausible for a single shipment record."
 
   # ── INCOTERMS 2020 ────────────────────────────────────────────────────────────
   # Incoterms 2020 (International Commercial Terms, ICC) define the point at
@@ -188,30 +225,36 @@ rules:
   #
   # Incoterms 2020 introduced DPU (Delivered at Place Unloaded), replacing DAT.
   # FAS and FOB apply to sea/inland waterway only; all others apply to any mode.
-  - field: incoterm
-    rule: lookup
-    lookup_values: [EXW, FCA, FAS, FOB, CFR, CIF, CPT, CIP, DAP, DPU, DDP]
+  - name: incoterm_allowed_values
+    type: allowed_values
+    field: incoterm
+    allowed_values: [EXW, FCA, FAS, FOB, CFR, CIF, CPT, CIP, DAP, DPU, DDP]
     severity: error
     description: "Incoterm must be a valid Incoterms 2020 code (ICC). DPU replaced DAT in the 2020 revision. Incorrect Incoterm affects insurance, customs valuation, and cost allocation."
+    error_message: "Incoterm must be a valid Incoterms 2020 code (ICC). DPU replaced DAT in the 2020 revision. Incorrect Incoterm affects insurance, customs valuation, and cost allocation."
 
   # ── CUSTOMS ──────────────────────────────────────────────────────────────────
   # HS Code (Harmonised System) — the WCO international tariff classification.
   # 6 digits = international standard; 8–10 digits = country-specific extensions.
   # Example: 847130 = laptop computers. Required for customs declaration and
   # import duty calculation.
-  - field: hs_code
-    rule: regex
+  - name: hs_code_regex
+    type: regex
+    field: hs_code
     pattern: "^[0-9]{6,10}$"
     severity: error
     description: "HS code must be 6–10 digits (WCO Harmonised System). 6 digits = international; 8–10 digits = national extension. Required for customs entry and duty calculation."
+    error_message: "HS code must be 6–10 digits (WCO Harmonised System). 6 digits = international; 8–10 digits = national extension. Required for customs entry and duty calculation."
 
   # Customs clearance lifecycle status.
-  - field: customs_status
-    rule: lookup
-    lookup_values: [PRE_CLEARANCE, IN_CUSTOMS, CLEARED, HELD, REFUSED,
+  - name: customs_status_allowed_values
+    type: allowed_values
+    field: customs_status
+    allowed_values: [PRE_CLEARANCE, IN_CUSTOMS, CLEARED, HELD, REFUSED,
                     DUTY_PAYABLE]
     severity: error
     description: "Customs status must reflect the current clearance stage. HELD and REFUSED statuses should trigger operational alerts."
+    error_message: "Customs status must reflect the current clearance stage. HELD and REFUSED statuses should trigger operational alerts."
 
   # ── HAZARDOUS MATERIALS ──────────────────────────────────────────────────────
   # IMDG (International Maritime Dangerous Goods) and IATA DGR classification.
@@ -225,29 +268,35 @@ rules:
   #   5 = Oxidisers / organic peroxides
   #   6 = Toxic / infectious  7 = Radioactive material
   #   8 = Corrosives          9 = Miscellaneous (lithium batteries, dry ice, etc.)
-  - field: hazmat_class
-    rule: lookup
-    lookup_values: [NONE, 1_EXPLOSIVES, 2_GASES, 3_FLAMMABLE_LIQUIDS,
+  - name: hazmat_class_allowed_values
+    type: allowed_values
+    field: hazmat_class
+    allowed_values: [NONE, 1_EXPLOSIVES, 2_GASES, 3_FLAMMABLE_LIQUIDS,
                     4_FLAMMABLE_SOLIDS, 5_OXIDISERS, 6_TOXIC,
                     7_RADIOACTIVE, 8_CORROSIVES, 9_MISCELLANEOUS]
     severity: error
     description: "Hazmat class must be declared. Use NONE for non-hazardous goods. Classes 1–9 require a Dangerous Goods Declaration (DGD) under IMDG/IATA DGR."
+    error_message: "Hazmat class must be declared. Use NONE for non-hazardous goods. Classes 1–9 require a Dangerous Goods Declaration (DGD) under IMDG/IATA DGR."
 
   # ── SHIPMENT STATUS ──────────────────────────────────────────────────────────
-  - field: shipment_status
-    rule: lookup
-    lookup_values: [BOOKED, COLLECTED, IN_TRANSIT, CUSTOMS, OUT_FOR_DELIVERY,
+  - name: shipment_status_allowed_values
+    type: allowed_values
+    field: shipment_status
+    allowed_values: [BOOKED, COLLECTED, IN_TRANSIT, CUSTOMS, OUT_FOR_DELIVERY,
                     DELIVERED, EXCEPTION, RETURNED, LOST]
     severity: error
     description: "Shipment status must be a recognised lifecycle stage. EXCEPTION and LOST statuses should trigger SLA and claims workflows."
+    error_message: "Shipment status must be a recognised lifecycle stage. EXCEPTION and LOST statuses should trigger SLA and claims workflows."
 
   # ── INSURANCE ────────────────────────────────────────────────────────────────
   # Declared cargo value for insurance purposes, in USD. Upper bound of
   # $100,000,000 (100 million) covers high-value project cargo.
   # Zero is valid (uninsured shipment). Negative values indicate a data error.
-  - field: insurance_value_usd
-    rule: range
+  - name: insurance_value_usd_range
+    type: range
+    field: insurance_value_usd
     min: 0.0
     max: 100000000.0
     severity: warning
     description: "Insurance value must be between USD 0 and USD 100,000,000. Zero indicates an uninsured shipment. Negative values are invalid."
+    error_message: "Insurance value must be between USD 0 and USD 100,000,000. Zero indicates an uninsured shipment. Negative values are invalid."

--- a/examples/starter_contracts/manufacturing.yaml
+++ b/examples/starter_contracts/manufacturing.yaml
@@ -39,139 +39,174 @@ rules:
   # Asset tag format: 2–6 uppercase letters (asset class) + hyphen + 4–8 digits (serial).
   # Examples: PUMP-00142, MTR-001, CONV-04892, FURN-0001
   # Adapt the regex to match your asset naming convention.
-  - field: asset_id
-    rule: not_empty
+  - name: asset_id_not_empty
+    type: not_empty
+    field: asset_id
     severity: error
     description: "Asset ID is mandatory — readings cannot be processed without knowing the source asset."
+    error_message: "Asset ID is mandatory — readings cannot be processed without knowing the source asset."
 
-  - field: asset_id
-    rule: regex
+  - name: asset_id_regex
+    type: regex
+    field: asset_id
     pattern: "^[A-Z]{2,6}-[0-9]{4,8}$"
     severity: error
     description: "Asset ID must follow the format PREFIX-SERIAL (e.g., PUMP-00142, CONV-04892)."
+    error_message: "Asset ID must follow the format PREFIX-SERIAL (e.g., PUMP-00142, CONV-04892)."
 
-  - field: line_id
-    rule: not_empty
+  - name: line_id_not_empty
+    type: not_empty
+    field: line_id
     severity: error
     description: "Production line ID is required for routing to the correct process context."
+    error_message: "Production line ID is required for routing to the correct process context."
 
-  - field: line_id
-    rule: max_length
-    max: 20
+  - name: line_id_max_length
+    type: max_length
+    field: line_id
+    max_length: 20
     severity: error
     description: "Line ID must not exceed 20 characters."
+    error_message: "Line ID must not exceed 20 characters."
 
   # ── SENSOR TYPE ──────────────────────────────────────────────────────────────
-  - field: sensor_type
-    rule: lookup
+  - name: sensor_type_allowed_values
+    type: allowed_values
+    field: sensor_type
     # Extend this list with your sensor types.
     # OPC UA node class names used as a starting point.
-    lookup_values: [TEMPERATURE, PRESSURE, VIBRATION, FLOW, HUMIDITY,
+    allowed_values: [TEMPERATURE, PRESSURE, VIBRATION, FLOW, HUMIDITY,
                     CURRENT, VOLTAGE, TORQUE, SPEED, POSITION, FORCE,
                     LEVEL, PH, CONDUCTIVITY, WEIGHT, THICKNESS, OPACITY]
     severity: error
     description: "Sensor type must be a recognised measurement category."
+    error_message: "Sensor type must be a recognised measurement category."
 
   # ── MEASUREMENT VALUE ────────────────────────────────────────────────────────
-  - field: reading_value
-    rule: not_empty
+  - name: reading_value_not_empty
+    type: not_empty
+    field: reading_value
     severity: error
     description: "Reading value is mandatory."
+    error_message: "Reading value is mandatory."
 
   # Temperature range: covers ambient (-40°C) through industrial furnace (1200°C).
   # For narrower processes (e.g., cold chain: -25 to +8°C), create a separate
   # contract or use required_if to apply tighter bounds for TEMPERATURE sensors.
-  - field: temperature_reading
-    rule: range
+  - name: temperature_reading_range
+    type: range
+    field: temperature_reading
     min: -40.0
     max: 1200.0
     severity: error
     description: "Temperature reading must be between -40°C and 1200°C. Values outside this range are physically implausible for industrial sensors."
+    error_message: "Temperature reading must be between -40°C and 1200°C. Values outside this range are physically implausible for industrial sensors."
 
   # Pressure range: 0 to 1000 bar covers most industrial applications.
   # Adjust max for high-pressure hydraulics (up to 3000 bar) or low-pressure
   # pneumatics (adjust min to -1 for vacuum).
-  - field: pressure_reading
-    rule: range
+  - name: pressure_reading_range
+    type: range
+    field: pressure_reading
     min: 0.0
     max: 1000.0
     severity: error
     description: "Pressure reading must be between 0 and 1,000 bar."
+    error_message: "Pressure reading must be between 0 and 1,000 bar."
 
   # Current range: 0 to 1000 A covers most industrial motors and drives.
-  - field: current_reading
-    rule: range
+  - name: current_reading_range
+    type: range
+    field: current_reading
     min: 0.0
     max: 1000.0
     severity: warning
     description: "Current reading must be between 0 and 1,000 amperes."
+    error_message: "Current reading must be between 0 and 1,000 amperes."
 
-  - field: reading_value
-    rule: cross_field_range
-    min_field: tolerance_low
-    max_field: tolerance_high
+  - name: reading_value_cross_field_range
+    type: cross_field_range
+    field: reading_value
+    cross_min_field: tolerance_low
+    cross_max_field: tolerance_high
     severity: error
     description: "Reading must fall within the tolerance band for this part/process."
+    error_message: "Reading must fall within the tolerance band for this part/process."
 
   # ── ENGINEERING UNITS ────────────────────────────────────────────────────────
   # Unit errors are among the most common and damaging data quality failures
   # in manufacturing. Validate units explicitly.
-  - field: unit
-    rule: lookup
+  - name: unit_allowed_values
+    type: allowed_values
+    field: unit
     # SI and common industrial units. Extend as needed.
-    lookup_values: [degC, degF, K, bar, psi, kPa, MPa, Pa,
+    allowed_values: [degC, degF, K, bar, psi, kPa, MPa, Pa,
                     mm_s, m_s2, Hz, rpm, L_min, m3_h, kg_s,
-                    pct_RH, A, V, kW, W, Nm, N, kg, g, mm, m,
+                    pct_RH, A, V, kW, W, Nm, "N", kg, g, mm, m,
                     pH, mS_cm, ppm, ppb, lux, dB]
     severity: error
     description: "Engineering unit must be a recognised symbol. This prevents unit confusion errors (e.g., Celsius entered as Fahrenheit)."
+    error_message: "Engineering unit must be a recognised symbol. This prevents unit confusion errors (e.g., Celsius entered as Fahrenheit)."
 
   # ── TIMESTAMP ────────────────────────────────────────────────────────────────
-  - field: timestamp
-    rule: not_empty
+  - name: timestamp_not_empty
+    type: not_empty
+    field: timestamp
     severity: error
     description: "Timestamp is mandatory for time-series data."
+    error_message: "Timestamp is mandatory for time-series data."
 
-  - field: timestamp
-    rule: regex
+  - name: timestamp_regex
+    type: regex
+    field: timestamp
     # ISO 8601 datetime with timezone
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Timestamp must be ISO 8601 datetime with timezone (e.g., 2026-03-09T14:30:00.000Z)."
+    error_message: "Timestamp must be ISO 8601 datetime with timezone (e.g., 2026-03-09T14:30:00.000Z)."
 
-  - field: timestamp
-    rule: compare
+  - name: timestamp_compare
+    type: compare
+    field: timestamp
     compare_op: lte
     compare_to: now
     severity: error
     description: "Sensor timestamp cannot be in the future."
+    error_message: "Sensor timestamp cannot be in the future."
 
   # ── OPC UA QUALITY FLAGS ─────────────────────────────────────────────────────
   # OPC UA defines a quality code for every data point indicating the
   # reliability of the reading. Always validate quality_flag before
   # using a reading in process control or analytics.
-  - field: quality_flag
-    rule: lookup
+  - name: quality_flag_allowed_values
+    type: allowed_values
+    field: quality_flag
     # OPC UA Part 8 quality codes (simplified)
-    lookup_values: [GOOD, BAD, UNCERTAIN, SUBSTITUTED, CALCULATED,
+    allowed_values: [GOOD, BAD, UNCERTAIN, SUBSTITUTED, CALCULATED,
                     SENSOR_FAILURE, COMM_FAILURE, OUT_OF_RANGE,
                     CONFIGURATION_ERROR, NOT_CONNECTED]
     severity: error
     description: "OPC UA quality flag must be set. Readings with BAD or SENSOR_FAILURE quality should not be used in process control."
+    error_message: "OPC UA quality flag must be set. Readings with BAD or SENSOR_FAILURE quality should not be used in process control."
 
   # Rule: reject readings with BAD quality before they enter downstream systems.
   # Using required_if as a workaround: if quality_flag is BAD, require a
   # reason_code field to be present (forces explicit acknowledgement).
-  - field: reason_code
-    rule: required_if
-    when_field: quality_flag
-    when_value: BAD
+  - name: reason_code_required_if
+    type: required_if
+    field: reason_code
     severity: error
     description: "A reason code is required when quality flag is BAD (e.g., SENSOR_OFFLINE, MAINTENANCE, CALIBRATION)."
+    required_if:
+      field: quality_flag
+      value: BAD
+    error_message: "A reason code is required when quality flag is BAD (e.g., SENSOR_OFFLINE, MAINTENANCE, CALIBRATION)."
 
   # ── SHIFT / BATCH CONTEXT ────────────────────────────────────────────────────
-  - field: shift_code
-    rule: lookup
-    lookup_values: [MORNING, AFTERNOON, NIGHT, DAY, MAINTENANCE]
+  - name: shift_code_allowed_values
+    type: allowed_values
+    field: shift_code
+    allowed_values: [MORNING, AFTERNOON, NIGHT, DAY, MAINTENANCE]
     severity: warning
     description: "Shift code enables aggregate quality analysis per production shift."
+    error_message: "Shift code enables aggregate quality analysis per production shift."

--- a/examples/starter_contracts/pharma.yaml
+++ b/examples/starter_contracts/pharma.yaml
@@ -45,108 +45,136 @@ rules:
   # Format: 3 uppercase alphanumerics + hyphen + 3 digits + hyphen + 4 digits
   # Example: ABC-001-0042, XYZ-003-1001
   # Adapt the regex to match your study's USUBJID convention.
-  - field: subject_id
-    rule: not_empty
+  - name: subject_id_not_empty
+    type: not_empty
+    field: subject_id
     severity: error
     description: "Subject ID (USUBJID) is mandatory for all observations."
+    error_message: "Subject ID (USUBJID) is mandatory for all observations."
 
-  - field: subject_id
-    rule: regex
+  - name: subject_id_regex
+    type: regex
+    field: subject_id
     # Format: STUDY-SITE-SUBJECT (e.g., "XYZ-003-1001")
     pattern: "^[A-Z0-9]{2,6}-[0-9]{3}-[0-9]{4}$"
     severity: error
     description: "Subject ID must follow STUDY-SITE-SUBJECT format (e.g., XYZ-003-1001)."
+    error_message: "Subject ID must follow STUDY-SITE-SUBJECT format (e.g., XYZ-003-1001)."
 
   # ── VISIT ────────────────────────────────────────────────────────────────────
   # CDISC SDTM VISIT: planned visit name from the protocol schedule.
   # Extend this list to match your study's visit schedule.
-  - field: visit_name
-    rule: lookup
-    lookup_values: [SCREENING, BASELINE, WEEK2, WEEK4, WEEK8, WEEK12,
+  - name: visit_name_allowed_values
+    type: allowed_values
+    field: visit_name
+    allowed_values: [SCREENING, BASELINE, WEEK2, WEEK4, WEEK8, WEEK12,
                     WEEK16, WEEK24, WEEK48, MONTH6, MONTH12, EOS,
                     EOT, FOLLOWUP, UNSCHEDULED, TELEPHONE]
     severity: error
     description: "Visit name must be a protocol-defined visit. UNSCHEDULED is permitted; must be documented in source data."
+    error_message: "Visit name must be a protocol-defined visit. UNSCHEDULED is permitted; must be documented in source data."
 
   # ── DATES ────────────────────────────────────────────────────────────────────
-  - field: observation_date
-    rule: not_empty
+  - name: observation_date_not_empty
+    type: not_empty
+    field: observation_date
     severity: error
     description: "Observation date is mandatory — ICH E6(R2) §5.18.4 requires contemporaneous records."
+    error_message: "Observation date is mandatory — ICH E6(R2) §5.18.4 requires contemporaneous records."
 
-  - field: observation_date
-    rule: regex
+  - name: observation_date_regex
+    type: regex
+    field: observation_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Observation date must be in YYYY-MM-DD format."
+    error_message: "Observation date must be in YYYY-MM-DD format."
 
-  - field: observation_date
-    rule: compare
+  - name: observation_date_compare
+    type: compare
+    field: observation_date
     compare_op: lte
     compare_to: today
     severity: error
     description: "Observation date cannot be in the future (21 CFR Part 11 data integrity)."
+    error_message: "Observation date cannot be in the future (21 CFR Part 11 data integrity)."
 
   # ── LABORATORY TEST ──────────────────────────────────────────────────────────
   # LOINC code: numeric part, hyphen, check digit. Range: 5–7 digits.
   # For production, replace with a lookup_file pointing to the LOINC code list
   # relevant to your study's laboratory panel:
   #   lookup_file: "reference_data/loinc_study_panel.csv"
-  - field: test_code
-    rule: not_empty
+  - name: test_code_not_empty
+    type: not_empty
+    field: test_code
     severity: error
     description: "LOINC test code is mandatory for laboratory observations."
+    error_message: "LOINC test code is mandatory for laboratory observations."
 
-  - field: test_code
-    rule: regex
+  - name: test_code_regex
+    type: regex
+    field: test_code
     # LOINC format: 5–7 digits, hyphen, 1 check digit
     pattern: "^[0-9]{5,7}-[0-9]$"
     severity: error
     description: "Test code must be a valid LOINC format (e.g., 2160-0 for serum creatinine)."
+    error_message: "Test code must be a valid LOINC format (e.g., 2160-0 for serum creatinine)."
 
   # ── RESULT ───────────────────────────────────────────────────────────────────
-  - field: result_value
-    rule: not_empty
+  - name: result_value_not_empty
+    type: not_empty
+    field: result_value
     severity: error
     description: "Result value is mandatory. Use 'BLQ' for below limit of quantification, not empty."
+    error_message: "Result value is mandatory. Use 'BLQ' for below limit of quantification, not empty."
 
-  - field: result_unit
-    rule: lookup
+  - name: result_unit_allowed_values
+    type: allowed_values
+    field: result_unit
     # Common clinical laboratory units (SI and conventional).
     # Extend with units specific to your study's endpoints.
-    lookup_values: [mg_dL, mmol_L, g_dL, g_L, U_L, IU_L, mIU_mL,
+    allowed_values: [mg_dL, mmol_L, g_dL, g_L, U_L, IU_L, mIU_mL,
                     pg_mL, ng_mL, ug_mL, nmol_L, umol_L, pmol_L,
                     10e9_L, 10e12_L, pct, sec, INR, ratio,
                     mmHg, bpm, kg, kg_m2, cm, mm]
     severity: error
     description: "Result unit must be a recognised clinical laboratory unit."
+    error_message: "Result unit must be a recognised clinical laboratory unit."
 
   # Plausibility check: catches extreme values that are almost certainly
   # data entry errors (e.g., entered in wrong unit, decimal point shift).
   # Adjust the range to the plausible range for your primary endpoint.
-  - field: result_numeric
-    rule: range
+  - name: result_numeric_range
+    type: range
+    field: result_numeric
     min: 0.0
     max: 100000.0
     severity: warning
     description: "Numeric result value should be within a physiologically plausible range. Review values at the extremes."
+    error_message: "Numeric result value should be within a physiologically plausible range. Review values at the extremes."
 
-  - field: result_numeric
-    rule: cross_field_range
-    min_field: normal_range_low
-    max_field: normal_range_high
+  - name: result_numeric_cross_field_range
+    type: cross_field_range
+    field: result_numeric
+    cross_min_field: normal_range_low
+    cross_max_field: normal_range_high
     severity: warning
     description: "Result is outside the reference range for this test. Requires clinical review."
+    error_message: "Result is outside the reference range for this test. Requires clinical review."
 
-  - field: normal_range_low
-    rule: not_empty
+  - name: normal_range_low_not_empty
+    type: not_empty
+    field: normal_range_low
     severity: error
     description: "Normal range low is required — needed for clinically significant abnormality (CSA) flagging."
+    error_message: "Normal range low is required — needed for clinically significant abnormality (CSA) flagging."
 
-  - field: normal_range_high
-    rule: not_empty
+  - name: normal_range_high_not_empty
+    type: not_empty
+    field: normal_range_high
     severity: error
     description: "Normal range high is required."
+    error_message: "Normal range high is required."
 
   # ── CDISC FLAGS ──────────────────────────────────────────────────────────────
   # CDISC SDTM VSBLFL: Baseline flag. "Y" for the baseline observation,
@@ -154,24 +182,30 @@ rules:
   # may be flagged as baseline.
   # NOTE: The grouped uniqueness constraint (only one Y per USUBJID+TESTCD)
   # will be available via the grouped_unique rule type (roadmap — P1).
-  - field: baseline_flag
-    rule: lookup
-    lookup_values: ["Y", "N"]
+  - name: baseline_flag_allowed_values
+    type: allowed_values
+    field: baseline_flag
+    allowed_values: ["Y", "N"]
     severity: error
     description: "Baseline flag must be Y or N (CDISC VSBLFL). Only one observation per subject per test may be Y."
+    error_message: "Baseline flag must be Y or N (CDISC VSBLFL). Only one observation per subject per test may be Y."
 
   # CDISC SDTM DTYPE: Derivation type for derived/imputed records.
-  - field: derivation_type
-    rule: lookup
-    lookup_values: [ORIGINAL, LOCF, BOCF, WOCF, AVERAGE, MEDIAN,
+  - name: derivation_type_allowed_values
+    type: allowed_values
+    field: derivation_type
+    allowed_values: [ORIGINAL, LOCF, BOCF, WOCF, AVERAGE, MEDIAN,
                     MINIMUM, MAXIMUM, INTERPOLATED]
     severity: warning
     description: "Derivation type must indicate whether the record is original or derived (CDISC DTYPE)."
+    error_message: "Derivation type must indicate whether the record is original or derived (CDISC DTYPE)."
 
   # ── INVESTIGATOR SIGN-OFF ────────────────────────────────────────────────────
   # 21 CFR Part 11: electronic records require an electronic signature attribute.
   # The signed_by field stores the investigator ID who reviewed the record.
-  - field: signed_by
-    rule: not_empty
+  - name: signed_by_not_empty
+    type: not_empty
+    field: signed_by
     severity: warning
     description: "Investigator ID is required for 21 CFR Part 11 electronic signature compliance."
+    error_message: "Investigator ID is required for 21 CFR Part 11 electronic signature compliance."

--- a/examples/starter_contracts/public_sector.yaml
+++ b/examples/starter_contracts/public_sector.yaml
@@ -48,135 +48,174 @@ rules:
   # UK National Insurance Number (NIN): 2 letters, 6 digits, 1 letter.
   # The prefix letters exclude D, F, I, Q, U, V (by HMRC rules).
   # REPLACE THIS with your country's national ID format.
-  - field: national_id
-    rule: not_empty
+  - name: national_id_not_empty
+    type: not_empty
+    field: national_id
     severity: error
     description: "National identifier is mandatory for citizen service records."
+    error_message: "National identifier is mandatory for citizen service records."
 
-  - field: national_id
-    rule: regex
+  - name: national_id_regex
+    type: regex
+    field: national_id
     # UK NIN format — replace with your national ID regex
     pattern: "^[A-CEGHJ-PR-TW-Z]{2}[0-9]{6}[A-D]$"
     severity: error
     description: "National ID must match the required format for this jurisdiction."
+    error_message: "National ID must match the required format for this jurisdiction."
 
   # ── PERSONAL DETAILS ─────────────────────────────────────────────────────────
-  - field: date_of_birth
-    rule: not_empty
+  - name: date_of_birth_not_empty
+    type: not_empty
+    field: date_of_birth
     severity: error
     description: "Date of birth is required for eligibility verification."
+    error_message: "Date of birth is required for eligibility verification."
 
-  - field: date_of_birth
-    rule: regex
+  - name: date_of_birth_regex
+    type: regex
+    field: date_of_birth
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Date of birth must be in YYYY-MM-DD format."
+    error_message: "Date of birth must be in YYYY-MM-DD format."
 
-  - field: date_of_birth
-    rule: compare
+  - name: date_of_birth_compare
+    type: compare
+    field: date_of_birth
     compare_op: lte
     compare_to: today
     severity: error
     description: "Date of birth cannot be in the future."
+    error_message: "Date of birth cannot be in the future."
 
-  - field: first_name
-    rule: not_empty
+  - name: first_name_not_empty
+    type: not_empty
+    field: first_name
     severity: error
     description: "First name is required."
+    error_message: "First name is required."
 
-  - field: last_name
-    rule: not_empty
+  - name: last_name_not_empty
+    type: not_empty
+    field: last_name
     severity: error
     description: "Last name is required."
+    error_message: "Last name is required."
 
   # ── ADDRESS ──────────────────────────────────────────────────────────────────
   # UK postcode format: outward code (1-2 letters, 1-2 digits) + space +
   # inward code (1 digit, 2 letters). Examples: SW1A 1AA, M1 1AE, EC2R 8AH
   # REPLACE with your country's postcode/zip code format.
-  - field: postcode
-    rule: regex
+  - name: postcode_regex
+    type: regex
+    field: postcode
     pattern: "^[A-Z]{1,2}[0-9][0-9A-Z]?\\s[0-9][A-Z]{2}$"
     severity: error
     description: "Postcode must be a valid UK postcode format (e.g., SW1A 1AA). Replace with your local format."
+    error_message: "Postcode must be a valid UK postcode format (e.g., SW1A 1AA). Replace with your local format."
 
-  - field: address_line1
-    rule: not_empty
+  - name: address_line1_not_empty
+    type: not_empty
+    field: address_line1
     severity: error
     description: "Address line 1 is required."
+    error_message: "Address line 1 is required."
 
   # ── BENEFIT / SERVICE CLASSIFICATION ─────────────────────────────────────────
   # UK benefit codes — replace with your jurisdiction's scheme codes.
   # These codes feed downstream payment systems directly.
-  - field: benefit_type
-    rule: lookup
+  - name: benefit_type_allowed_values
+    type: allowed_values
+    field: benefit_type
     # UK benefits: Job Seeker's Allowance, Universal Credit, Personal Independence
     # Payment, Employment Support Allowance, Child Benefit, Pension Credit,
     # Housing Benefit
-    lookup_values: [JSA, UC, PIP, ESA, CHB, PC, HB, DLA, AA, CA,
+    allowed_values: [JSA, UC, PIP, ESA, CHB, PC, HB, DLA, AA, CA,
                     MATERNITY, PATERNITY, BEREAVEMENT, COUNCIL_TAX]
     severity: error
     description: "Benefit type must be a recognised scheme code. Invalid codes prevent payment routing."
+    error_message: "Benefit type must be a recognised scheme code. Invalid codes prevent payment routing."
 
-  - field: household_income_band
-    rule: lookup
+  - name: household_income_band_allowed_values
+    type: allowed_values
+    field: household_income_band
     # Income bands A–E. Define thresholds in your scheme documentation.
     # Band A = lowest income; Band E = highest income.
-    lookup_values: [A, B, C, D, E, EXEMPT]
+    allowed_values: [A, B, C, D, E, EXEMPT]
     severity: error
     description: "Income band is required for means-tested benefit eligibility calculation."
+    error_message: "Income band is required for means-tested benefit eligibility calculation."
 
   # ── CASE MANAGEMENT ──────────────────────────────────────────────────────────
-  - field: application_date
-    rule: not_empty
+  - name: application_date_not_empty
+    type: not_empty
+    field: application_date
     severity: error
     description: "Application date is mandatory for SLA tracking and backdating rules."
+    error_message: "Application date is mandatory for SLA tracking and backdating rules."
 
-  - field: application_date
-    rule: regex
+  - name: application_date_regex
+    type: regex
+    field: application_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Application date must be in YYYY-MM-DD format."
+    error_message: "Application date must be in YYYY-MM-DD format."
 
-  - field: case_status
-    rule: lookup
-    lookup_values: [PENDING, APPROVED, REJECTED, APPEAL, WITHDRAWN,
+  - name: case_status_allowed_values
+    type: allowed_values
+    field: case_status
+    allowed_values: [PENDING, APPROVED, REJECTED, APPEAL, WITHDRAWN,
                     SUSPENDED, UNDER_REVIEW, ESCALATED, CLOSED]
     severity: error
     description: "Case status must be a valid workflow state."
+    error_message: "Case status must be a valid workflow state."
 
-  - field: department_code
-    rule: not_empty
+  - name: department_code_not_empty
+    type: not_empty
+    field: department_code
     severity: error
     description: "Originating department code is required for inter-departmental routing and audit."
+    error_message: "Originating department code is required for inter-departmental routing and audit."
 
-  - field: department_code
-    rule: max_length
-    max: 8
+  - name: department_code_max_length
+    type: max_length
+    field: department_code
+    max_length: 8
     severity: error
     description: "Department code must not exceed 8 characters."
+    error_message: "Department code must not exceed 8 characters."
 
   # ── MAKER-CHECKER ────────────────────────────────────────────────────────────
   # The maker-checker model is standard in civil service approval hierarchies.
   # The case_worker_id is the "maker"; the approver_id is the "checker".
   # A case cannot proceed to APPROVED status without both fields populated.
-  - field: case_worker_id
-    rule: not_empty
+  - name: case_worker_id_not_empty
+    type: not_empty
+    field: case_worker_id
     severity: error
     description: "Case worker ID is required — maker-checker audit requirement."
+    error_message: "Case worker ID is required — maker-checker audit requirement."
 
-  - field: approver_id
-    rule: required_if
-    when_field: case_status
-    when_value: APPROVED
+  - name: approver_id_required_if
+    type: required_if
+    field: approver_id
     severity: error
     description: "Approver ID is required when case status is APPROVED (maker-checker compliance)."
+    required_if:
+      field: case_status
+      value: APPROVED
+    error_message: "Approver ID is required when case status is APPROVED (maker-checker compliance)."
 
   # ── GDPR ─────────────────────────────────────────────────────────────────────
   # GDPR Article 5(1)(d): personal data must be accurate and kept up to date.
   # Record the data source to support accuracy accountability.
-  - field: data_source
-    rule: lookup
-    lookup_values: [SELF_DECLARED, VERIFIED_DOCUMENT, GOVERNMENT_REGISTRY,
+  - name: data_source_allowed_values
+    type: allowed_values
+    field: data_source
+    allowed_values: [SELF_DECLARED, VERIFIED_DOCUMENT, GOVERNMENT_REGISTRY,
                     THIRD_PARTY_VERIFIED, ESTIMATED, HISTORICAL_TRANSFER]
     severity: warning
     description: "Data source indicates the verification level of this record (GDPR Article 5 accuracy principle)."
+    error_message: "Data source indicates the verification level of this record (GDPR Article 5 accuracy principle)."

--- a/examples/starter_contracts/real_estate.yaml
+++ b/examples/starter_contracts/real_estate.yaml
@@ -64,35 +64,42 @@ rules:
   # property_id is the platform's primary unique identifier for a listing.
   # Format: PROP- followed by exactly 8 uppercase alphanumeric characters.
   # This is a platform-defined ID, distinct from UPRN (see below).
-  - field: property_id
-    rule: not_empty
+  - name: property_id_not_empty
+    type: not_empty
+    field: property_id
     severity: error
     description: "Property ID is mandatory. All listing and transaction records must carry a unique platform property identifier."
+    error_message: "Property ID is mandatory. All listing and transaction records must carry a unique platform property identifier."
 
-  - field: property_id
-    rule: regex
+  - name: property_id_regex
+    type: regex
+    field: property_id
     # Platform ID: PROP- prefix + 8 uppercase alphanumeric characters
     pattern: "^PROP-[A-Z0-9]{8}$"
     severity: error
     description: "Property ID must match format PROP-XXXXXXXX (8 uppercase alphanumeric characters, e.g., PROP-A1B2C3D4)."
+    error_message: "Property ID must match format PROP-XXXXXXXX (8 uppercase alphanumeric characters, e.g., PROP-A1B2C3D4)."
 
   # ── UPRN ─────────────────────────────────────────────────────────────────────
   # UK Unique Property Reference Number (UPRN): assigned by local authorities
   # and maintained by Ordnance Survey AddressBase.
   # UPRNs are 1–12 digits. The field is optional — not all listings will have
   # one — but if present it must be numeric and within the valid length range.
-  - field: uprn
-    rule: regex
+  - name: uprn_regex
+    type: regex
+    field: uprn
     # Numeric, 1–12 digits. Empty string ("") passes — field is optional.
     # Enforce at ingestion only when the field is non-empty.
     pattern: "^$|^[0-9]{1,12}$"
     severity: warning
     description: "UPRN (Unique Property Reference Number) must be numeric and up to 12 digits if provided (Ordnance Survey AddressBase standard)."
+    error_message: "UPRN (Unique Property Reference Number) must be numeric and up to 12 digits if provided (Ordnance Survey AddressBase standard)."
 
   # ── LISTING TYPE ─────────────────────────────────────────────────────────────
-  - field: listing_type
-    rule: lookup
-    lookup_values:
+  - name: listing_type_allowed_values
+    type: allowed_values
+    field: listing_type
+    allowed_values:
       - FOR_SALE
       - FOR_RENT
       - SOLD
@@ -102,13 +109,15 @@ rules:
       - WITHDRAWN
     severity: error
     description: "Listing type must be a recognised market status."
+    error_message: "Listing type must be a recognised market status."
 
   # ── PROPERTY TYPE ─────────────────────────────────────────────────────────────
   # Covers residential (RICS residential classification) and commercial
   # (RICS commercial classification) property types.
-  - field: property_type
-    rule: lookup
-    lookup_values:
+  - name: property_type_allowed_values
+    type: allowed_values
+    field: property_type
+    allowed_values:
       - DETACHED
       - SEMI_DETACHED
       - TERRACED
@@ -123,42 +132,50 @@ rules:
       - PARKING
     severity: error
     description: "Property type must be a recognised residential or commercial classification."
+    error_message: "Property type must be a recognised residential or commercial classification."
 
   # ── BEDROOMS AND BATHROOMS ───────────────────────────────────────────────────
   # Range 0–20: zero is valid for studios and commercial properties.
   # Values above 20 are implausible for standard residential stock and
   # almost certainly indicate a data entry error.
-  - field: bedrooms
-    rule: range
+  - name: bedrooms_range
+    type: range
+    field: bedrooms
     min: 0
     max: 20
     severity: error
     description: "Bedroom count must be between 0 and 20. Studios and commercial units may have 0. Values above 20 are implausible."
+    error_message: "Bedroom count must be between 0 and 20. Studios and commercial units may have 0. Values above 20 are implausible."
 
-  - field: bathrooms
-    rule: range
+  - name: bathrooms_range
+    type: range
+    field: bathrooms
     min: 0
     max: 20
     severity: error
     description: "Bathroom count must be between 0 and 20."
+    error_message: "Bathroom count must be between 0 and 20."
 
   # ── ASKING PRICE ─────────────────────────────────────────────────────────────
   # Range 0–1,000,000,000 (£1 billion): covers ultra-prime London addresses
   # (e.g., One Hyde Park penthouse) and global trophy commercial assets.
   # Zero is valid for cases where the price is not publicly disclosed
   # (POA — Price On Application).
-  - field: asking_price
-    rule: range
+  - name: asking_price_range
+    type: range
+    field: asking_price
     min: 0
     max: 1000000000
     severity: error
     description: "Asking price must be between 0 and 1,000,000,000. Zero is valid for POA (Price on Application) listings. Adjust max for your market."
+    error_message: "Asking price must be between 0 and 1,000,000,000. Zero is valid for POA (Price on Application) listings. Adjust max for your market."
 
   # ── CURRENCY ─────────────────────────────────────────────────────────────────
   # ISO 4217 currency codes covering major real estate markets.
-  - field: currency
-    rule: lookup
-    lookup_values:
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values:
       - GBP    # United Kingdom
       - EUR    # Eurozone
       - USD    # United States / international trophy assets
@@ -169,17 +186,20 @@ rules:
       - CHF    # Switzerland
     severity: error
     description: "Currency must be a supported ISO 4217 code covering major real estate markets."
+    error_message: "Currency must be a supported ISO 4217 code covering major real estate markets."
 
   # ── FLOOR AREA ───────────────────────────────────────────────────────────────
   # Range 10–100,000 sqm: 10 sqm is the minimum habitable floor area under
   # most UK housing standards (Housing Act 1985 overcrowding provisions).
   # 100,000 sqm covers very large commercial warehouses and industrial sites.
-  - field: floor_area_sqm
-    rule: range
+  - name: floor_area_sqm_range
+    type: range
+    field: floor_area_sqm
     min: 10
     max: 100000
     severity: warning
     description: "Floor area must be between 10 sqm (minimum habitable space) and 100,000 sqm (large commercial/industrial). Values outside this range warrant review."
+    error_message: "Floor area must be between 10 sqm (minimum habitable space) and 100,000 sqm (large commercial/industrial). Values outside this range warrant review."
 
   # ── EPC RATING ───────────────────────────────────────────────────────────────
   # Energy Performance Certificate rating under the EU Energy Performance
@@ -189,9 +209,10 @@ rules:
   # Band A is most energy-efficient; Band G is least efficient.
   # EXEMPT: listed buildings, temporary structures, places of worship.
   # NOT_REQUIRED: certain commercial premises and new-build edge cases.
-  - field: epc_rating
-    rule: lookup
-    lookup_values:
+  - name: epc_rating_allowed_values
+    type: allowed_values
+    field: epc_rating
+    allowed_values:
       - A          # Most energy-efficient (SAP score 92–100)
       - B          # SAP score 81–91
       - C          # SAP score 69–80
@@ -203,6 +224,7 @@ rules:
       - NOT_REQUIRED
     severity: error
     description: "EPC rating must be a valid band (A–G), EXEMPT, or NOT_REQUIRED. EPC is legally required for all sold or let properties in England and Wales under the Energy Performance of Buildings Regulations 2012."
+    error_message: "EPC rating must be a valid band (A–G), EXEMPT, or NOT_REQUIRED. EPC is legally required for all sold or let properties in England and Wales under the Energy Performance of Buildings Regulations 2012."
 
   # ── TENURE ───────────────────────────────────────────────────────────────────
   # Tenure type is fundamental to mortgage lender decisions and legal due
@@ -212,9 +234,10 @@ rules:
   # own the freehold — common in converted period houses.
   # COMMONHOLD: an alternative to leasehold for flats (Commonhold and
   # Leasehold Reform Act 2002) — currently rare in England and Wales.
-  - field: tenure
-    rule: lookup
-    lookup_values:
+  - name: tenure_allowed_values
+    type: allowed_values
+    field: tenure
+    allowed_values:
       - FREEHOLD
       - LEASEHOLD
       - SHARE_OF_FREEHOLD
@@ -222,52 +245,64 @@ rules:
       - UNKNOWN
     severity: error
     description: "Tenure must be a recognised legal form of ownership. LEASEHOLD properties are subject to ground rent rules under the Leasehold Reform (Ground Rent) Act 2022."
+    error_message: "Tenure must be a recognised legal form of ownership. LEASEHOLD properties are subject to ground rent rules under the Leasehold Reform (Ground Rent) Act 2022."
 
   # ── LISTING DATE ─────────────────────────────────────────────────────────────
-  - field: listing_date
-    rule: not_empty
+  - name: listing_date_not_empty
+    type: not_empty
+    field: listing_date
     severity: error
     description: "Listing date is required for time-on-market analytics and portal compliance."
+    error_message: "Listing date is required for time-on-market analytics and portal compliance."
 
-  - field: listing_date
-    rule: regex
+  - name: listing_date_regex
+    type: regex
+    field: listing_date
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Listing date must be in YYYY-MM-DD format."
+    error_message: "Listing date must be in YYYY-MM-DD format."
 
-  - field: listing_date
-    rule: compare
+  - name: listing_date_compare
+    type: compare
+    field: listing_date
     compare_op: lte
     compare_to: today
     severity: error
     description: "Listing date cannot be in the future."
+    error_message: "Listing date cannot be in the future."
 
   # ── POSTCODE ─────────────────────────────────────────────────────────────────
   # UK postcode format per Royal Mail / Ordnance Survey specification.
   # Covers all valid formats: SW1A 1AA, EC2A 4BX, W1A 0AX, M1 1AE, B1 1BB.
   # The space between the outward and inward codes is required.
   # Replace with your national postal code format for non-UK deployments.
-  - field: postcode
-    rule: regex
+  - name: postcode_regex
+    type: regex
+    field: postcode
     # UK postcode: 1–2 letters + 1 digit (+ optional digit or letter) + space + digit + 2 letters
     pattern: "^[A-Z]{1,2}[0-9][0-9A-Z]?\\s[0-9][A-Z]{2}$"
     severity: error
     description: "Postcode must be a valid UK postcode format (e.g., SW1A 1AA, EC2A 4BX). Replace with your national format for non-UK deployments."
+    error_message: "Postcode must be a valid UK postcode format (e.g., SW1A 1AA, EC2A 4BX). Replace with your national format for non-UK deployments."
 
   # ── AGENT ID ─────────────────────────────────────────────────────────────────
   # The listing agent's platform identifier. Used for audit trail, agent
   # performance reporting, and duplicate listing detection.
-  - field: agent_id
-    rule: not_empty
+  - name: agent_id_not_empty
+    type: not_empty
+    field: agent_id
     severity: error
     description: "Agent ID is mandatory for audit trail and duplicate listing detection."
+    error_message: "Agent ID is mandatory for audit trail and duplicate listing detection."
 
   # ── STATUS ───────────────────────────────────────────────────────────────────
   # Lifecycle status of the transaction — distinct from listing_type.
   # Reflects the legal/commercial stage of the sale or letting.
-  - field: status
-    rule: lookup
-    lookup_values:
+  - name: status_allowed_values
+    type: allowed_values
+    field: status
+    allowed_values:
       - ACTIVE       # Listing is live on the market
       - UNDER_OFFER  # Offer accepted, not yet exchanged
       - EXCHANGED    # Contracts exchanged — legally binding
@@ -276,6 +311,7 @@ rules:
       - EXPIRED      # Listing mandate expired
     severity: error
     description: "Status must be a recognised transaction lifecycle stage."
+    error_message: "Status must be a recognised transaction lifecycle stage."
 
   # ── SDLT ─────────────────────────────────────────────────────────────────────
   # Stamp Duty Land Tax (SDLT) — HM Revenue & Customs.
@@ -284,33 +320,39 @@ rules:
   # Land Transaction Tax (LTT) applies in Wales; LBTT applies in Scotland.
   # This field carries the HMRC determination for English/NI transactions.
   # EXEMPT: certain transfers between spouses, charities, and corporate groups.
-  - field: sdlt_applicable
-    rule: lookup
-    lookup_values:
-      - YES
-      - NO
+  - name: sdlt_applicable_allowed_values
+    type: allowed_values
+    field: sdlt_applicable
+    allowed_values:
+      - "YES"
+      - "NO"
       - EXEMPT    # HMRC-recognised SDLT exemptions (e.g., charity relief)
     severity: error
     description: "SDLT applicable status is required for all residential transactions in England and Northern Ireland (HM Revenue & Customs — Stamp Duty Land Tax)."
+    error_message: "SDLT applicable status is required for all residential transactions in England and Northern Ireland (HM Revenue & Customs — Stamp Duty Land Tax)."
 
   # ── YEAR BUILT ───────────────────────────────────────────────────────────────
   # Range 1000–2030: lower bound of 1000 covers Grade I listed medieval
   # buildings in the UK. Upper bound of 2030 allows for new-build completions
   # in the near future. A year before 1000 or after 2030 is almost certainly
   # a data entry error.
-  - field: year_built
-    rule: range
+  - name: year_built_range
+    type: range
+    field: year_built
     min: 1000
     max: 2030
     severity: warning
     description: "Year built must be between 1000 (medieval listed buildings) and 2030 (near-future new builds). Values outside this range are likely data entry errors."
+    error_message: "Year built must be between 1000 (medieval listed buildings) and 2030 (near-future new builds). Values outside this range are likely data entry errors."
 
   # ── PARKING SPACES ───────────────────────────────────────────────────────────
   # Zero is valid (city-centre flats with no parking allocation).
   # Upper limit of 1000 covers large commercial car parks listed as assets.
-  - field: parking_spaces
-    rule: range
+  - name: parking_spaces_range
+    type: range
+    field: parking_spaces
     min: 0
     max: 1000
     severity: warning
     description: "Parking spaces must be between 0 and 1000. Zero is valid for properties with no parking allocation."
+    error_message: "Parking spaces must be between 0 and 1000. Zero is valid for properties with no parking allocation."

--- a/examples/starter_contracts/retail.yaml
+++ b/examples/starter_contracts/retail.yaml
@@ -51,147 +51,184 @@ rules:
   # Format: 4–20 uppercase letters, digits, or hyphens.
   # Examples: ELEC-SNY-XM5-BLK, SHOE-NK-AIR270-42, BOOK-9781234567890
   # Adapt the regex to your SKU naming convention.
-  - field: sku
-    rule: not_empty
+  - name: sku_not_empty
+    type: not_empty
+    field: sku
     severity: error
     description: "SKU is mandatory — it is the primary key for all downstream inventory, fulfilment, and merchandising systems."
+    error_message: "SKU is mandatory — it is the primary key for all downstream inventory, fulfilment, and merchandising systems."
 
-  - field: sku
-    rule: regex
+  - name: sku_regex
+    type: regex
+    field: sku
     pattern: "^[A-Z0-9\\-]{4,20}$"
     severity: error
     description: "SKU must be 4–20 uppercase alphanumeric characters or hyphens (e.g., ELEC-SNY-XM5-BLK). Lowercase SKUs cause silent mismatches in case-sensitive WMS systems."
+    error_message: "SKU must be 4–20 uppercase alphanumeric characters or hyphens (e.g., ELEC-SNY-XM5-BLK). Lowercase SKUs cause silent mismatches in case-sensitive WMS systems."
 
   # GTIN: optional at creation time, but if present must be valid format.
   # EAN-8 (8 digits), UPC-A (12 digits), EAN-13 (13 digits), GTIN-14 (14 digits).
   # The check digit (last digit) is a modulo-10 (Luhn variant) checksum.
-  - field: gtin
-    rule: checksum
-    algorithm: gtin_mod10
+  - name: gtin_checksum
+    type: checksum
+    field: gtin
+    checksum_algorithm: mod10_gs1   # GS1 modulo-10 (GTIN-8/12/13/14)
     severity: error
     description: "GTIN check digit must be valid (GS1 modulo-10 algorithm)."
-  - field: gtin
-    rule: regex
+    error_message: "GTIN check digit must be valid (GS1 modulo-10 algorithm)."
+  - name: gtin_regex
+    type: regex
+    field: gtin
     pattern: "^[0-9]{8,14}$"
     severity: error
     description: "GTIN must be 8–14 digits (EAN-8, UPC-A, EAN-13, or GTIN-14). The final digit is a GS1 modulo-10 check digit — validate the full checksum before submitting to marketplaces."
+    error_message: "GTIN must be 8–14 digits (EAN-8, UPC-A, EAN-13, or GTIN-14). The final digit is a GS1 modulo-10 check digit — validate the full checksum before submitting to marketplaces."
 
   # ── PRODUCT DESCRIPTION ──────────────────────────────────────────────────────
-  - field: product_name
-    rule: not_empty
+  - name: product_name_not_empty
+    type: not_empty
+    field: product_name
     severity: error
     description: "Product name is mandatory for catalogue display, search indexing, and marketplace listings."
+    error_message: "Product name is mandatory for catalogue display, search indexing, and marketplace listings."
 
-  - field: product_name
-    rule: max_length
-    max: 255
+  - name: product_name_max_length
+    type: max_length
+    field: product_name
+    max_length: 255
     severity: error
     description: "Product name must not exceed 255 characters. Many marketplace APIs (Amazon, Google Shopping) enforce a 200-character limit — a tighter max can be set per channel."
+    error_message: "Product name must not exceed 255 characters. Many marketplace APIs (Amazon, Google Shopping) enforce a 200-character limit — a tighter max can be set per channel."
 
-  - field: brand
-    rule: not_empty
+  - name: brand_not_empty
+    type: not_empty
+    field: brand
     severity: error
     description: "Brand is mandatory for catalogue organisation, brand-level reporting, and marketplace brand registry."
+    error_message: "Brand is mandatory for catalogue organisation, brand-level reporting, and marketplace brand registry."
 
-  - field: brand
-    rule: max_length
-    max: 100
+  - name: brand_max_length
+    type: max_length
+    field: brand
+    max_length: 100
     severity: error
     description: "Brand name must not exceed 100 characters."
+    error_message: "Brand name must not exceed 100 characters."
 
   # ── CLASSIFICATION ───────────────────────────────────────────────────────────
   # GPC (Global Product Classification) top-level brick categories, aligned
   # to GS1 Global Product Classification standard. Extend with sub-categories
   # as your catalogue matures, or replace with your internal taxonomy.
-  - field: category_code
-    rule: not_empty
+  - name: category_code_not_empty
+    type: not_empty
+    field: category_code
     severity: error
     description: "Category code is mandatory for navigation, tax class derivation, and age restriction rules."
+    error_message: "Category code is mandatory for navigation, tax class derivation, and age restriction rules."
 
-  - field: category_code
-    rule: lookup
-    lookup_values: [ELECTRONICS, CLOTHING_APPAREL, FOOTWEAR, FOOD_BEVERAGE,
+  - name: category_code_allowed_values
+    type: allowed_values
+    field: category_code
+    allowed_values: [ELECTRONICS, CLOTHING_APPAREL, FOOTWEAR, FOOD_BEVERAGE,
                     HEALTH_BEAUTY, HOME_GARDEN, TOYS_GAMES, SPORTS_OUTDOORS,
                     BOOKS_MEDIA, AUTOMOTIVE, JEWELLERY, FURNITURE,
                     OFFICE_SUPPLIES, PET_SUPPLIES, GROCERY, PHARMACY]
     severity: error
     description: "Category code must be a recognised GPC-aligned category. Used for VAT rate determination, age restriction defaults, and marketplace routing."
+    error_message: "Category code must be a recognised GPC-aligned category. Used for VAT rate determination, age restriction defaults, and marketplace routing."
 
   # ── PRICING ──────────────────────────────────────────────────────────────────
   # Unit price: retail selling price in the specified currency.
   # Upper bound of 1,000,000 covers luxury goods, industrial equipment,
   # and high-value jewellery. For standard consumer retail, consider max: 10000.
-  - field: unit_price
-    rule: not_empty
+  - name: unit_price_not_empty
+    type: not_empty
+    field: unit_price
     severity: error
     description: "Unit price is mandatory. A missing price will cause the product to be hidden or mis-priced on all sales channels."
+    error_message: "Unit price is mandatory. A missing price will cause the product to be hidden or mis-priced on all sales channels."
 
-  - field: unit_price
-    rule: range
+  - name: unit_price_range
+    type: range
+    field: unit_price
     min: 0.0
     max: 1000000.0
     severity: error
     description: "Unit price must be between 0 and 1,000,000. Zero is valid for free/promotional items. Negative values indicate a data entry error."
+    error_message: "Unit price must be between 0 and 1,000,000. Zero is valid for free/promotional items. Negative values indicate a data entry error."
 
   # ISO 4217 currency codes. Extend the list for additional trading currencies.
   # The currency must match the pricing region — a GBP price with a USD currency
   # code will cause incorrect FX conversion in ERP and marketplace listings.
-  - field: currency
-    rule: lookup
-    lookup_values: [USD, EUR, GBP, SEK, NOK, DKK, CHF, CAD, AUD, JPY, CNY,
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values: [USD, EUR, GBP, SEK, NOK, DKK, CHF, CAD, AUD, JPY, CNY,
                     INR, BRL, NGN, ZAR]
     severity: error
     description: "Currency must be a valid ISO 4217 code. Mismatched currency codes cause incorrect FX conversion and VAT calculation errors."
+    error_message: "Currency must be a valid ISO 4217 code. Mismatched currency codes cause incorrect FX conversion and VAT calculation errors."
 
   # ── INVENTORY ────────────────────────────────────────────────────────────────
   # Stock on hand. Upper bound of 10,000,000 covers bulk commodity retailers
   # and FMCG distributors. For fashion/electronics, consider max: 100000.
-  - field: stock_quantity
-    rule: range
+  - name: stock_quantity_range
+    type: range
+    field: stock_quantity
     min: 0
     max: 10000000
     severity: error
     description: "Stock quantity must be between 0 and 10,000,000. Negative stock indicates a fulfilment or returns processing error."
+    error_message: "Stock quantity must be between 0 and 10,000,000. Negative stock indicates a fulfilment or returns processing error."
 
   # Reorder point: the stock level that triggers a purchase order.
   # Must be non-negative; a zero reorder point means no automatic reorder.
-  - field: reorder_point
-    rule: range
+  - name: reorder_point_range
+    type: range
+    field: reorder_point
     min: 0
     max: 100000
     severity: warning
     description: "Reorder point must be between 0 and 100,000. A reorder point higher than stock_quantity should trigger a purchasing alert."
+    error_message: "Reorder point must be between 0 and 100,000. A reorder point higher than stock_quantity should trigger a purchasing alert."
 
-  - field: stock_quantity
-    rule: cross_field_range
-    min_field: reorder_point
+  - name: stock_quantity_compare
+    type: compare
+    field: stock_quantity
+    compare_to: reorder_point
+    compare_op: gte
     severity: warning
     description: "Stock quantity is below the reorder point — a purchase order should be raised."
+    error_message: "Stock quantity is below the reorder point — a purchase order should be raised."
 
   # ── PHYSICAL ATTRIBUTES ──────────────────────────────────────────────────────
   # Weight in grams. Upper bound of 500,000 g = 500 kg.
   # Using grams (not kg) as the base unit avoids decimal precision issues
   # with lightweight items (e.g., a 15 g phone case = 0.015 kg, error-prone).
-  - field: weight_grams
-    rule: range
+  - name: weight_grams_range
+    type: range
+    field: weight_grams
     min: 0
     max: 500000
     severity: warning
     description: "Product weight must be between 0 and 500,000 g (500 kg). Weight is used for shipping rate calculation and carrier selection — errors cause incorrect freight costs."
+    error_message: "Product weight must be between 0 and 500,000 g (500 kg). Weight is used for shipping rate calculation and carrier selection — errors cause incorrect freight costs."
 
   # ── ORIGIN & REGULATORY ──────────────────────────────────────────────────────
   # ISO 3166-1 alpha-2 country of origin codes.
   # Required for customs (Rules of Origin), consumer labelling, and
   # country-of-origin restrictions in trade compliance.
-  - field: country_of_origin
-    rule: lookup
+  - name: country_of_origin_allowed_values
+    type: allowed_values
+    field: country_of_origin
     # ISO 3166-1 alpha-2 — common manufacturing and sourcing countries.
     # Extend with additional codes as needed. Full list: iso.org/obp/ui/#search
-    lookup_values: [GB, US, DE, FR, IT, ES, CN, JP, KR, IN, BR, MX, TR, PL,
+    allowed_values: [GB, US, DE, FR, IT, ES, CN, JP, KR, IN, BR, MX, TR, PL,
                     NL, BE, SE, CH, AU, CA, NG, ZA, GH, KE, EG, MA, SG, HK,
                     TW, TH, VN, ID, PH, BD, PK]
     severity: error
     description: "Country of origin must be a valid ISO 3166-1 alpha-2 code. Required for EU/UK customs (Rules of Origin proof) and consumer labelling regulations."
+    error_message: "Country of origin must be a valid ISO 3166-1 alpha-2 code. Required for EU/UK customs (Rules of Origin proof) and consumer labelling regulations."
 
   # ── TAX CLASSIFICATION ───────────────────────────────────────────────────────
   # EU VAT Directive 2006/112/EC and UK VAT Act 1994 define tax classes.
@@ -201,19 +238,23 @@ rules:
   # REDUCED     — reduced rate (UK: 5%, EU: typically 5–10% — food, energy, books in some states)
   # ZERO_RATED  — 0% VAT but still VAT-registered supply (UK: children's clothes, most food)
   # EXEMPT      — outside scope of VAT (insurance, financial services, healthcare)
-  - field: tax_class
-    rule: lookup
-    lookup_values: [STANDARD, REDUCED, ZERO_RATED, EXEMPT]
+  - name: tax_class_allowed_values
+    type: allowed_values
+    field: tax_class
+    allowed_values: [STANDARD, REDUCED, ZERO_RATED, EXEMPT]
     severity: error
     description: "Tax class must be set. Incorrect tax class causes VAT miscalculation on every sale. ZERO_RATED and EXEMPT have different VAT reclaim implications."
+    error_message: "Tax class must be set. Incorrect tax class causes VAT miscalculation on every sale. ZERO_RATED and EXEMPT have different VAT reclaim implications."
 
   # ── PRODUCT STATUS ───────────────────────────────────────────────────────────
-  - field: product_status
-    rule: lookup
-    lookup_values: [DRAFT, ACTIVE, DISCONTINUED, OUT_OF_STOCK, SEASONAL,
+  - name: product_status_allowed_values
+    type: allowed_values
+    field: product_status
+    allowed_values: [DRAFT, ACTIVE, DISCONTINUED, OUT_OF_STOCK, SEASONAL,
                     CLEARANCE]
     severity: error
     description: "Product status controls visibility across all sales channels. DRAFT products must not be published to live channels."
+    error_message: "Product status controls visibility across all sales channels. DRAFT products must not be published to live channels."
 
   # ── AGE RESTRICTION ──────────────────────────────────────────────────────────
   # EU General Product Safety Regulation (GPSR, Regulation 2023/988, effective
@@ -223,17 +264,21 @@ rules:
   #
   # 15_PLUS — teen-oriented content (some video games, social media features)
   # 18_PLUS — alcohol, tobacco products, adult content, certain knives (UK)
-  - field: age_restriction
-    rule: lookup
-    lookup_values: [NONE, 15_PLUS, 18_PLUS]
+  - name: age_restriction_allowed_values
+    type: allowed_values
+    field: age_restriction
+    allowed_values: [NONE, 15_PLUS, 18_PLUS]
     severity: error
     description: "Age restriction must be explicitly set (EU GPSR / UK Product Safety). Use NONE to confirm the product was assessed and has no age restriction, not just that the field was skipped."
+    error_message: "Age restriction must be explicitly set (EU GPSR / UK Product Safety). Use NONE to confirm the product was assessed and has no age restriction, not just that the field was skipped."
 
   # ── CONDITION ────────────────────────────────────────────────────────────────
   # Product condition is required for marketplace compliance (Amazon, eBay,
   # Zalando all require condition disclosure). Affects buyer trust and return rates.
-  - field: condition
-    rule: lookup
-    lookup_values: [NEW, REFURBISHED, USED_LIKE_NEW, USED_GOOD, USED_ACCEPTABLE]
+  - name: condition_allowed_values
+    type: allowed_values
+    field: condition
+    allowed_values: [NEW, REFURBISHED, USED_LIKE_NEW, USED_GOOD, USED_ACCEPTABLE]
     severity: error
     description: "Product condition must be declared. Marketplace platforms require explicit condition disclosure — omission or mismatch triggers listing suppression."
+    error_message: "Product condition must be declared. Marketplace platforms require explicit condition disclosure — omission or mismatch triggers listing suppression."

--- a/examples/starter_contracts/social_media_age_compliance.yaml
+++ b/examples/starter_contracts/social_media_age_compliance.yaml
@@ -63,123 +63,154 @@ asset_id: "urn:opendqv:example:social_media:social_media_age_compliance"
 rules:
 
   # ── USER IDENTIFICATION ──────────────────────────────────────────────────────
-  - field: user_id
-    rule: not_empty
+  - name: user_id_not_empty
+    type: not_empty
+    field: user_id
     severity: error
     description: "user_id is mandatory — every registration record must be traceable."
+    error_message: "user_id is mandatory — every registration record must be traceable."
 
   # ── AGE GATE ──────────────────────────────────────────────────────────────────
   # Declared age provides a quick first-pass gate and cross-field consistency
   # check. DOB remains the authoritative age signal (see dob_age_gate below).
-  - field: age
-    rule: not_empty
+  - name: age_not_empty
+    type: not_empty
+    field: age
     severity: error
     description: "Declared age is required."
+    error_message: "Declared age is required."
 
-  - field: age
-    rule: range
+  - name: age_range
+    type: range
+    field: age
     min: 13
     max: 150
     severity: error
     description: "Declared age must be 13 or above for platform access."
+    error_message: "Declared age must be 13 or above for platform access."
 
   # Cross-field consistency: declared age must match computed age from DOB
   # within ±1 year (birthday timing edge cases). A large mismatch — e.g.
   # age=36 with dob=1980-01-01 (computed 46) — indicates falsified data.
-  - field: age
-    rule: age_match
+  - name: age_age_match
+    type: age_match
+    field: age
     dob_field: dob
     severity: error
     description: "Declared age is inconsistent with date of birth — possible falsified age declaration (Ofcom due diligence)."
+    error_message: "Declared age is inconsistent with date of birth — possible falsified age declaration (Ofcom due diligence)."
 
   # ── DATE OF BIRTH ─────────────────────────────────────────────────────────────
   # DOB is the tamper-resistant age signal. The dob_age_gate rule derives actual
   # age from DOB and enforces min_age: 13 directly.
   # ISO 8601 date format: YYYY-MM-DD.
-  - field: dob
-    rule: not_empty
+  - name: dob_not_empty
+    type: not_empty
+    field: dob
     severity: error
     description: "Date of birth is required for age assurance audit records."
+    error_message: "Date of birth is required for age assurance audit records."
 
-  - field: dob
-    rule: regex
+  - name: dob_regex
+    type: regex
+    field: dob
     # Accepts YYYY-MM-DD: e.g. 2001-07-14
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Date of birth must be in ISO 8601 format: YYYY-MM-DD."
+    error_message: "Date of birth must be in ISO 8601 format: YYYY-MM-DD."
 
   # Cross-field age gate: derives actual age from dob and enforces minimum 13.
   # This catches cases where the age field is correct but dob is inconsistent
   # (e.g. age=36, dob=2020-01-01). Verification status does not override this.
-  - field: dob
-    rule: date_format
-    format: "YYYY-MM-DD"
+  - name: dob_date_format
+    type: date_format
+    field: dob
+    format: "%Y-%m-%d"
     min_age: 13
     severity: error
     description: "Date of birth indicates user is under 13. Platform access denied regardless of declared age (UK Online Safety Act minimum age)."
+    error_message: "Date of birth indicates user is under 13. Platform access denied regardless of declared age (UK Online Safety Act minimum age)."
 
   # ── IDENTITY VERIFICATION STATUS ─────────────────────────────────────────────
   # Ofcom's draft age assurance guidance requires platforms to record whether
   # age has been verified (TRUE) or is self-declared (FALSE).
   # Self-declared age is permitted for low-risk features but must be flagged
   # so that downstream systems can apply appropriate content restrictions.
-  - field: verified_identity
-    rule: not_empty
+  - name: verified_identity_not_empty
+    type: not_empty
+    field: verified_identity
     severity: error
     description: "verified_identity must be recorded for every registration (TRUE or FALSE)."
+    error_message: "verified_identity must be recorded for every registration (TRUE or FALSE)."
 
-  - field: verified_identity
-    rule: lookup
-    lookup_values: [TRUE, FALSE]
+  - name: verified_identity_allowed_values
+    type: allowed_values
+    field: verified_identity
+    allowed_values: ["TRUE", "FALSE"]   # quoted — bare TRUE/FALSE are YAML booleans
     severity: error
     description: "verified_identity must be TRUE (identity verified) or FALSE (self-declared)."
+    error_message: "verified_identity must be TRUE (identity verified) or FALSE (self-declared)."
 
   # Advisory warning: self-declared age records should be reviewed or subject
   # to additional content restrictions under the platform's age assurance policy.
   # This rule fires when verified_identity is not TRUE (i.e., is self-declared).
-  - field: verified_identity
-    rule: lookup
-    lookup_values: [TRUE]
+  - name: verified_identity_allowed_values_2
+    type: allowed_values
+    field: verified_identity
+    allowed_values: ["TRUE"]
     severity: warning
     description: "Identity is self-declared (verified_identity=FALSE). Under Ofcom age assurance guidance, self-declared records should trigger enhanced content restrictions or be escalated for verification."
+    error_message: "Identity is self-declared (verified_identity=FALSE). Under Ofcom age assurance guidance, self-declared records should trigger enhanced content restrictions or be escalated for verification."
 
   # ── VERIFICATION METHOD ───────────────────────────────────────────────────────
   # Required only when verified_identity=TRUE.
   # Must be one of the platform's approved age verification methods.
   # See: ref/verification_methods.txt
-  - field: verification_method
-    rule: required_if
-    when_field: verified_identity
-    when_value: TRUE
+  - name: verification_method_required_if
+    type: required_if
+    field: verification_method
     severity: error
     description: "verification_method is required when verified_identity is TRUE. Record the method used to comply with Ofcom audit trail requirements."
+    required_if:
+      field: verified_identity
+      value: "TRUE"
+    error_message: "verification_method is required when verified_identity is TRUE. Record the method used to comply with Ofcom audit trail requirements."
 
-  - field: verification_method
-    rule: lookup
+  - name: verification_method_lookup
+    type: lookup
+    field: verification_method
     lookup_file: "ref/verification_methods.txt"
     severity: error
     description: "verification_method must be an approved method (DOCUMENT_CHECK, BIOMETRIC, CREDIT_BUREAU, MOBILE_NETWORK_OPERATOR, BANK_VERIFICATION, GOVERNMENT_ID)."
+    error_message: "verification_method must be an approved method (DOCUMENT_CHECK, BIOMETRIC, CREDIT_BUREAU, MOBILE_NETWORK_OPERATOR, BANK_VERIFICATION, GOVERNMENT_ID)."
 
   # ── VERIFICATION TIMESTAMP ────────────────────────────────────────────────────
   # Required only when verified_identity=TRUE.
   # ISO 8601 datetime with timezone: YYYY-MM-DDTHH:MM:SSZ or ±HH:MM offset.
   # Timestamp is needed for audit trails — Ofcom may require evidence of when
   # verification occurred, especially for under-18 users.
-  - field: verification_timestamp
-    rule: required_if
-    when_field: verified_identity
-    when_value: TRUE
+  - name: verification_timestamp_required_if
+    type: required_if
+    field: verification_timestamp
     severity: error
     description: "verification_timestamp is required when verified_identity is TRUE. Ofcom audit trails must record when age verification occurred."
+    required_if:
+      field: verified_identity
+      value: "TRUE"
+    error_message: "verification_timestamp is required when verified_identity is TRUE. Ofcom audit trails must record when age verification occurred."
 
   # Condition ensures this regex only fires when verified_identity=TRUE,
   # preventing false errors when the timestamp is absent for unverified records.
-  - field: verification_timestamp
-    rule: regex
+  - name: verification_timestamp_regex
+    type: regex
+    field: verification_timestamp
     # ISO 8601 datetime: YYYY-MM-DDTHH:MM:SS followed by Z or ±HH:MM timezone offset
     # Examples: 2026-03-10T14:23:00Z, 2026-03-10T14:23:00+00:00
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|[+-][0-9]{2}:[0-9]{2})$"
-    when_field: verified_identity
-    when_value: TRUE
     severity: error
     description: "verification_timestamp must be a valid ISO 8601 datetime with timezone (e.g., 2026-03-10T14:23:00Z)."
+    required_if:
+      field: verified_identity
+      value: "TRUE"
+    error_message: "verification_timestamp must be a valid ISO 8601 datetime with timezone (e.g., 2026-03-10T14:23:00Z)."

--- a/examples/starter_contracts/social_media_age_compliance.yaml
+++ b/examples/starter_contracts/social_media_age_compliance.yaml
@@ -210,7 +210,7 @@ rules:
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "verification_timestamp must be a valid ISO 8601 datetime with timezone (e.g., 2026-03-10T14:23:00Z)."
-    required_if:
+    condition:
       field: verified_identity
       value: "TRUE"
     error_message: "verification_timestamp must be a valid ISO 8601 datetime with timezone (e.g., 2026-03-10T14:23:00Z)."

--- a/examples/starter_contracts/technology.yaml
+++ b/examples/starter_contracts/technology.yaml
@@ -64,31 +64,39 @@ rules:
   # ── INCIDENT IDENTIFICATION ──────────────────────────────────────────────────
   # INC- prefix followed by 6 digits. Adjust to your ticketing system format.
   # Common patterns: INC-000001 (ServiceNow), TKT-000001, INC20240001.
-  - field: incident_id
-    rule: not_empty
+  - name: incident_id_not_empty
+    type: not_empty
+    field: incident_id
     severity: error
     description: "Incident ID is mandatory. Every detected event must receive a unique reference for audit trail and SLA tracking."
+    error_message: "Incident ID is mandatory. Every detected event must receive a unique reference for audit trail and SLA tracking."
 
-  - field: incident_id
-    rule: regex
+  - name: incident_id_regex
+    type: regex
+    field: incident_id
     pattern: "^INC-[0-9]{6}$"
     severity: error
     description: "Incident ID must match format INC-XXXXXX (6 digits). Example: INC-000042."
+    error_message: "Incident ID must match format INC-XXXXXX (6 digits). Example: INC-000042."
 
   # ── SERVICE ──────────────────────────────────────────────────────────────────
   # The name of the affected service or system. Free text but bounded by length.
   # For production, replace max_length with a lookup_file pointing to your
   # internal service catalogue to ensure only registered services are reported.
-  - field: service_name
-    rule: not_empty
+  - name: service_name_not_empty
+    type: not_empty
+    field: service_name
     severity: error
     description: "Service name is mandatory. Required to route the incident to the correct on-call team."
+    error_message: "Service name is mandatory. Required to route the incident to the correct on-call team."
 
-  - field: service_name
-    rule: max_length
-    max: 100
+  - name: service_name_max_length
+    type: max_length
+    field: service_name
+    max_length: 100
     severity: error
     description: "Service name must not exceed 100 characters."
+    error_message: "Service name must not exceed 100 characters."
 
   # ── SEVERITY ─────────────────────────────────────────────────────────────────
   # ITIL 4 / PagerDuty-aligned priority levels:
@@ -99,20 +107,23 @@ rules:
   #   P5: Informational — no customer impact, proactive alert
   # P1 incidents must be escalated to on-call SRE within 15 minutes per
   # typical enterprise SLA. See docs for SLA policy integration.
-  - field: severity
-    rule: lookup
-    lookup_values: [P1, P2, P3, P4, P5]
+  - name: severity_allowed_values
+    type: allowed_values
+    field: severity
+    allowed_values: [P1, P2, P3, P4, P5]
     severity: error
     description: "Severity must be an ITIL 4 priority code. P1=critical outage (4h SLA), P2=major degradation, P3=partial impact, P4=low, P5=informational."
+    error_message: "Severity must be an ITIL 4 priority code. P1=critical outage (4h SLA), P2=major degradation, P3=partial impact, P4=low, P5=informational."
 
   # ── INCIDENT TYPE ────────────────────────────────────────────────────────────
   # SECURITY_BREACH: unauthorised access or data exfiltration — triggers GDPR workflow.
   # DATA_LOSS: data irrecoverably lost or corrupted — also triggers GDPR review.
   # THIRD_PARTY_DEPENDENCY: failure in an upstream provider (CDN, payment processor,
   # DNS). Important for SOC 2 vendor management evidence (CC9.2).
-  - field: incident_type
-    rule: lookup
-    lookup_values:
+  - name: incident_type_allowed_values
+    type: allowed_values
+    field: incident_type
+    allowed_values:
       - OUTAGE
       - DEGRADATION
       - SECURITY_BREACH
@@ -123,43 +134,53 @@ rules:
       - THIRD_PARTY_DEPENDENCY
     severity: error
     description: "Incident type must be a recognised ITIL 4 / NIST classification. SECURITY_BREACH and DATA_LOSS types automatically trigger GDPR breach assessment."
+    error_message: "Incident type must be a recognised ITIL 4 / NIST classification. SECURITY_BREACH and DATA_LOSS types automatically trigger GDPR breach assessment."
 
   # ── DETECTION TIMESTAMP ──────────────────────────────────────────────────────
   # ISO 8601 datetime with mandatory timezone offset. All incident timestamps
   # must include timezone to avoid ambiguity in distributed / multi-region teams.
   # Examples: 2026-03-09T14:30:00Z (UTC), 2026-03-09T15:30:00+01:00 (CET)
-  - field: detected_at
-    rule: not_empty
+  - name: detected_at_not_empty
+    type: not_empty
+    field: detected_at
     severity: error
     description: "Detection timestamp is mandatory. The 72-hour GDPR notification clock starts from the moment of awareness, not discovery."
+    error_message: "Detection timestamp is mandatory. The 72-hour GDPR notification clock starts from the moment of awareness, not discovery."
 
-  - field: detected_at
-    rule: regex
+  - name: detected_at_regex
+    type: regex
+    field: detected_at
     # ISO 8601 datetime with timezone: UTC (Z) or offset (+HH:MM / -HH:MM)
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Detection timestamp must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z or 2026-03-09T15:30:00+01:00)."
+    error_message: "Detection timestamp must be ISO 8601 with timezone (e.g., 2026-03-09T14:30:00Z or 2026-03-09T15:30:00+01:00)."
 
-  - field: detected_at
-    rule: compare
+  - name: detected_at_compare
+    type: compare
+    field: detected_at
     compare_op: lte
     compare_to: now
     severity: error
     description: "Detection timestamp cannot be in the future."
+    error_message: "Detection timestamp cannot be in the future."
 
   # ── REPORTER ─────────────────────────────────────────────────────────────────
-  - field: reported_by
-    rule: not_empty
+  - name: reported_by_not_empty
+    type: not_empty
+    field: reported_by
     severity: error
     description: "Reported by is mandatory. Required for incident accountability and SOC 2 CC7.3 audit evidence."
+    error_message: "Reported by is mandatory. Required for incident accountability and SOC 2 CC7.3 audit evidence."
 
   # ── AFFECTED REGION ──────────────────────────────────────────────────────────
   # AWS region identifiers plus GLOBAL (multi-region / CDN) and ON_PREMISE.
   # Adjust this lookup to match your actual cloud provider and deployed regions.
   # For Azure: use eastus, westeurope, etc. For GCP: us-central1, europe-west1.
-  - field: affected_region
-    rule: lookup
-    lookup_values:
+  - name: affected_region_allowed_values
+    type: allowed_values
+    field: affected_region
+    allowed_values:
       - us-east-1
       - us-west-2
       - eu-west-1
@@ -171,6 +192,7 @@ rules:
       - ON_PREMISE
     severity: error
     description: "Affected region must be a recognised deployment region. Required for blast radius analysis and customer communication scoping."
+    error_message: "Affected region must be a recognised deployment region. Required for blast radius analysis and customer communication scoping."
 
   # ── INCIDENT STATUS ──────────────────────────────────────────────────────────
   # ITIL 4 incident lifecycle states:
@@ -178,9 +200,10 @@ rules:
   # POST_MORTEM: blameless post-mortem process initiated (required for all P1/P2).
   # A P1 remaining in DETECTED status for more than 15 minutes without moving
   # to INVESTIGATING should trigger an SLA breach alert.
-  - field: status
-    rule: lookup
-    lookup_values:
+  - name: status_allowed_values
+    type: allowed_values
+    field: status
+    allowed_values:
       - DETECTED
       - INVESTIGATING
       - IDENTIFIED
@@ -189,27 +212,32 @@ rules:
       - POST_MORTEM
     severity: error
     description: "Status must reflect the ITIL 4 incident lifecycle. POST_MORTEM status is required for all P1 and P2 incidents after resolution."
+    error_message: "Status must reflect the ITIL 4 incident lifecycle. POST_MORTEM status is required for all P1 and P2 incidents after resolution."
 
   # ── IMPACT METRICS ───────────────────────────────────────────────────────────
   # customers_affected_count: number of unique customers experiencing degraded
   # or unavailable service. Max 100,000,000 (100M) — adjust to your total
   # addressable user base. Used for GDPR breach materiality assessment.
-  - field: customers_affected_count
-    rule: range
+  - name: customers_affected_count_range
+    type: range
+    field: customers_affected_count
     min: 0
     max: 100000000
     severity: warning
     description: "Customers affected must be between 0 and 100,000,000. Used for GDPR breach scope assessment and customer communications prioritisation."
+    error_message: "Customers affected must be between 0 and 100,000,000. Used for GDPR breach scope assessment and customer communications prioritisation."
 
   # estimated_revenue_impact_usd: projected direct revenue loss.
   # Max 1,000,000,000 (1B USD) — adjust to your maximum realistic single-incident
   # impact. Used for executive escalation and insurance claim triggers.
-  - field: estimated_revenue_impact_usd
-    rule: range
+  - name: estimated_revenue_impact_usd_range
+    type: range
+    field: estimated_revenue_impact_usd
     min: 0
     max: 1000000000
     severity: warning
     description: "Estimated revenue impact must be between 0 and 1,000,000,000 USD. Values above threshold trigger CFO escalation workflow."
+    error_message: "Estimated revenue impact must be between 0 and 1,000,000,000 USD. Values above threshold trigger CFO escalation workflow."
 
   # ── GDPR BREACH ASSESSMENT ───────────────────────────────────────────────────
   # GDPR Article 33: where a personal data breach is likely to result in a risk
@@ -217,45 +245,53 @@ rules:
   # the supervisory authority within 72 hours of becoming aware of the breach.
   # UNDER_ASSESSMENT: security/legal team still evaluating whether personal data
   # was involved. Must be resolved to YES or NO within 24 hours of DETECTED.
-  - field: gdpr_breach
-    rule: lookup
-    lookup_values: [YES, NO, UNDER_ASSESSMENT]
+  - name: gdpr_breach_allowed_values
+    type: allowed_values
+    field: gdpr_breach
+    allowed_values: ["YES", "NO", UNDER_ASSESSMENT]
     severity: error
     description: "GDPR breach status is mandatory for all SECURITY_BREACH and DATA_LOSS incidents. YES triggers the 72-hour ICO/supervisory authority notification obligation (GDPR Art. 33)."
+    error_message: "GDPR breach status is mandatory for all SECURITY_BREACH and DATA_LOSS incidents. YES triggers the 72-hour ICO/supervisory authority notification obligation (GDPR Art. 33)."
 
   # ── GDPR NOTIFICATION ────────────────────────────────────────────────────────
   # When gdpr_breach = YES, gdpr_notification_sent_at must be present.
   # The 72-hour clock runs from detected_at. Failure to notify within 72 hours
   # must be explained and documented (GDPR Art. 33(1): "without undue delay").
   # Fines for failure to notify: up to 2% of global annual turnover or €10M.
-  - field: gdpr_notification_sent_at
-    rule: required_if
-    when_field: gdpr_breach
-    when_value: "YES"
+  - name: gdpr_notification_sent_at_required_if
+    type: required_if
+    field: gdpr_notification_sent_at
     severity: error
     description: "GDPR notification timestamp is required when gdpr_breach = YES. Supervisory authority (e.g., ICO) must be notified within 72 hours of detection (GDPR Article 33)."
+    required_if:
+      field: gdpr_breach
+      value: "YES"
+    error_message: "GDPR notification timestamp is required when gdpr_breach = YES. Supervisory authority (e.g., ICO) must be notified within 72 hours of detection (GDPR Article 33)."
 
   # ── MEAN TIME TO RESOLVE ─────────────────────────────────────────────────────
   # mttr_minutes: elapsed time from detected_at to RESOLVED status.
   # Range: 0 to 525,600 minutes (365 days). Zero is valid for auto-remediated
   # incidents. Values over 10,080 (1 week) should trigger an executive review.
   # P1 SLA benchmark: resolve within 240 minutes (4 hours).
-  - field: mttr_minutes
-    rule: range
+  - name: mttr_minutes_range
+    type: range
+    field: mttr_minutes
     min: 0
     # 525,600 = 365 days × 24 hours × 60 minutes
     max: 525600
     severity: warning
     description: "MTTR must be between 0 and 525,600 minutes (1 year). P1 SLA target is typically ≤240 minutes. Values above 10,080 (1 week) require executive review."
+    error_message: "MTTR must be between 0 and 525,600 minutes (1 year). P1 SLA target is typically ≤240 minutes. Values above 10,080 (1 week) require executive review."
 
   # ── ASSIGNED TEAM ────────────────────────────────────────────────────────────
   # The team responsible for resolution. VENDOR_ESCALATION: incident has been
   # escalated to a third-party provider (e.g., AWS Support, Cloudflare, Stripe).
   # For SOC 2 CC9.2 (vendor management), VENDOR_ESCALATION incidents must have
   # an associated ticket number in the vendor's support system.
-  - field: assigned_team
-    rule: lookup
-    lookup_values:
+  - name: assigned_team_allowed_values
+    type: allowed_values
+    field: assigned_team
+    allowed_values:
       - SRE
       - SECURITY
       - PLATFORM
@@ -265,6 +301,7 @@ rules:
       - VENDOR_ESCALATION
     severity: error
     description: "Assigned team must be a recognised team identifier. Required for on-call routing and SOC 2 CC7.4 incident evaluation evidence."
+    error_message: "Assigned team must be a recognised team identifier. Required for on-call routing and SOC 2 CC7.4 incident evaluation evidence."
 
   # ── ROOT CAUSE CATEGORY ──────────────────────────────────────────────────────
   # Post-mortem classification. HUMAN_ERROR: misconfiguration, wrong deployment,
@@ -272,9 +309,10 @@ rules:
   # EXTERNAL_DEPENDENCY: failure in a service your system depends on but does
   # not control. UNKNOWN: set at RESOLVED if root cause not yet determined;
   # must be updated before POST_MORTEM is closed.
-  - field: root_cause_category
-    rule: lookup
-    lookup_values:
+  - name: root_cause_category_allowed_values
+    type: allowed_values
+    field: root_cause_category
+    allowed_values:
       - HUMAN_ERROR
       - SOFTWARE_BUG
       - INFRASTRUCTURE
@@ -283,3 +321,4 @@ rules:
       - UNKNOWN
     severity: warning
     description: "Root cause category is required for post-mortem analysis and SOC 2 CC7.4 evidence. UNKNOWN is acceptable at resolution but must be resolved before the post-mortem is closed."
+    error_message: "Root cause category is required for post-mortem analysis and SOC 2 CC7.4 evidence. UNKNOWN is acceptable at resolution but must be resolved before the post-mortem is closed."

--- a/examples/starter_contracts/telecoms.yaml
+++ b/examples/starter_contracts/telecoms.yaml
@@ -34,116 +34,148 @@ rules:
   # E.164 international number format: + followed by country code and subscriber
   # number, total 8–15 digits. No spaces, dashes, or brackets.
   # Examples: +447911123456 (UK mobile), +2348012345678 (Nigeria mobile)
-  - field: calling_number
-    rule: not_empty
+  - name: calling_number_not_empty
+    type: not_empty
+    field: calling_number
     severity: error
     description: "Calling number is mandatory for all CDR records."
+    error_message: "Calling number is mandatory for all CDR records."
 
-  - field: calling_number
-    rule: regex
+  - name: calling_number_regex
+    type: regex
+    field: calling_number
     pattern: "^\\+[1-9][0-9]{7,14}$"
     severity: error
     description: "Calling number must be in E.164 format (+[country code][number])."
+    error_message: "Calling number must be in E.164 format (+[country code][number])."
 
-  - field: called_number
-    rule: not_empty
+  - name: called_number_not_empty
+    type: not_empty
+    field: called_number
     severity: error
     description: "Called number is mandatory."
+    error_message: "Called number is mandatory."
 
-  - field: called_number
-    rule: regex
+  - name: called_number_regex
+    type: regex
+    field: called_number
     pattern: "^\\+[1-9][0-9]{7,14}$"
     severity: error
     description: "Called number must be in E.164 format."
+    error_message: "Called number must be in E.164 format."
 
   # ── TIMING ──────────────────────────────────────────────────────────────────
-  - field: call_start_time
-    rule: not_empty
+  - name: call_start_time_not_empty
+    type: not_empty
+    field: call_start_time
     severity: error
     description: "Call start time is mandatory — revenue and regulatory obligation."
+    error_message: "Call start time is mandatory — revenue and regulatory obligation."
 
-  - field: call_start_time
-    rule: regex
+  - name: call_start_time_regex
+    type: regex
+    field: call_start_time
     # ISO 8601 datetime with timezone: 2026-03-09T14:30:00Z or +01:00
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Call start time must be ISO 8601 datetime with timezone."
+    error_message: "Call start time must be ISO 8601 datetime with timezone."
 
-  - field: call_start_time
-    rule: compare
+  - name: call_start_time_compare
+    type: compare
+    field: call_start_time
     compare_op: lte
     compare_to: now
     severity: error
     description: "Call start time cannot be in the future."
+    error_message: "Call start time cannot be in the future."
 
-  - field: duration_seconds
-    rule: not_empty
+  - name: duration_seconds_not_empty
+    type: not_empty
+    field: duration_seconds
     severity: error
     description: "Call duration is required."
+    error_message: "Call duration is required."
 
-  - field: duration_seconds
-    rule: range
+  - name: duration_seconds_range
+    type: range
+    field: duration_seconds
     min: 0
     # 86400 = 24 hours. Calls longer than this are data errors.
     max: 86400
     severity: error
     description: "Call duration must be between 0 and 86,400 seconds (24 hours)."
+    error_message: "Call duration must be between 0 and 86,400 seconds (24 hours)."
 
   # ── CALL CLASSIFICATION ──────────────────────────────────────────────────────
-  - field: call_type
-    rule: lookup
+  - name: call_type_allowed_values
+    type: allowed_values
+    field: call_type
     # GSMA CDR call type classifications
-    lookup_values: [VOICE, SMS, DATA, MMS, ROAMING_VOICE, ROAMING_DATA,
+    allowed_values: [VOICE, SMS, DATA, MMS, ROAMING_VOICE, ROAMING_DATA,
                     ROAMING_SMS, VOICEMAIL, CONFERENCE, PREMIUM_RATE,
                     INTERNATIONAL, EMERGENCY]
     severity: error
     description: "Call type must be a GSMA-defined CDR classification."
+    error_message: "Call type must be a GSMA-defined CDR classification."
 
-  - field: record_type
-    rule: lookup
+  - name: record_type_allowed_values
+    type: allowed_values
+    field: record_type
     # CDR record perspective: who generated the record
-    lookup_values: [ORIGINATING, TERMINATING, TRANSIT, FORWARDED, ROAMING_VISITOR]
+    allowed_values: [ORIGINATING, TERMINATING, TRANSIT, FORWARDED, ROAMING_VISITOR]
     severity: error
     description: "Record type indicates the network node's perspective on the call."
+    error_message: "Record type indicates the network node's perspective on the call."
 
   # ── NETWORK IDENTIFICATION ───────────────────────────────────────────────────
   # MCC-MNC (Mobile Country Code - Mobile Network Code)
   # MCC: 3 digits. MNC: 2 or 3 digits.
   # Examples: 234-20 (UK Three), 621-30 (Nigeria MTN)
-  - field: network_code
-    rule: regex
+  - name: network_code_regex
+    type: regex
+    field: network_code
     pattern: "^[0-9]{3}-[0-9]{2,3}$"
     severity: error
     description: "Network code must be MCC-MNC format (e.g., 234-20 for UK Three)."
+    error_message: "Network code must be MCC-MNC format (e.g., 234-20 for UK Three)."
 
-  - field: serving_cell_id
-    rule: not_empty
+  - name: serving_cell_id_not_empty
+    type: not_empty
+    field: serving_cell_id
     severity: warning
     description: "Serving cell ID required for network analysis and regulatory reporting."
+    error_message: "Serving cell ID required for network analysis and regulatory reporting."
 
   # ── CHARGING ────────────────────────────────────────────────────────────────
-  - field: charge_amount
-    rule: range
+  - name: charge_amount_range
+    type: range
+    field: charge_amount
     min: 0
     # 1000 in local currency units. Adjust max for your pricing model.
     # Values above this threshold likely indicate a unit error or fraud.
     max: 1000
     severity: warning
     description: "Charge amount should be between 0 and 1,000 currency units. High values require review."
+    error_message: "Charge amount should be between 0 and 1,000 currency units. High values require review."
 
-  - field: charge_currency
-    rule: lookup
-    lookup_values: [USD, EUR, GBP, NGN, KES, GHS, ZAR, INR, JPY, CNY, BRL, SEK]
+  - name: charge_currency_allowed_values
+    type: allowed_values
+    field: charge_currency
+    allowed_values: [USD, EUR, GBP, NGN, KES, GHS, ZAR, INR, JPY, CNY, BRL, SEK]
     severity: error
     description: "Charge currency must be a supported ISO 4217 code."
+    error_message: "Charge currency must be a supported ISO 4217 code."
 
   # ── QUALITY INDICATORS ───────────────────────────────────────────────────────
-  - field: data_completeness_flag
-    rule: lookup
+  - name: data_completeness_flag_allowed_values
+    type: allowed_values
+    field: data_completeness_flag
     # Indicates whether the CDR is a complete record or a partial reconstruction
-    lookup_values: [COMPLETE, PARTIAL, RECONSTRUCTED, ESTIMATED]
+    allowed_values: [COMPLETE, PARTIAL, RECONSTRUCTED, ESTIMATED]
     severity: warning
     description: "Data completeness flag indicates CDR record reliability."
+    error_message: "Data completeness flag indicates CDR record reliability."
 
   # For Ofcom regulatory reporting: CDRs with PARTIAL or RECONSTRUCTED flags
   # must be reported separately. Use the quality trend API to track the ratio

--- a/examples/starter_contracts/travel.yaml
+++ b/examples/starter_contracts/travel.yaml
@@ -73,23 +73,28 @@ rules:
   # across all major GDS platforms (Amadeus: 6 chars, Sabre: 6 chars,
   # Travelport/Galileo: 6 chars). Examples: X7K2QA, BH34TL, 9GXPQR.
   # Lower-case letters, spaces, or special characters will fail GDS lookup.
-  - field: booking_reference
-    rule: not_empty
+  - name: booking_reference_not_empty
+    type: not_empty
+    field: booking_reference
     severity: error
     description: "Booking reference (PNR) is mandatory. All booking records must carry a PNR for GDS retrieval and check-in."
+    error_message: "Booking reference (PNR) is mandatory. All booking records must carry a PNR for GDS retrieval and check-in."
 
-  - field: booking_reference
-    rule: regex
+  - name: booking_reference_regex
+    type: regex
+    field: booking_reference
     # IATA PNR: exactly 6 uppercase alphanumeric characters
     pattern: "^[A-Z0-9]{6}$"
     severity: error
     description: "Booking reference must be exactly 6 uppercase alphanumeric characters (IATA PNR format, e.g., X7K2QA). Required by all major GDS platforms."
+    error_message: "Booking reference must be exactly 6 uppercase alphanumeric characters (IATA PNR format, e.g., X7K2QA). Required by all major GDS platforms."
 
   # ── BOOKING TYPE ─────────────────────────────────────────────────────────────
   # PACKAGE triggers EU Package Travel Directive 2015/2302/EU protections.
-  - field: booking_type
-    rule: lookup
-    lookup_values:
+  - name: booking_type_allowed_values
+    type: allowed_values
+    field: booking_type
+    allowed_values:
       - FLIGHT
       - HOTEL
       - CAR_HIRE
@@ -101,6 +106,7 @@ rules:
       - EXCURSION    # Day trip / activity
     severity: error
     description: "Booking type must be a recognised travel product. PACKAGE bookings trigger EU Package Travel Directive 2015/2302/EU consumer protection obligations."
+    error_message: "Booking type must be a recognised travel product. PACKAGE bookings trigger EU Package Travel Directive 2015/2302/EU consumer protection obligations."
 
   # ── ORIGIN AND DESTINATION AIRPORT ──────────────────────────────────────────
   # IATA airport codes (IATA SSIM Chapter 2): exactly 3 uppercase letters.
@@ -108,112 +114,141 @@ rules:
   # SIN (Singapore Changi), CDG (Paris Charles de Gaulle).
   # A 3-letter code is required for all FLIGHT bookings; it is optional
   # (or may contain a non-airport identifier) for other booking types.
-  - field: origin_airport
-    rule: regex
+  - name: origin_airport_regex
+    type: regex
+    field: origin_airport
     pattern: "^$|^[A-Z]{3}$"
     severity: error
     description: "Origin airport must be a valid 3-letter IATA airport code (e.g., LHR, JFK, DXB). Required for FLIGHT bookings."
+    error_message: "Origin airport must be a valid 3-letter IATA airport code (e.g., LHR, JFK, DXB). Required for FLIGHT bookings."
 
   # destination_airport is required when booking_type is FLIGHT.
-  - field: destination_airport
-    rule: required_if
-    when_field: booking_type
-    when_value: FLIGHT
+  - name: destination_airport_required_if
+    type: required_if
+    field: destination_airport
     severity: error
     description: "Destination airport is required for FLIGHT bookings."
+    required_if:
+      field: booking_type
+      value: FLIGHT
+    error_message: "Destination airport is required for FLIGHT bookings."
 
-  - field: destination_airport
-    rule: regex
+  - name: destination_airport_regex
+    type: regex
+    field: destination_airport
     pattern: "^$|^[A-Z]{3}$"
     severity: error
     description: "Destination airport must be a valid 3-letter IATA airport code (e.g., LHR, JFK, DXB)."
+    error_message: "Destination airport must be a valid 3-letter IATA airport code (e.g., LHR, JFK, DXB)."
 
   # ── DEPARTURE DATETIME ───────────────────────────────────────────────────────
   # ISO 8601 with mandatory timezone offset — required for cross-border
   # itinerary construction and DST-safe arrival time calculations.
-  - field: departure_datetime
-    rule: not_empty
+  - name: departure_datetime_not_empty
+    type: not_empty
+    field: departure_datetime
     severity: error
     description: "Departure datetime is mandatory for all bookings."
+    error_message: "Departure datetime is mandatory for all bookings."
 
-  - field: departure_datetime
-    rule: regex
+  - name: departure_datetime_regex
+    type: regex
+    field: departure_datetime
     # ISO 8601 datetime with mandatory timezone: Z or ±HH:MM
     pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$"
     severity: error
     description: "Departure datetime must be ISO 8601 with timezone (e.g., 2026-06-15T08:30:00Z or 2026-06-15T09:30:00+01:00)."
+    error_message: "Departure datetime must be ISO 8601 with timezone (e.g., 2026-06-15T08:30:00Z or 2026-06-15T09:30:00+01:00)."
 
-  - field: departure_datetime
-    rule: compare
+  - name: departure_datetime_compare
+    type: compare
+    field: departure_datetime
     compare_op: gte
     compare_to: now
     severity: warning
     description: "Departure datetime is in the past. Expected for historical records only — flag for new booking pipelines."
+    error_message: "Departure datetime is in the past. Expected for historical records only — flag for new booking pipelines."
 
   # ── RETURN DATETIME ──────────────────────────────────────────────────────────
   # return_datetime is mandatory for PACKAGE bookings under the EU Package
   # Travel Directive (the end date of the package must be defined).
   # It is optional for one-way flights, hotels, and transfers.
-  - field: return_datetime
-    rule: required_if
-    when_field: booking_type
-    when_value: PACKAGE
+  - name: return_datetime_required_if
+    type: required_if
+    field: return_datetime
     severity: error
     description: "Return datetime is required for PACKAGE bookings (EU Package Travel Directive 2015/2302/EU — the package end date must be defined)."
+    required_if:
+      field: booking_type
+      value: PACKAGE
+    error_message: "Return datetime is required for PACKAGE bookings (EU Package Travel Directive 2015/2302/EU — the package end date must be defined)."
 
-  - field: return_datetime
-    rule: cross_field_range
+  - name: return_datetime_compare
+    type: compare
+    field: return_datetime
     compare_op: gte
-    compare_to_field: departure_datetime
+    compare_to: departure_datetime
     severity: error
     description: "Return datetime must be on or after departure datetime."
+    error_message: "Return datetime must be on or after departure datetime."
 
   # ── PASSENGER COUNT ──────────────────────────────────────────────────────────
   # Range 1–500: minimum 1 (a booking with zero passengers is invalid).
   # Maximum 500 covers full charter aircraft (e.g., Airbus A380 max ~853,
   # but 500 is a conservative ceiling for most OTA/airline systems).
   # Reduce to 9 for leisure OTA use cases (max group booking).
-  - field: passenger_count
-    rule: range
+  - name: passenger_count_range
+    type: range
+    field: passenger_count
     min: 1
     max: 500
     severity: error
     description: "Passenger count must be between 1 and 500. Zero passengers is invalid. Adjust max for your use case (9 for leisure groups, 500 for charters)."
+    error_message: "Passenger count must be between 1 and 500. Zero passengers is invalid. Adjust max for your use case (9 for leisure groups, 500 for charters)."
 
   # ── CABIN CLASS ──────────────────────────────────────────────────────────────
   # Cabin class is only meaningful for FLIGHT bookings.
   # IATA fare basis codes map to these 4 cabins in all major GDS systems.
-  - field: cabin_class
-    rule: required_if
-    when_field: booking_type
-    when_value: FLIGHT
+  - name: cabin_class_required_if
+    type: required_if
+    field: cabin_class
     severity: error
     description: "Cabin class is required for FLIGHT bookings."
+    required_if:
+      field: booking_type
+      value: FLIGHT
+    error_message: "Cabin class is required for FLIGHT bookings."
 
-  - field: cabin_class
-    rule: lookup
-    lookup_values:
+  - name: cabin_class_allowed_values
+    type: allowed_values
+    field: cabin_class
+    allowed_values:
       - ECONOMY
       - PREMIUM_ECONOMY
       - BUSINESS
       - FIRST
     severity: error
     description: "Cabin class must be one of: ECONOMY, PREMIUM_ECONOMY, BUSINESS, FIRST."
+    error_message: "Cabin class must be one of: ECONOMY, PREMIUM_ECONOMY, BUSINESS, FIRST."
 
   # ── HOTEL STAR RATING ────────────────────────────────────────────────────────
   # Hotel star rating is only required for HOTEL bookings.
   # Ratings 1–5 align with the AA Hotel Star Rating and Hotelstars Union
   # classification used across Europe.
-  - field: hotel_star_rating
-    rule: required_if
-    when_field: booking_type
-    when_value: HOTEL
+  - name: hotel_star_rating_required_if
+    type: required_if
+    field: hotel_star_rating
     severity: error
     description: "Hotel star rating is required for HOTEL bookings."
+    required_if:
+      field: booking_type
+      value: HOTEL
+    error_message: "Hotel star rating is required for HOTEL bookings."
 
-  - field: hotel_star_rating
-    rule: lookup
-    lookup_values:
+  - name: hotel_star_rating_allowed_values
+    type: allowed_values
+    field: hotel_star_rating
+    allowed_values:
       - "1"
       - "2"
       - "3"
@@ -222,28 +257,34 @@ rules:
       - UNRATED    # Hostels, serviced apartments, boutique properties
     severity: error
     description: "Hotel star rating must be 1–5 or UNRATED (AA Hotel Star Rating / Hotelstars Union classification)."
+    error_message: "Hotel star rating must be 1–5 or UNRATED (AA Hotel Star Rating / Hotelstars Union classification)."
 
   # ── TOTAL PRICE ──────────────────────────────────────────────────────────────
   # Range 0–10,000,000: zero is valid for reward-only bookings (fully
   # redeemed via loyalty points / miles). Upper limit of £10 million
   # covers ultra-luxury charters and high-end cruise packages.
-  - field: total_price
-    rule: not_empty
+  - name: total_price_not_empty
+    type: not_empty
+    field: total_price
     severity: error
     description: "Total price is mandatory for revenue recognition and ATOL/ABTA financial protection calculations."
+    error_message: "Total price is mandatory for revenue recognition and ATOL/ABTA financial protection calculations."
 
-  - field: total_price
-    rule: range
+  - name: total_price_range
+    type: range
+    field: total_price
     min: 0
     max: 10000000
     severity: error
     description: "Total price must be between 0 and 10,000,000. Zero is valid for fully points-redeemed bookings."
+    error_message: "Total price must be between 0 and 10,000,000. Zero is valid for fully points-redeemed bookings."
 
   # ── CURRENCY ─────────────────────────────────────────────────────────────────
   # ISO 4217 currency codes covering major travel markets.
-  - field: currency
-    rule: lookup
-    lookup_values:
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values:
       - USD    # United States
       - EUR    # Eurozone
       - GBP    # United Kingdom
@@ -260,14 +301,16 @@ rules:
       - ZAR    # South Africa
     severity: error
     description: "Currency must be a supported ISO 4217 code covering major travel markets."
+    error_message: "Currency must be a supported ISO 4217 code covering major travel markets."
 
   # ── BOOKING STATUS ───────────────────────────────────────────────────────────
   # Standard booking lifecycle states used across airlines and OTA platforms.
   # TICKETED is airline-specific — a confirmed booking becomes ticketed when
   # the airline issues an e-ticket (13-digit BSP ticket number).
-  - field: booking_status
-    rule: lookup
-    lookup_values:
+  - name: booking_status_allowed_values
+    type: allowed_values
+    field: booking_status
+    allowed_values:
       - PENDING      # Booking initiated, payment not yet confirmed
       - CONFIRMED    # Payment confirmed, not yet ticketed
       - TICKETED     # E-ticket issued (airlines only)
@@ -278,6 +321,7 @@ rules:
       - WAITLISTED   # Booking on waitlist — seat/room not yet guaranteed
     severity: error
     description: "Booking status must be a recognised lifecycle state."
+    error_message: "Booking status must be a recognised lifecycle state."
 
   # ── PAYMENT METHOD ───────────────────────────────────────────────────────────
   # PCI DSS v4.0 NOTE: Raw payment card numbers (PANs) must NEVER appear in
@@ -285,9 +329,10 @@ rules:
   # PCI DSS Requirement 3.3: Do not retain sensitive authentication data
   # (full PAN, CVV, PIN) after authorisation. Any 16-digit number appearing
   # in a booking record field must be rejected at the API gateway.
-  - field: payment_method
-    rule: lookup
-    lookup_values:
+  - name: payment_method_allowed_values
+    type: allowed_values
+    field: payment_method
+    allowed_values:
       - CARD            # Credit/debit card — tokenised reference only, no PAN
       - BANK_TRANSFER
       - WALLET          # e.g., PayPal, Apple Pay, Google Pay
@@ -297,47 +342,57 @@ rules:
       - BNPL            # Buy Now Pay Later (e.g., Klarna, Affirm)
     severity: error
     description: "Payment method must be a recognised payment instrument. CARD payments must use a tokenised reference — raw PANs are prohibited under PCI DSS v4.0 Requirement 3.3."
+    error_message: "Payment method must be a recognised payment instrument. CARD payments must use a tokenised reference — raw PANs are prohibited under PCI DSS v4.0 Requirement 3.3."
 
   # ── AIRLINE CODE ─────────────────────────────────────────────────────────────
   # IATA Airline Designator: exactly 2 characters.
   # Format: 2 letters (e.g., BA = British Airways, EK = Emirates,
   # SQ = Singapore Airlines) or 1 letter + 1 digit (e.g., 2I = Star Peru).
   # Required for FLIGHT bookings; optional for other booking types.
-  - field: airline_code
-    rule: required_if
-    when_field: booking_type
-    when_value: FLIGHT
+  - name: airline_code_required_if
+    type: required_if
+    field: airline_code
     severity: error
     description: "Airline code is required for FLIGHT bookings."
+    required_if:
+      field: booking_type
+      value: FLIGHT
+    error_message: "Airline code is required for FLIGHT bookings."
 
-  - field: airline_code
-    rule: regex
+  - name: airline_code_regex
+    type: regex
+    field: airline_code
     # IATA 2-char designator: 2 letters or letter+digit
     pattern: "^$|^[A-Z0-9]{2}$"
     severity: error
     description: "Airline code must be a 2-character IATA airline designator (e.g., BA, EK, SQ, 2I)."
+    error_message: "Airline code must be a 2-character IATA airline designator (e.g., BA, EK, SQ, 2I)."
 
   # ── LOYALTY PROGRAMME ID ─────────────────────────────────────────────────────
   # Loyalty programme membership number — optional field.
   # Maximum 20 characters covers the longest frequent-flyer/hotel loyalty
   # membership numbers (e.g., BA Executive Club: 9 digits, Marriott Bonvoy:
   # 9 digits, Emirates Skywards: 16 digits).
-  - field: loyalty_programme_id
-    rule: max_length
-    max: 20
+  - name: loyalty_programme_id_max_length
+    type: max_length
+    field: loyalty_programme_id
+    max_length: 20
     severity: warning
     description: "Loyalty programme membership ID must not exceed 20 characters. Field is optional but must conform to this length if provided."
+    error_message: "Loyalty programme membership ID must not exceed 20 characters. Field is optional but must conform to this length if provided."
 
   # ── LEAD PASSENGER EMAIL ─────────────────────────────────────────────────────
   # Lead passenger email is required for booking confirmation delivery and
   # GDPR Article 14 processing notice requirements.
   # PII — must be handled under GDPR data minimisation principles.
   # Basic format validation only — MX record validation out of scope here.
-  - field: lead_passenger_email
-    rule: regex
+  - name: lead_passenger_email_regex
+    type: regex
+    field: lead_passenger_email
     pattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
     severity: error
     description: "Lead passenger email must be in a valid format (e.g., john.smith@example.com). Required for booking confirmation and GDPR Article 14 processing notice."
+    error_message: "Lead passenger email must be in a valid format (e.g., john.smith@example.com). Required for booking confirmation and GDPR Article 14 processing notice."
 
   # ── GDPR MARKETING CONSENT ────────────────────────────────────────────────────
   # GDPR Article 7: Conditions for consent.
@@ -347,11 +402,13 @@ rules:
   # NOT_ASKED: consent was not solicited at booking (permissible but recorded
   # so that downstream marketing systems do not incorrectly assume consent).
   # A missing or null consent field must not be treated as YES.
-  - field: gdpr_marketing_consent
-    rule: lookup
-    lookup_values:
-      - YES       # Explicit opt-in — marketing communications permitted
-      - NO        # Explicit opt-out
+  - name: gdpr_marketing_consent_allowed_values
+    type: allowed_values
+    field: gdpr_marketing_consent
+    allowed_values:
+      - "YES"       # Explicit opt-in — marketing communications permitted
+      - "NO"        # Explicit opt-out
       - NOT_ASKED # Consent not solicited — treat as NO for marketing
     severity: error
     description: "GDPR marketing consent status is mandatory. Must be YES (opted in), NO (opted out), or NOT_ASKED. A missing value must not be treated as consent (GDPR Article 7 / CJEU Planet49)."
+    error_message: "GDPR marketing consent status is mandatory. Must be YES (opted in), NO (opted out), or NOT_ASKED. A missing value must not be treated as consent (GDPR Article 7 / CJEU Planet49)."

--- a/examples/starter_contracts/universal.yaml
+++ b/examples/starter_contracts/universal.yaml
@@ -32,62 +32,77 @@ rules:
   # ── NOT EMPTY ────────────────────────────────────────────────────────────────
   # Use for: any field that must always be present and non-blank.
   # The most common rule — apply it to every mandatory field.
-  - field: record_id
-    rule: not_empty
+  - name: record_id_not_empty
+    type: not_empty
+    field: record_id
     severity: error
     description: "Every record must have a unique identifier."
+    error_message: "Every record must have a unique identifier."
 
-  - field: email
-    rule: not_empty
+  - name: email_not_empty
+    type: not_empty
+    field: email
     severity: error
     description: "Email address is required for contact."
+    error_message: "Email address is required for contact."
 
   # ── REGEX ────────────────────────────────────────────────────────────────────
   # Use for: structured strings with a known pattern (emails, IDs, phone numbers,
   # national identifiers, postcodes, account numbers).
   # Tip: anchor your patterns with ^ and $ to match the full string.
-  - field: email
-    rule: regex
+  - name: email_regex
+    type: regex
+    field: email
     pattern: "^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
     severity: error
     description: "Email must be a valid address format."
+    error_message: "Email must be a valid address format."
 
-  - field: phone
-    rule: regex
+  - name: phone_regex
+    type: regex
+    field: phone
     # E.164 international format: +[country code][number], 8–15 digits total
     pattern: "^\\+[1-9][0-9]{7,14}$"
     severity: warning
     description: "Phone number should use E.164 international format (+442071234567)."
+    error_message: "Phone number should use E.164 international format (+442071234567)."
 
-  - field: created_date
-    rule: regex
+  - name: created_date_regex
+    type: regex
+    field: created_date
     # ISO 8601 date: YYYY-MM-DD
     pattern: "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
     severity: error
     description: "Created date must be in YYYY-MM-DD format."
+    error_message: "Created date must be in YYYY-MM-DD format."
 
   # ── LOOKUP ───────────────────────────────────────────────────────────────────
   # Use for: categorical fields with a fixed set of valid values.
   # Inline values (as below) work well for small, stable lists.
   # For large or frequently-updated lists, use lookup_file: path/to/codes.csv
   # For externally-managed lists, use lookup_file: https://api.example.com/codes
-  - field: status
-    rule: lookup
-    lookup_values: [ACTIVE, INACTIVE, PENDING, SUSPENDED]
+  - name: status_allowed_values
+    type: allowed_values
+    field: status
+    allowed_values: [ACTIVE, INACTIVE, PENDING, SUSPENDED]
     severity: error
     description: "Status must be one of the defined lifecycle values."
+    error_message: "Status must be one of the defined lifecycle values."
 
-  - field: currency
-    rule: lookup
-    lookup_values: [USD, EUR, GBP, JPY, CNY, INR, NGN, BRL, SEK, AUD, CAD, CHF]
+  - name: currency_allowed_values
+    type: allowed_values
+    field: currency
+    allowed_values: [USD, EUR, GBP, JPY, CNY, INR, NGN, BRL, SEK, AUD, CAD, CHF]
     severity: error
     description: "Currency must be a supported ISO 4217 code."
+    error_message: "Currency must be a supported ISO 4217 code."
 
-  - field: country_code
-    rule: lookup
+  - name: country_code_allowed_values
+    type: allowed_values
+    field: country_code
     # To use the full ISO 3166-1 list, replace with:
     # lookup_file: "reference_data/iso3166_alpha2.csv"
-    lookup_values: [AD, AE, AF, AG, AI, AL, AM, AO, AR, AS, AT, AU, AZ, BA, BB,
+    allowed_values: [AD, AE, AF, AG, AI, AL, AM, AO, AR, AS, AT, AU, AZ, BA, BB,
                     BD, BE, BF, BG, BH, BI, BJ, BL, BM, BN, BO, BQ, BR, BS, BT,
                     BV, BW, BY, BZ, CA, CC, CD, CF, CG, CH, CI, CK, CL, CM, CN,
                     CO, CR, CU, CV, CW, CX, CY, CZ, DE, DJ, DK, DM, DO, DZ, EC,
@@ -97,7 +112,7 @@ rules:
                     IS, IT, JE, JM, JO, JP, KE, KG, KH, KI, KM, KN, KP, KR, KW,
                     KY, KZ, LA, LB, LC, LI, LK, LR, LS, LT, LU, LV, LY, MA, MC,
                     MD, ME, MF, MG, MH, MK, ML, MM, MN, MO, MP, MQ, MR, MS, MT,
-                    MU, MV, MW, MX, MY, MZ, NA, NC, NE, NF, NG, NI, NL, NO, NP,
+                    MU, MV, MW, MX, MY, MZ, NA, NC, NE, NF, NG, NI, NL, "NO", NP,
                     NR, NU, NZ, OM, PA, PE, PF, PG, PH, PK, PL, PM, PN, PR, PS,
                     PT, PW, PY, QA, RE, RO, RS, RU, RW, SA, SB, SC, SD, SE, SG,
                     SH, SI, SJ, SK, SL, SM, SN, SO, SR, SS, ST, SV, SX, SY, SZ,
@@ -106,72 +121,89 @@ rules:
                     WS, YE, YT, ZA, ZM, ZW]
     severity: warning
     description: "Country code must be a valid ISO 3166-1 alpha-2 code."
+    error_message: "Country code must be a valid ISO 3166-1 alpha-2 code."
 
   # ── RANGE ────────────────────────────────────────────────────────────────────
   # Use for: numeric fields with known valid bounds.
   # Catches unit errors (value entered in wrong unit), data entry errors,
   # and sensor faults.
-  - field: amount
-    rule: range
+  - name: amount_range
+    type: range
+    field: amount
     min: 0
     max: 1000000
     severity: error
     description: "Amount must be between 0 and 1,000,000."
+    error_message: "Amount must be between 0 and 1,000,000."
 
-  - field: score
-    rule: range
+  - name: score_range
+    type: range
+    field: score
     min: 0
     max: 100
     severity: error
     description: "Score must be a percentage between 0 and 100."
+    error_message: "Score must be a percentage between 0 and 100."
 
   # ── MAX LENGTH ───────────────────────────────────────────────────────────────
   # Use for: free-text fields that feed downstream systems with column limits.
-  - field: description
-    rule: max_length
-    max: 500
+  - name: description_max_length
+    type: max_length
+    field: description
+    max_length: 500
     severity: warning
     description: "Description must not exceed 500 characters."
+    error_message: "Description must not exceed 500 characters."
 
-  - field: record_id
-    rule: max_length
-    max: 50
+  - name: record_id_max_length
+    type: max_length
+    field: record_id
+    max_length: 50
     severity: error
     description: "Record ID must not exceed 50 characters."
+    error_message: "Record ID must not exceed 50 characters."
 
   # ── UNIQUE ───────────────────────────────────────────────────────────────────
   # Use for: primary key fields that must not repeat within a batch.
   # Note: uniqueness is checked within a single validate/batch call, not
   # across all historical records. For cross-batch deduplication, use
   # your database's primary key constraint.
-  - field: record_id
-    rule: unique
+  - name: record_id_unique
+    type: unique
+    field: record_id
     severity: error
     description: "Record ID must be unique within the submitted batch."
+    error_message: "Record ID must be unique within the submitted batch."
 
   # ── COMPARE ─────────────────────────────────────────────────────────────────
   # Use for: relational checks against a fixed value or another field.
   # Operations: eq, ne, gt, gte, lt, lte
-  - field: score
-    rule: compare
-    compare_op: gte
-    compare_to: 0
+  - name: score_min
+    type: min
+    field: score
+    min: 0
     severity: error
     description: "Score cannot be negative."
+    error_message: "Score cannot be negative."
 
-  - field: created_date
-    rule: compare
+  - name: created_date_compare
+    type: compare
+    field: created_date
     compare_op: lte
     compare_to: today
     severity: error
     description: "Created date cannot be in the future."
+    error_message: "Created date cannot be in the future."
 
   # ── REQUIRED IF ──────────────────────────────────────────────────────────────
   # Use for: fields that are mandatory only under specific conditions.
   # Example: reason is required when status is SUSPENDED.
-  - field: suspension_reason
-    rule: required_if
-    when_field: status
-    when_value: SUSPENDED
+  - name: suspension_reason_required_if
+    type: required_if
+    field: suspension_reason
     severity: error
     description: "Suspension reason is required when status is SUSPENDED."
+    required_if:
+      field: status
+      value: SUSPENDED
+    error_message: "Suspension reason is required when status is SUSPENDED."

--- a/llms.txt
+++ b/llms.txt
@@ -40,7 +40,7 @@ Runs the full validation engine in-process. Zero network dependency. Useful for 
 from opendqv.sdk.local import LocalValidator
 
 validator = LocalValidator()  # reads OPENDQV_CONTRACTS_DIR, else the bundled opendqv/contracts/
-result = validator.validate({"email": "alice@example.com", "age": 25}, contract="customer")
+result = validator.validate({"name": "Alice", "email": "alice@example.com", "age": 25}, contract="customer")
 
 # Batch — works directly with DataFrames
 import pandas as pd
@@ -120,7 +120,7 @@ MCP responses add `governance_tip` (always) and `draft_notice` (only for DRAFT c
 
 ## Rule types
 
-`not_empty`, `not_empty_string` (type-guarded), `regex`, `min`, `max`, `range`, `min_length`, `max_length`, `date_format`, `unique` (batch), `min_age`, `max_age`, `compare` (cross-field), `required_if` (conditional), `lookup` (file or HTTP reference list), `checksum`, `cross_field_range`, `field_sum`, `forbidden_if`, `conditional_value`, `date_diff`, `ratio_check`, `geospatial_bounds`, `age_match`
+The 24 types in the engine's dispatch table: `age_match`, `allowed_values`, `checksum`, `compare`, `conditional_lookup`, `conditional_value`, `cross_field_range`, `date_diff`, `date_format`, `field_sum`, `forbidden_if`, `geospatial_bounds`, `lookup`, `max`, `max_length`, `min`, `min_length`, `not_empty`, `not_empty_string`, `range`, `ratio_check`, `regex`, `required_if`, `unique`. `min_age` / `max_age` are keys on a `date_format` rule, not types; `unique` is batch-only.
 
 ## Ecosystem position
 

--- a/llms.txt
+++ b/llms.txt
@@ -37,9 +37,9 @@ Requires a running OpenDQV API server. One API serves Salesforce Apex, Python, N
 Runs the full validation engine in-process. Zero network dependency. Useful for CI tests, ETL scripts, Pandas DataFrames, and edge deployments.
 
 ```python
-from sdk.local import LocalValidator
+from opendqv.sdk.local import LocalValidator
 
-validator = LocalValidator()  # reads OPENDQV_CONTRACTS_DIR or ./contracts/
+validator = LocalValidator()  # reads OPENDQV_CONTRACTS_DIR, else the bundled opendqv/contracts/
 result = validator.validate({"email": "alice@example.com", "age": 25}, contract="customer")
 
 # Batch — works directly with DataFrames
@@ -65,10 +65,10 @@ curl -X POST http://localhost:8000/api/v1/validate/batch \
 
 # Discover available contracts
 curl http://localhost:8000/api/v1/contracts
-# → [{name, version, status, rule_count, owner, asset_id, contract_hash}, ...]
+# → [{name, version, status, rule_count, owner, asset_id, description}, ...]  (contract_hash is on GET /contracts/{name})
 
 # Understand why a rule failed and how to fix it
-curl http://localhost:8000/api/v1/contracts/customer/explain/email/email_format
+curl http://localhost:8000/api/v1/contracts/customer/explain/email/valid_email
 # → {"explanation": "...", "valid_examples": [...], "invalid_examples": [...]}
 ```
 
@@ -78,7 +78,7 @@ An MCP server is available. It gives agents native access to all OpenDQV tools w
 
 ```bash
 pip install opendqv[mcp]
-python mcp_server.py
+python -m opendqv.mcp_server
 ```
 
 Claude Desktop config (`~/.claude/claude_desktop_config.json`):
@@ -87,14 +87,14 @@ Claude Desktop config (`~/.claude/claude_desktop_config.json`):
   "mcpServers": {
     "opendqv": {
       "command": "python",
-      "args": ["/path/to/OpenDQV/mcp_server.py"],
+      "args": ["-m", "opendqv.mcp_server"],
       "env": {"OPENDQV_AGENT_IDENTITY": "your.email@example.com"}
     }
   }
 }
 ```
 
-MCP tools exposed: `validate_record`, `validate_batch`, `list_contracts`, `get_contract`, `explain_error`, `create_contract_draft`, `get_quality_metrics`
+MCP tools exposed: `validate_record`, `validate_batch`, `list_contracts`, `get_contract`, `get_contract_jsonschema`, `explain_error`, `create_contract_draft`, `get_quality_metrics`, `get_quality_trend`, `get_rule_velocity`, `list_agents`, `list_audit_events`, `get_audit_event`, `list_versions`, `compare_contracts`
 
 Agents can bootstrap new contracts via `create_contract_draft` when no matching contract exists. Names must start with `MCP_`. Drafts are testable immediately and require human approval before going ACTIVE.
 
@@ -106,8 +106,10 @@ Full guide: `docs/llm_integration.md`
 
 Single record:
 ```json
-{"valid": false, "errors": [{"field": "email", "rule": "email_format", "message": "...", "severity": "error"}], "contract": "customer", "version": "1.0", "contract_hash": "sha256:..."}
+{"valid": false, "errors": [{"field": "email", "rule": "valid_email", "message": "...", "severity": "error", "error_code": "OPENDQV_REGEX_VALID_EMAIL", "suggested_fix": "...", "counterpart_missing": null}], "contract": "customer", "version": "1.1", "contract_hash": "...", "engine_version": "<engine-version>"}
 ```
+
+`counterpart_missing` is `true` when a cross-field rule failed because its counterpart field was absent or blank.
 
 Batch:
 ```json
@@ -118,7 +120,7 @@ MCP responses add `governance_tip` (always) and `draft_notice` (only for DRAFT c
 
 ## Rule types
 
-`not_empty`, `not_empty_string` (type-guarded), `regex`, `min`, `max`, `range`, `min_length`, `max_length`, `date_format`, `unique` (batch), `min_age`, `max_age`, `compare` (cross-field), `required_if` (conditional), `lookup` (file or HTTP reference list), `checksum`, `cross_field_range`, `field_sum`, `forbidden_if`, `conditional_value`, `date_diff`, `ratio_check`, `conditional_lookup`, `geospatial_bounds`, `age_match`
+`not_empty`, `not_empty_string` (type-guarded), `regex`, `min`, `max`, `range`, `min_length`, `max_length`, `date_format`, `unique` (batch), `min_age`, `max_age`, `compare` (cross-field), `required_if` (conditional), `lookup` (file or HTTP reference list), `checksum`, `cross_field_range`, `field_sum`, `forbidden_if`, `conditional_value`, `date_diff`, `ratio_check`, `geospatial_bounds`, `age_match`
 
 ## Ecosystem position
 
@@ -164,7 +166,7 @@ OpenDQV is the **write-time** layer. It blocks records before they enter any sys
 - `contract_hash` — SHA-256 of the exact ruleset used. Echo it alongside records for point-in-time audit. Use it to skip catalog syncs when a contract has not changed.
 - `trace_id` — pass via `X-Trace-Id` header or query param; echoed in response headers and trace log. Use your orchestrator run ID, Kafka offset, or request ID for end-to-end correlation.
 - `severity: error` — blocks the write (returns 422). `severity: warning` — passes but appears in `warnings` array.
-- `status` — `draft` (testable, not production), `review` (pending approval), `active` (production-ready).
+- `status` — `draft` (testable, not production), `review` (pending approval), `active` (production-ready), `archived` (retired). ACTIVE and REVIEW contracts are immutable.
 
 ## Contract authoring (YAML)
 

--- a/opendqv/cli.py
+++ b/opendqv/cli.py
@@ -110,7 +110,7 @@ def cmd_init(args):
     """Initialise a contracts directory.
 
     Default: writes a single starter customer.yaml.
-    With --all: copies every bundled contract (43+ regulated domains) and
+    With --all: copies every bundled contract (every regulated starter in the library) and
     reference lookup files to the target directory — a writable working copy
     of the full OpenDQV library.
     """
@@ -1022,7 +1022,7 @@ def main():
     p_init = subparsers.add_parser("init", help="Initialise a contracts directory")
     p_init.add_argument("--dir", default="contracts", help="Target directory (default: ./contracts)")
     p_init.add_argument("--force", action="store_true", help="Overwrite existing contract files")
-    p_init.add_argument("--all", action="store_true", help="Copy every bundled contract (43+ regulated domains) instead of the single starter")
+    p_init.add_argument("--all", action="store_true", help="Copy every bundled contract (every regulated starter in the library) instead of the single starter")
 
     # list
     subparsers.add_parser("list", help="List all contracts")

--- a/opendqv/mcp_server.py
+++ b/opendqv/mcp_server.py
@@ -1578,7 +1578,7 @@ async def _tool_create_contract_draft(args: dict) -> list[types.TextContent]:
         "message": (
             f"Draft contract '{contract.name}' created with {len(contract.rules)} rule(s). "
             "You can now call validate_record against it (draft status allows testing). "
-            "To submit for human review: POST /api/v1/contracts/{name}/submit-for-review. "
+            "To submit for human review: POST /api/v1/contracts/{name}/{version}/submit-review. "
             "The contract will only become ACTIVE — and visible in the shared library — "
             f"after a human approves it.{remote_reload_note}"
         ),

--- a/postman/OpenDQV.postman_collection.json
+++ b/postman/OpenDQV.postman_collection.json
@@ -8,7 +8,8 @@
   "variable": [
     { "key": "base_url", "value": "http://localhost:8000", "type": "string" },
     { "key": "auth_token", "value": "", "type": "string" },
-    { "key": "contract_name", "value": "customer", "type": "string" }
+    { "key": "contract_name", "value": "customer", "type": "string" },
+    { "key": "contract_version", "value": "1.0", "type": "string" }
   ],
   "auth": {
     "type": "bearer",
@@ -299,9 +300,9 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/submit-review",
+              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/{{contract_version}}/submit-review",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "submit-review"]
+              "path": ["api", "v1", "contracts", "{{contract_name}}", "{{contract_version}}", "submit-review"]
             },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "description": "Transitions a DRAFT contract to REVIEW state. In AUTH_MODE=token this requires editor or admin role. A different user (approver role) must approve or reject."
@@ -312,9 +313,9 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/approve",
+              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/{{contract_version}}/approve",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "approve"]
+              "path": ["api", "v1", "contracts", "{{contract_name}}", "{{contract_version}}", "approve"]
             },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "description": "Transitions a REVIEW contract to ACTIVE state. Requires approver or admin role. Once ACTIVE the contract is immutable — rule mutations return 409."
@@ -325,9 +326,9 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/reject",
+              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/{{contract_version}}/reject",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "reject"]
+              "path": ["api", "v1", "contracts", "{{contract_name}}", "{{contract_version}}", "reject"]
             },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
@@ -348,14 +349,13 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/generate",
+              "raw": "{{base_url}}/api/v1/generate?contract_name={{contract_name}}&target=salesforce",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "generate"]
-            },
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"target\": \"apex\"\n}"
+              "path": ["api", "v1", "generate"],
+              "query": [
+                { "key": "contract_name", "value": "{{contract_name}}" },
+                { "key": "target", "value": "salesforce" }
+              ]
             },
             "description": "Generates a Salesforce Apex trigger/class that enforces the contract rules natively in your Salesforce org. Use the salesforce_contact contract for best results."
           }
@@ -365,14 +365,13 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/generate",
+              "raw": "{{base_url}}/api/v1/generate?contract_name={{contract_name}}&target=js",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "generate"]
-            },
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"target\": \"javascript\"\n}"
+              "path": ["api", "v1", "generate"],
+              "query": [
+                { "key": "contract_name", "value": "{{contract_name}}" },
+                { "key": "target", "value": "js" }
+              ]
             },
             "description": "Generates a JavaScript validation module compatible with Node.js and browser environments."
           }
@@ -382,14 +381,13 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/generate",
+              "raw": "{{base_url}}/api/v1/generate?contract_name={{contract_name}}&target=snowflake",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "generate"]
-            },
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"target\": \"snowflake\"\n}"
+              "path": ["api", "v1", "generate"],
+              "query": [
+                { "key": "contract_name", "value": "{{contract_name}}" },
+                { "key": "target", "value": "snowflake" }
+              ]
             },
             "description": "Generates a Snowflake JavaScript UDF that enforces the contract rules inside Snowflake. Use with Snowflake External Functions or as a native UDF."
           }
@@ -432,14 +430,18 @@
         {
           "name": "Revoke token",
           "request": {
-            "method": "DELETE",
+            "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/tokens/:token_id",
+              "raw": "{{base_url}}/api/v1/tokens/revoke",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "tokens", ":token_id"],
-              "variable": [{ "key": "token_id", "value": "REPLACE_WITH_TOKEN_ID" }]
+              "path": ["api", "v1", "tokens", "revoke"]
             },
-            "description": "Permanently revokes a PAT by ID. Requires admin role. Revoked tokens are invalidated immediately."
+            "header": [{ "key": "Content-Type", "value": "text/plain" }],
+            "body": {
+              "mode": "raw",
+              "raw": "REPLACE_WITH_TOKEN_VALUE"
+            },
+            "description": "Permanently revokes a PAT by token value (plain-text body). Requires admin role. Revoked tokens are invalidated immediately. To revoke every token for a user: POST /api/v1/tokens/revoke/{username}."
           }
         }
       ]
@@ -453,16 +455,16 @@
           "request": {
             "method": "POST",
             "url": {
-              "raw": "{{base_url}}/api/v1/import/great-expectations",
+              "raw": "{{base_url}}/api/v1/import/gx",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "import", "great-expectations"]
+              "path": ["api", "v1", "import", "gx"]
             },
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"suite\": {\n    \"expectation_suite_name\": \"customer_suite\",\n    \"expectations\": [\n      {\n        \"expectation_type\": \"expect_column_values_to_not_be_null\",\n        \"kwargs\": { \"column\": \"email\" }\n      },\n      {\n        \"expectation_type\": \"expect_column_values_to_match_regex\",\n        \"kwargs\": { \"column\": \"email\", \"regex\": \"^[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+$\" }\n      }\n    ]\n  },\n  \"contract_name\": \"customer_from_gx\"\n}"
+              "raw": "{\n  \"expectation_suite_name\": \"customer_suite\",\n  \"expectations\": [\n    {\n      \"expectation_type\": \"expect_column_values_to_not_be_null\",\n      \"kwargs\": { \"column\": \"email\" }\n    },\n    {\n      \"expectation_type\": \"expect_column_values_to_match_regex\",\n      \"kwargs\": { \"column\": \"email\", \"regex\": \"^[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+$\" }\n    }\n  ]\n}"
             },
-            "description": "Converts a Great Expectations expectation suite into an OpenDQV contract. Supported expectation types: not_null, regex match, value range, accepted values."
+            "description": "Converts a Great Expectations expectation suite into an OpenDQV contract. Supported expectation types: not_null, regex match, value range, accepted values. The body is the raw GX suite (no wrapper) — the contract name comes from expectation_suite_name. Add ?save=true to write the YAML to the contracts directory."
           }
         },
         {
@@ -521,11 +523,11 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{base_url}}/api/v1/contracts/{{contract_name}}/export/odcs",
+              "raw": "{{base_url}}/api/v1/export/odcs/{{contract_name}}",
               "host": ["{{base_url}}"],
-              "path": ["api", "v1", "contracts", "{{contract_name}}", "export", "odcs"]
+              "path": ["api", "v1", "export", "odcs", "{{contract_name}}"]
             },
-            "description": "Exports a contract as Open Data Contract Standard (ODCS) YAML. Compatible with data catalogues that support the ODCS specification."
+            "description": "Exports a contract as Open Data Contract Standard v3.1.0 YAML (schema-valid ODCS 3.x). Compatible with data catalogues that support the ODCS specification."
           }
         },
         {

--- a/scripts/replay_previous_corpus.py
+++ b/scripts/replay_previous_corpus.py
@@ -70,6 +70,10 @@ def replay(ref: str) -> dict:
     for path in files_at(ref):
         stem = Path(path).stem
         for line in read_at(ref, path):
+            if "record" not in line:
+                # Not a corpus row (e.g. frozen/regulatory_claims.jsonl carries
+                # base+patch claims, not records) — owned by its own test.
+                continue
             name = line.get("contract") or stem
             if not (CONTRACTS / f"{name}.yaml").exists():
                 flips.append({"contract": name, "kind": line.get("kind", "?"), "change": "contract removed"})

--- a/tests/test_starter_templates_load.py
+++ b/tests/test_starter_templates_load.py
@@ -1,0 +1,82 @@
+"""Guard: every template in examples/starter_contracts/ loads through the registry and
+lints with zero errors.
+
+The templates were written in a pre-1.0 dialect (`- field:` / `rule:` / `lookup_values:`)
+and drifted unnoticed for months because nothing exercised them (2.7.0 docs audit). This
+pins the migrated shape so the examples a newcomer copies are the examples the engine
+runs.
+"""
+import shutil
+from pathlib import Path
+
+import pytest
+
+from opendqv.core.contracts import ContractRegistry
+from opendqv.core.linter import lint_contract_file
+
+# CI runs from /home/runner — never hardcode the checkout path.
+STARTER_DIR = Path(__file__).resolve().parent.parent / "examples" / "starter_contracts"
+TEMPLATES = sorted(STARTER_DIR.glob("*.yaml"))
+
+
+def test_directory_has_templates():
+    assert len(TEMPLATES) >= 17, [p.name for p in TEMPLATES]
+
+
+@pytest.fixture(scope="module")
+def loaded_registry(tmp_path_factory):
+    """Copy every template + ref/ into a temp contracts dir and load it once."""
+    d = tmp_path_factory.mktemp("starter_contracts")
+    for p in TEMPLATES:
+        shutil.copy(p, d / p.name)
+    shutil.copytree(STARTER_DIR / "ref", d / "ref")
+    reg = ContractRegistry(d)
+    return {c["name"] for c in reg.list_contracts(include_all=True)}
+
+
+@pytest.mark.parametrize("template", TEMPLATES, ids=lambda p: p.name)
+def test_template_loads_through_registry(template, loaded_registry):
+    # Flat-format templates are named from the filename stem; the `contract:` format
+    # from its own name: field. Either way the stem must resolve to a loaded contract.
+    stem = template.stem
+    assert stem in loaded_registry, f"{template.name} did not load (loaded: {sorted(loaded_registry)})"
+
+
+@pytest.mark.parametrize("template", TEMPLATES, ids=lambda p: p.name)
+def test_template_lints_with_zero_errors(template):
+    result = lint_contract_file(str(template))
+    errors = [i for i in result.issues if i.severity == "error"]
+    assert not errors, [(i.code, i.rule_name, i.message) for i in errors]
+
+
+@pytest.mark.parametrize("template", TEMPLATES, ids=lambda p: p.name)
+def test_template_uses_current_rule_shape(template):
+    """No `rule:` keys, no unknown-type warnings — every rule carries name/type/field/error_message."""
+    import yaml
+
+    raw = yaml.safe_load(template.read_text(encoding="utf-8"))
+    rules = raw["contract"]["rules"] if "contract" in raw else raw["rules"]
+    for r in rules:
+        assert "rule" not in r, f"{template.name}: legacy `rule:` key in {r}"
+        for key in ("name", "type", "field", "severity", "error_message"):
+            assert key in r, f"{template.name}: rule {r.get('name')} missing `{key}`"
+    names = [r["name"] for r in rules]
+    assert len(names) == len(set(names)), f"{template.name}: duplicate rule names"
+
+
+@pytest.mark.parametrize("template", TEMPLATES, ids=lambda p: p.name)
+def test_template_has_no_bare_yaml_booleans(template):
+    """PyYAML is YAML 1.1: bare YES/NO/TRUE/FALSE/ON/OFF become Python booleans, which
+    stringify to "True"/"False" and never match the "YES"/"NO"/"TRUE" a record sends.
+    Norway's ISO code is NO. Every such literal in a value position must be quoted."""
+    import yaml
+
+    raw = yaml.safe_load(template.read_text(encoding="utf-8"))
+    rules = raw["contract"]["rules"] if "contract" in raw else raw["rules"]
+    for r in rules:
+        for v in r.get("allowed_values") or []:
+            assert not isinstance(v, bool), f"{template.name}: {r['name']} has bare boolean {v!r} in allowed_values"
+        for block in ("required_if", "condition"):
+            for k in ("value", "not_value"):
+                v = (r.get(block) or {}).get(k)
+                assert not isinstance(v, bool), f"{template.name}: {r['name']} {block}.{k} is bare boolean {v!r}"

--- a/tests/test_starter_templates_load.py
+++ b/tests/test_starter_templates_load.py
@@ -80,3 +80,14 @@ def test_template_has_no_bare_yaml_booleans(template):
             for k in ("value", "not_value"):
                 v = (r.get(block) or {}).get(k)
                 assert not isinstance(v, bool), f"{template.name}: {r['name']} {block}.{k} is bare boolean {v!r}"
+
+
+@pytest.mark.parametrize("template", TEMPLATES, ids=lambda p: p.name)
+def test_required_if_block_only_on_required_if_rules(template):
+    """/code-review of #162: a `required_if:` block on any other rule type is
+    inert (only the required_if handler reads it) — gating is `condition:`."""
+    import yaml
+    raw = yaml.safe_load(template.read_text(encoding="utf-8"))
+    rules = (raw.get("contract") or raw).get("rules") or []
+    stray = [r["name"] for r in rules if isinstance(r, dict) and "required_if" in r and r.get("type") != "required_if"]
+    assert stray == [], f"{template.name}: required_if block on non-required_if rule(s) {stray} — use condition:"


### PR DESCRIPTION
Four parallel docs-vs-code audits (entry points; rules & contracts; integrations & MCP; security & ops) against main @ d7f9552 (v2.7.0), each verifying documented commands and payloads by running them, then four fixers on disjoint file sets. ~130 findings. One commit per slice.

**What was wrong, by class**
- Pre-2.4 residue: root-relative `mcp_server.py` paths (namespace moved in 2.1), `from sdk.local`, `contracts/` at repo root, catalog snippets iterating `/registry` as a list and reading a `contract_hash` key that is `schema_hash`, stale counts (43/44/45 contracts, 50 endpoints, 18–26 commands, 3,390 tests, 76 docs).
- 2.4→2.7 changes not reflected: `fields:` → `allowed_fields:`; ACTIVE-only → ACTIVE **and REVIEW** immutability; `.match` → unanchored `.search`; null handling → explicit presence / D6 / D10 / `counterpart_missing`; `condition` vocabulary incl. `present`; `create_version` semantics; mcp 2.x; contexts moved to `examples/contexts/`; DORA (CDR 2025/301), Martyn's Law events, MiFID codes; release flow (`release.yml` → `publish.yml`); SEC register (004 scope, 006, 010, 011, `CONTRACT_NAME_RE`).
- Worked examples that did not run: the CLI CSV import (wrong column header → every row skipped, next step fails), the quickstart curl (`version: 1.0` → 404), the MCP walkthrough (passing record now fails `age_dob_consistent`), the Martyn's Law example record. All rewritten and re-run; real output pasted.
- **`examples/starter_contracts/`: 15 of 17 templates were in a pre-1.0 rule shape (`rule:`/`lookup_values`/`when_field`…) that the loader rejects** — the templates the docs tell users to copy did not load. All 16 non-benchmark templates migrated to the current shape (every parameter and comment kept; latent bugs the old dialect hid fixed, e.g. `max:` on `max_length`, bare YAML `NO` for Norway). New `tests/test_starter_templates_load.py` (69 tests) pins that every template loads through `ContractRegistry` and lints with zero errors.
- README "Known limitations in v2.2.x … v2.3.0 will…" replaced with current presence semantics and the honest statement that an unknown rule type still loads with a warning and passes — `opendqv lint` catches it (no future promise).
- Two user-facing strings in code: `create_contract_draft`'s message named a route that does not exist (`submit-for-review`); `init --all` help carried a stale contract count.

**Audit corrections along the way** (the audits were leads, not verdicts): the per-rule `GET /contracts/{name}/explain/{field}/{rule_name}` route *does* exist (kept; example rule name fixed); `min_age`/`max_age` do fire as add-on keys; the venue contract's field is `sia_registration_number` (event contract uses `sia_notification_reference`).

**Not changed, recorded:** `examples/starter_contracts/sample_records/*.json` use the bundled library's field names (documented in the README there); one time-dependent sample comment; `quickstart.md` `WORKBENCH_PORT`/`API_PORT` variables could not be verified against any compose file — follow-up.

**Verification:** full suite in CI; relative-link check on all changed markdown clean; ruff E/W/F clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm


**Also folds in #161 (Mac Claude):** CONTRIBUTING pointer to the three frozen fixture files a bundled-contract change must move with; contexts.md link text. #161 closed as superseded.


**Also fixes a latent CI red on main:** since the v2.7.0 tag, `scripts/replay_previous_corpus.py` scanned `frozen/regulatory_claims.jsonl` (claim rows, no `record` key) and `test_previous_release_replay_reports_and_gates` crashed with `KeyError` — verified failing on main. The replay now skips non-record rows.
