### PR TITLE
replay detector: exclude frozen/regulatory_claims.jsonl from the replay baseline (main is red on test_previous_release_replay_reports_and_gates since v2.7.0 became the latest tag)

### DIFF
--- a/scripts/replay_previous_corpus.py
+++ b/scripts/replay_previous_corpus.py
@@ -43,7 +43,10 @@ def files_at(ref: str) -> list[str]:
     """Corpus files at ``ref``: the generated per-contract files plus the frozen
     minimal_clean rows (kept in frozen/ so the generator's glob never sees them)."""
     out = subprocess.run(["git", "ls-tree", "-r", "--name-only", ref, f"{FIXTURE_DIR}/"], cwd=ROOT, capture_output=True, text=True)
-    return [p for p in out.stdout.split() if p.endswith(".jsonl")]
+    # The claims fixture (frozen/regulatory_claims.jsonl, 2.7.0) carries
+    # base + patch rows, not records — it has its own test and is not a
+    # replay baseline.
+    return [p for p in out.stdout.split() if p.endswith(".jsonl") and not p.endswith("regulatory_claims.jsonl")]
 
 
 def read_at(ref: str, path: str) -> list[dict]:
@@ -70,6 +73,8 @@ def replay(ref: str) -> dict:
     for path in files_at(ref):
         stem = Path(path).stem
         for line in read_at(ref, path):
+            if "record" not in line:
+                continue  # not a record row (defensive: a future fixture shape must not break the replay)
             name = line.get("contract") or stem
             if not (CONTRACTS / f"{name}.yaml").exists():
                 flips.append({"contract": name, "kind": line.get("kind", "?"), "change": "contract removed"})


### PR DESCRIPTION
One-line fix, split out of #161 (closed as superseded by #162) because it is not docs and `main` is red without it.

With `v2.7.0` now the latest tag, `scripts/replay_previous_corpus.py` globs every `.jsonl` under `tests/fixtures/conformance/` at the tag — which since 2.7.0 includes `frozen/regulatory_claims.jsonl` (base + patch rows, no `record`) — and raises `KeyError: 'record'`, so `tests/test_backlog_146_minimal_clean_and_replay.py::test_previous_release_replay_reports_and_gates` fails on `main`. #160 was green only because its baseline was still `v2.6.0`; #161's CI was the first run with `v2.7.0` as the baseline.

Fix: the claims file is excluded from the replay (it has its own test, `tests/test_regulatory_claims.py`) and rows without a `record` are skipped defensively. Locally: backlog-146 tests green; `replay_previous_corpus.py v2.7.0` → 0 flips, 0 unwaived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vgWu6PuYnKaizE2gSBpeA