### PR TITLE
2.9.0: unknown rule keys and unknown contract keys are refused at load (nearest-key hint); attestation keys round-trip on every write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to OpenDQV are documented here.
 
+## [2.9.0] - Unreleased
+
+### Unknown rule keys and unknown contract keys are refused at load
+
+Requested by the managed-engine maintainer (2026-09-06); the same class as
+the unknown-type silent pass 2.8.0 closed, one level down. pydantic's default
+`extra="ignore"` let `date_diff_feild: start` load as a rule with no
+counterpart that never fired, and `banana: 7` load clean. Both engines now
+refuse the key; Core refuses at load (files under version control), the
+managed engine at submission.
+
+- **Rule level:** a key the engine does not read is refused when the rule is
+  built — every path (stored YAML, REST, MCP, importers, context overrides).
+  The message names the rule, each unknown key and the nearest known key
+  when the miss is a typo (same letters ignoring case and underscores, or a
+  couple of single-character edits): `rule "span": unknown key
+  "date_diff_feild" (did you mean "date_diff_field"?) — this engine does not
+  read it, so it would change nothing; remove it or fix the spelling. Known
+  keys: …`. Only the rule's own keys are checked: the values of `condition`
+  (its own closed vocabulary since 2.6.0), `required_if`, `forbidden_if` and
+  `provenance` are the author's maps and are never walked. YAML merge keys
+  and anchors keep working; an aliased rule still has its keys inspected.
+- **Contract level:** an unknown key in the `contract:` block, an unknown
+  top-level document key (a holder key for YAML anchors counts — put anchors
+  inline on the first rule that uses them), and the legacy flat document are
+  refused the same way. `CONTRACT_KEYS` / `RULE_KEYS` are the shared sets.
+  The field-keyed onboarding format keeps its own vocabulary and is not
+  checked.
+- **Stored vs submitted (Core's answer, as for unknown types):** a stored
+  file with an unknown key fails to load; the log names the file, the rule
+  and the key; the contract is absent — nothing is served with a rule
+  silently missing. `opendqv lint` reports `UNKNOWN_RULE_KEY` /
+  `UNKNOWN_CONTRACT_KEY` (errors) with the same hint. Every bundled contract
+  and every example loads clean under the check.
+- **Attestation keys round-trip (found by the sweep):** the fresh-file
+  serialiser (`create_draft`, `create_version`, imports) wrote `proposed_by`
+  / `proposed_at` but dropped `approved_by`, `approved_at`, the rejection
+  trail, `owner_email`, `owner_team`, `asset_id`, `sensitive_fields` and
+  `contexts` — every attribute the loader reads is now written back when
+  set. ODCS export carries the four attestation keys as `opendqv.<key>`
+  custom properties and import reads them, so the trail survives the round
+  trip. (Draft saves and lifecycle transitions patch the file in place and
+  never lost them.)
+
 ## [2.8.0] - 2026-09-05
 
 **Unknown rule types are refused at load — on both engines the same day.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ It validates records against YAML data contracts at the point of write — befor
 data enters the pipeline ("shift-left"). It is **not** a pipeline monitoring tool
 (that's Monte Carlo) or a pipeline test framework (that's dbt/Soda).
 
-**Version:** 2.8.0
+**Version:** 2.9.0
 **Stack:** FastAPI + Gunicorn/Uvicorn, Streamlit UI, SQLite/PostgreSQL, DuckDB (batch), MCP
 
 ---

--- a/docs/rules/core_rules.md
+++ b/docs/rules/core_rules.md
@@ -49,6 +49,12 @@ and hold identically on the single-record and batch paths:
   absent or blank the rule **fails** with the rule's `error_message`, and the
   error entry carries `counterpart_missing: true` (REST, GraphQL and MCP).
   The rule's own `field` being absent is still D6 (skipped).
+- **Unknown rule keys are refused at load (2.9.0).** A key the engine does not
+  read (`date_diff_feild`, `banana`) is a load error naming the rule, the key
+  and the nearest known key; likewise an unknown key in the `contract:` block
+  or at the top of the document. `opendqv lint`: `UNKNOWN_RULE_KEY`,
+  `UNKNOWN_CONTRACT_KEY`. The values of `condition`, `required_if`,
+  `forbidden_if` and `provenance` are the author's maps and are not walked.
 - **Unknown rule types are refused at load (2.8.0).** `Rule()` raises with the
   list of known types (`opendqv.core.rule_parser.RULE_TYPES`, the same set the
   validator dispatches and the linter checks); `min_age`/`max_age` are keys on a

--- a/opendqv/api/routes_imports.py
+++ b/opendqv/api/routes_imports.py
@@ -501,6 +501,7 @@ async def export_to_odcs(
         strict_schema=getattr(contract, "strict_schema", False),
         allowed_fields=getattr(contract, "allowed_fields", None),
         owner_email=getattr(contract, "owner_email", None),
+        attestation={k: getattr(contract, k, None) for k in ("proposed_by", "proposed_at", "approved_by", "approved_at")},
     )
     from fastapi.responses import Response
     return Response(content=yaml_str, media_type="application/yaml")

--- a/opendqv/cli.py
+++ b/opendqv/cli.py
@@ -491,6 +491,7 @@ def cmd_export_odcs(args):
         owner_email=getattr(contract, "owner_email", None),
         strict_schema=getattr(contract, "strict_schema", False),
         allowed_fields=getattr(contract, "allowed_fields", None),
+        attestation={k: getattr(contract, k, None) for k in ("proposed_by", "proposed_at", "approved_by", "approved_at")},
     )
 
     if args.output:

--- a/opendqv/core/contracts.py
+++ b/opendqv/core/contracts.py
@@ -18,13 +18,43 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from pydantic import BaseModel, field_validator
-from .rule_parser import Rule, Severity, ContractStatus, RULE_TYPES
+from .rule_parser import Rule, Severity, ContractStatus, RULE_TYPES, unknown_keys_message
 
 # Canonical contract-name charset. Letters, digits, hyphen, underscore only —
 # no path separators, no dots, so a name can never escape ``contracts_dir``
 # (SEC-002/006). The REST layer (``api/deps._CONTRACT_NAME_RE``) aliases this;
 # every core write path that takes a caller-supplied name must check it.
 CONTRACT_NAME_RE = _re.compile(r"^[A-Za-z0-9_-]{1,100}$")
+
+
+# Keys the canonical ``contract:`` block (and the legacy flat document) may
+# carry — exactly what _parse_contract_format reads. Shared with the linter.
+CONTRACT_KEYS: frozenset = frozenset({
+    "name", "version", "description", "owner", "status", "rules", "contexts",
+    "strict_schema", "allowed_fields", "fields",
+    "asset_id", "downstream_consumers", "catalog_visible", "sensitive_fields",
+    "validate_in_states", "owner_team", "owner_email", "source",
+    "proposed_by", "proposed_at", "approved_by", "approved_at",
+    "rejected_by", "rejected_at", "rejection_reason",
+})
+# The canonical document has exactly one top-level key. A holder key for YAML
+# anchors counts as unknown — anchors go inline on the first rule that uses them.
+DOCUMENT_KEYS: frozenset = frozenset({"contract"})
+
+
+def check_contract_keys(raw: dict) -> None:
+    """Refuse a key the loader does not read, at document level and in the
+    ``contract:`` block (2.9.0). Same class as the unknown-type refusal (#165)."""
+    if "contract" in raw and isinstance(raw["contract"], dict):
+        top = [k for k in raw if k not in DOCUMENT_KEYS]
+        if top:
+            raise ValueError(unknown_keys_message("document", None, top, DOCUMENT_KEYS))
+        block, who = raw["contract"], raw["contract"].get("name")
+    else:
+        block, who = raw, raw.get("name")
+    unknown = [k for k in block if k not in CONTRACT_KEYS]
+    if unknown:
+        raise ValueError(unknown_keys_message("contract", who, unknown, CONTRACT_KEYS))
 
 
 class UnknownContextError(ValueError):
@@ -1042,6 +1072,7 @@ class ContractRegistry:
 
     def _parse_contract_format(self, raw: dict) -> DataContract:
         """Parse the canonical contract format."""
+        check_contract_keys(raw)
         c = raw["contract"]
         rules = [Rule(**r) for r in c.get("rules", [])]
         return DataContract(
@@ -1085,6 +1116,7 @@ class ContractRegistry:
 
     def _parse_legacy_format(self, raw: dict, path: Path) -> DataContract:
         """Parse flat rules list format (like starter-rules.yaml)."""
+        check_contract_keys(raw)
         rules = [Rule(**r) for r in raw["rules"]]
         name = path.stem.replace("-", "_").replace(" ", "_")
         return DataContract(
@@ -1510,6 +1542,20 @@ class ContractRegistry:
                 "rules": rules_list,
             }
         }
+        # 2.9.0: every attribute the loader reads is written back when set.
+        # The approval trail (approved_by/approved_at), rejection trail, owner
+        # contact, catalog id, sensitive fields and contexts used to be dropped
+        # on every fresh-file write (the managed engine found the same gap).
+        block = data["contract"]
+        for key in ("approved_by", "approved_at", "rejected_by", "rejected_at", "rejection_reason",
+                    "owner_team", "owner_email", "asset_id"):
+            value = getattr(contract, key, None)
+            if value is not None:
+                block[key] = value
+        if contract.sensitive_fields:
+            block["sensitive_fields"] = list(contract.sensitive_fields)
+        if contract.contexts:
+            block["contexts"] = contract.contexts
         if contract.downstream_consumers:
             data["contract"]["downstream_consumers"] = contract.downstream_consumers
         if not contract.catalog_visible:

--- a/opendqv/core/importers/odcs.py
+++ b/opendqv/core/importers/odcs.py
@@ -477,6 +477,9 @@ def _team_owner(team: Any) -> tuple[str, Optional[str]]:
     return "", None
 
 
+_ATTESTATION_KEYS = ("proposed_by", "proposed_at", "approved_by", "approved_at")
+
+
 def _custom_property(doc: dict, key: str) -> Optional[Any]:
     for cp in doc.get("customProperties") or []:
         if isinstance(cp, dict) and cp.get("property") == key:
@@ -586,6 +589,10 @@ def import_odcs(contract_data: dict) -> dict:
         contract["strict_schema"] = True
     if isinstance(declared_fields, list) and declared_fields:
         contract["allowed_fields"] = [str(f) for f in declared_fields]
+    for key in _ATTESTATION_KEYS:   # 2.9.0: the approval trail survives the round trip
+        value = _custom_property(contract_data, f"opendqv.{key}")
+        if value is not None:
+            contract[key] = str(value)
 
     return {
         "contract": contract,
@@ -680,8 +687,12 @@ def export_odcs(
     odcs_metadata: Optional[dict] = None,
     strict_schema: bool = False,
     allowed_fields: list | None = None,
+    attestation: dict | None = None,
 ) -> dict:
-    """Export OpenDQV rules to an ODCS v3.1.0 contract dict (schema-valid)."""
+    """Export OpenDQV rules to an ODCS v3.1.0 contract dict (schema-valid).
+
+    ``attestation`` (2.9.0): ``{proposed_by, proposed_at, approved_by, approved_at}``,
+    carried as ``opendqv.<key>`` custom properties so the trail round-trips."""
     by_field: "OrderedDict[str, list[dict]]" = OrderedDict()
     for raw in rules:
         r = _rule_to_dict(raw)
@@ -743,6 +754,9 @@ def export_odcs(
         doc["customProperties"].append({"property": "opendqv.strict_schema", "value": True})
     if allowed_fields:
         doc["customProperties"].append({"property": "opendqv.allowed_fields", "value": [str(f) for f in allowed_fields]})
+    for key in _ATTESTATION_KEYS:
+        if attestation and attestation.get(key) is not None:
+            doc["customProperties"].append({"property": f"opendqv.{key}", "value": str(attestation[key])})
     schema_obj: dict[str, Any] = {"name": contract_name, "logicalType": "object", "properties": properties}
     if object_quality:
         schema_obj["quality"] = object_quality
@@ -765,9 +779,10 @@ def contract_to_odcs_yaml(
     odcs_metadata: Optional[dict] = None,
     strict_schema: bool = False,
     allowed_fields: list | None = None,
+    attestation: dict | None = None,
 ) -> str:
     """Export OpenDQV contract to ODCS v3.1.0 YAML string."""
     doc = export_odcs(contract_name, rules, version=version, status=status, description=description,
                       owner=owner, owner_email=owner_email, odcs_metadata=odcs_metadata,
-                      strict_schema=strict_schema, allowed_fields=allowed_fields)
+                      strict_schema=strict_schema, allowed_fields=allowed_fields, attestation=attestation)
     return yaml.dump(doc, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/opendqv/core/importers/odcs.py
+++ b/opendqv/core/importers/odcs.py
@@ -70,7 +70,7 @@ from typing import Any, Optional
 import yaml
 from pydantic import ValidationError
 
-from opendqv.core.rule_parser import _BUILTIN_PATTERNS, Rule
+from opendqv.core.rule_parser import _BUILTIN_PATTERNS, Rule, RULE_KEYS
 
 ODCS_API_VERSION = "v3.1.0"
 ODCS_ENGINE = "opendqv"
@@ -254,7 +254,7 @@ _IMPORT_DENIED_FIELDS = frozenset({
     "lookup_auth_header",
 })
 _ENGINE_STAMPED_FIELDS = _IMPORT_DENIED_FIELDS
-_ALLOWED_RULE_FIELDS = frozenset(Rule.model_fields.keys()) - _IMPORT_DENIED_FIELDS
+_ALLOWED_RULE_FIELDS = frozenset(RULE_KEYS) - _IMPORT_DENIED_FIELDS   # the same set Rule() accepts (2.9.0)
 _ALIAS_TO_FIELD = {"min": "min_value", "max": "max_value"}
 
 _NAME_RE = re.compile(r"[^a-z0-9_]+")

--- a/opendqv/core/linter.py
+++ b/opendqv/core/linter.py
@@ -37,7 +37,7 @@ from typing import Optional
 
 import yaml
 
-from opendqv.core.rule_parser import RULE_TYPES
+from opendqv.core.rule_parser import RULE_KEYS, RULE_TYPES, nearest_key
 from opendqv.core.validator import (
     _human_to_strptime,
     _PRESENCE_RULE_TYPES,  # single source of truth (round-2 B2)
@@ -337,6 +337,35 @@ def lint_contract_yaml(yaml_str: str, contract_name: str = "") -> LintResult:
             ))
         else:
             seen_names[name] = i
+
+    # ── Unknown keys (2.9.0) — document, contract block, and each rule's own keys ──
+    def _key_issue(code, rule_name, kind, who, unknown, known):
+        parts = []
+        for k in unknown:
+            near = nearest_key(k, known)
+            parts.append(f'"{k}"' + (f' (did you mean "{near}"?)' if near else ""))
+        result.issues.append(LintIssue(
+            severity="error", rule_name=rule_name, code=code,
+            message=(f"{kind} {who}: unknown key(s) {', '.join(parts)} — the engine does not read them and "
+                     f"refuses the contract at load; remove or fix the spelling."),
+        ))
+    from opendqv.core.contracts import CONTRACT_KEYS, DOCUMENT_KEYS
+    if isinstance(data, dict) and not (isinstance(raw_rules, dict)):   # the field-keyed format has its own vocabulary
+        if isinstance(contract_node, dict) and "contract" in data:
+            top = [k for k in data if k not in DOCUMENT_KEYS]
+            if top:
+                _key_issue("UNKNOWN_CONTRACT_KEY", None, "document", "top level", top, DOCUMENT_KEYS)
+            block, who = contract_node, str(contract_node.get("name", contract_name))
+        else:
+            block, who = data, str(data.get("name", contract_name))
+        unknown = [k for k in block if k not in CONTRACT_KEYS] if isinstance(block, dict) else []
+        if unknown:
+            _key_issue("UNKNOWN_CONTRACT_KEY", None, "contract", f'"{who}"', unknown, CONTRACT_KEYS)
+    for raw in raw_rules if isinstance(raw_rules, list) else []:
+        if isinstance(raw, dict):
+            unknown = [k for k in raw if k not in RULE_KEYS]
+            if unknown:
+                _key_issue("UNKNOWN_RULE_KEY", raw.get("name"), "rule", f'"{raw.get("name", "<unnamed>")}"', unknown, RULE_KEYS)
 
     # ── contexts: override types (2.8.0) ──────────────────────────────────────
     # An override is merged and constructed at load; an unknown type there

--- a/opendqv/core/rule_parser.py
+++ b/opendqv/core/rule_parser.py
@@ -75,6 +75,8 @@ except ImportError:  # pragma: no cover
     _regex_lib = None
     _HAS_REGEX_LIB = False
 import yaml
+import difflib
+
 from pydantic import BaseModel, Field, model_validator
 from typing import Any, List, Optional
 from enum import Enum
@@ -281,6 +283,22 @@ class Rule(BaseModel):
 
     model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
 
+    @model_validator(mode="before")
+    @classmethod
+    def _refuse_unknown_keys(cls, data):
+        """2.9.0: a key this engine does not read is refused, with the nearest
+        known key when the miss is a typo. Until 2.8.0 pydantic's default
+        ``extra="ignore"`` let ``date_diff_feild: start`` load as a rule with
+        no counterpart that never fired — the unknown-type silent pass (#165)
+        one level down. Only the rule's OWN keys are checked; the values of
+        ``condition`` / ``required_if`` / ``forbidden_if`` / ``provenance``
+        are maps whose keys belong to the author and are never walked here."""
+        if isinstance(data, dict):
+            unknown = [k for k in data if k not in RULE_KEYS]
+            if unknown:
+                raise ValueError(unknown_keys_message("rule", data.get("name"), unknown, RULE_KEYS))
+        return data
+
     _COMPARE_OP_ALIASES: dict = {
         ">": "gt", "<": "lt", ">=": "gte", "<=": "lte", "=": "eq", "!=": "neq",
     }
@@ -386,6 +404,39 @@ class Rule(BaseModel):
         self.cached_error_code = f"OPENDQV_{self.type.upper()}_{self.name.upper()}"
         self.cached_has_age_constraint = self.min_age is not None or self.max_age is not None
         return self
+
+
+# Keys a rule may carry: every model field the loader reads plus the YAML
+# aliases. The hot-path caches and the compiled pattern are internal.
+RULE_KEYS: frozenset = frozenset(
+    {n for n in Rule.model_fields if not n.startswith("cached_") and n != "compiled_pattern"} | {"min", "max"}
+)
+
+
+def _normalise_key(k: str) -> str:
+    return str(k).lower().replace("_", "").replace("-", "")
+
+
+def nearest_key(key: str, known) -> Optional[str]:
+    """The known key a typo most likely meant: same letters ignoring case and
+    underscores, else within a couple of single-character edits (difflib)."""
+    norm = _normalise_key(key)
+    for k in known:
+        if _normalise_key(k) == norm:
+            return k
+    close = difflib.get_close_matches(str(key), sorted(known), n=1, cutoff=0.75)
+    return close[0] if close else None
+
+
+def unknown_keys_message(kind: str, name, unknown, known) -> str:
+    """One message naming each unknown key with its nearest known key."""
+    parts = []
+    for k in unknown:
+        near = nearest_key(k, known)
+        parts.append(f'unknown key "{k}"' + (f' (did you mean "{near}"?)' if near else ""))
+    who = f'{kind} "{name}"' if name else kind
+    return (f"{who}: {', '.join(parts)} — this engine does not read it, so it would change nothing; "
+            f"remove it or fix the spelling. Known keys: {', '.join(sorted(known))}.")
 
 
 def parse_rules(yaml_str: str) -> List[Rule]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opendqv"
-version = "2.8.0"
+version = "2.9.0"
 description = "OpenDQV Core — open-source, contract-driven data quality validation engine for data pipelines and API boundaries"
 authors = ["Sunny Sharma"]
 license = "MIT"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -105,7 +105,7 @@ def _mixed_rules() -> list[Rule]:
         Rule(name="code_length_max", type="max_length", field="code",
              max_length=20, error_message="code too long"),
         Rule(name="created_date_format", type="date_format", field="created_date",
-             date_format="%Y-%m-%d", error_message="invalid date format"),
+             format="%Y-%m-%d", error_message="invalid date format"),
     ]
 
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -385,7 +385,7 @@ class TestFilenameNameMismatch:
         """Filename and YAML name agree → no mismatch issue."""
         yaml_str = (
             "contract:\n  name: customer\n  version: \"1.0\"\n  status: draft\n"
-            "rules: []\n"
+            "  rules: []\n"  # 2.9.0: top-level rules beside contract: is an unknown document key
         )
         result = lint_contract_yaml(yaml_str, contract_name="customer")
         codes = [i.code for i in result.issues]
@@ -396,7 +396,7 @@ class TestFilenameNameMismatch:
         """When called without a filename hint, the mismatch check is skipped."""
         yaml_str = (
             "contract:\n  name: media_content\n  version: \"1.0\"\n  status: draft\n"
-            "rules: []\n"
+            "  rules: []\n"
         )
         result = lint_contract_yaml(yaml_str)  # no contract_name
         codes = [i.code for i in result.issues]

--- a/tests/test_rule_coverage.py
+++ b/tests/test_rule_coverage.py
@@ -1293,7 +1293,7 @@ class TestAbsentFieldSkipping:
             Rule(name="ne", type="not_empty", field="dob",
                  error_message="dob is required"),
             Rule(name="df", type="date_format", field="dob",
-                 date_format="%Y-%m-%d",
+                 format="%Y-%m-%d",
                  error_message="dob must be YYYY-MM-DD"),
         ]
         result = validate_record({"dob": None}, rules, contract_name="test")
@@ -1307,7 +1307,7 @@ class TestAbsentFieldSkipping:
             Rule(name="ne", type="not_empty", field="dob",
                  error_message="dob is required"),
             Rule(name="df", type="date_format", field="dob",
-                 date_format="%Y-%m-%d",
+                 format="%Y-%m-%d",
                  error_message="dob must be YYYY-MM-DD"),
         ]
         result = validate_record({"dob": "   "}, rules, contract_name="test")
@@ -1321,7 +1321,7 @@ class TestAbsentFieldSkipping:
             Rule(name="ne", type="not_empty", field="dob",
                  error_message="dob is required"),
             Rule(name="df", type="date_format", field="dob",
-                 date_format="%Y-%m-%d",
+                 format="%Y-%m-%d",
                  error_message="dob must be YYYY-MM-DD"),
         ]
         result = validate_record({}, rules, contract_name="test")
@@ -1339,7 +1339,7 @@ class TestAbsentFieldSkipping:
         dict(type="range", min_value=0, max_value=100),
         dict(type="min_length", min_length=1),
         dict(type="max_length", max_length=10),
-        dict(type="date_format", date_format="%Y-%m-%d"),
+        dict(type="date_format", format="%Y-%m-%d"),
     ])
     def test_format_class_rule_skips_on_absent_single(self, absent_value, rule_kwargs):
         """Single-record path: format-class rules return valid on absent."""
@@ -1356,7 +1356,7 @@ class TestAbsentFieldSkipping:
         dict(type="range", min_value=0, max_value=100),
         dict(type="min_length", min_length=1),
         dict(type="max_length", max_length=10),
-        dict(type="date_format", date_format="%Y-%m-%d"),
+        dict(type="date_format", format="%Y-%m-%d"),
     ])
     def test_format_class_rule_skips_on_absent_batch(self, absent_value, rule_kwargs):
         """Batch path (DuckDB SQL) also skips absent values."""
@@ -1394,7 +1394,7 @@ class TestAbsentFieldSkipping:
         result = _validate(
             {"value": None, "country": "GB"},
             type="conditional_lookup",
-            condition_field="country", condition_value="GB",
+            condition={"field": "country", "value": "GB"},
             lookup_file="ref/nonexistent.csv",
         )
         assert result["valid"] is True
@@ -1412,7 +1412,7 @@ class TestAbsentFieldSkipping:
     def test_age_match_skips_on_absent_target(self):
         result = _validate(
             {"value": None, "dob": "1990-01-01"},
-            type="age_match", age_dob_field="dob",
+            type="age_match", dob_field="dob",
         )
         assert result["valid"] is True
 

--- a/tests/test_unknown_keys_refused.py
+++ b/tests/test_unknown_keys_refused.py
@@ -1,0 +1,220 @@
+"""2.9.0 — unknown rule keys and unknown contract keys are refused at load.
+
+Requested by the managed-engine maintainer (2026-09-06): the same class as the
+unknown-type silent pass 2.8.0 closed (#165), one level down. pydantic's
+default ``extra="ignore"`` let ``date_diff_feild: start`` load as a rule with
+no counterpart that never fired.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from opendqv.core.contracts import CONTRACT_KEYS, ContractRegistry, DataContract
+from opendqv.core.linter import lint_contract_yaml
+from opendqv.core.rule_parser import RULE_KEYS, Rule, nearest_key, parse_rules
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestRuleKeys:
+    def test_misspelt_key_is_refused_with_the_nearest_key(self):
+        with pytest.raises(ValueError) as exc:
+            Rule(name="span", type="date_diff", field="end", date_diff_feild="start",
+                 date_diff_unit="days", min_value=0, error_message="m")
+        msg = str(exc.value)
+        assert 'rule "span"' in msg and '"date_diff_feild"' in msg and 'did you mean "date_diff_field"' in msg
+        assert "Known keys:" in msg
+
+    def test_every_unknown_key_is_named(self):
+        with pytest.raises(ValueError) as exc:
+            Rule(name="r", type="not_empty", field="f", banana=7, Min_Value=3, error_message="m")
+        msg = str(exc.value)
+        assert '"banana"' in msg and '"Min_Value" (did you mean "min_value"?)' in msg
+
+    def test_managed_engine_s_own_slip_unit_instead_of_date_diff_unit(self):
+        with pytest.raises(ValueError, match='"unit"'):
+            parse_rules("rules:\n  - {name: d, type: date_diff, field: end, date_diff_field: start, unit: days, min_value: 0, error_message: m}\n")
+
+    def test_aliases_and_every_known_key_are_accepted(self):
+        Rule(name="r", type="range", field="f", min=1, max=2, error_message="m")
+        Rule(name="r", type="range", field="f", min_value=1, max_value=2, error_message="m")
+        for k in RULE_KEYS:
+            assert not k.startswith("cached_") and k != "compiled_pattern"
+
+    def test_nested_maps_are_the_author_s_and_never_walked(self):
+        # provenance / required_if / forbidden_if values are maps whose keys are
+        # not this rule's keys. (condition has its own closed vocabulary since 2.6.0.)
+        Rule(name="r", type="not_empty", field="f", error_message="m",
+             provenance={"authority_node": "hq", "lsn": 3, "anything_else": True})
+        Rule(name="r", type="required_if", field="f", error_message="m",
+             required_if={"field": "g", "value": "x", "note": "author's own annotation"})
+        Rule(name="r", type="forbidden_if", field="f", error_message="m",
+             forbidden_if={"field": "g", "value": "x", "reason": "author's own annotation"})
+
+    def test_yaml_merge_key_and_alias_keep_working_and_an_aliased_rule_is_still_inspected(self):
+        rules = parse_rules(
+            "rules:\n"
+            "  - &base {name: a, type: not_empty, field: f, error_message: m, severity: warning}\n"
+            "  - {<<: *base, name: b, field: g}\n"
+        )
+        assert [(r.name, r.field, r.severity.value) for r in rules] == [("a", "f", "warning"), ("b", "g", "warning")]
+        with pytest.raises(ValueError, match='rule "b".*"bannana"'):
+            parse_rules(
+                "rules:\n"
+                "  - &base {name: a, type: not_empty, field: f, error_message: m}\n"
+                "  - {<<: *base, name: b, bannana: 1}\n"
+            )
+
+    def test_model_dump_round_trip_carries_no_unknown_key(self):
+        r = Rule(name="r", type="regex", field="f", pattern="^a$", error_message="m", min_age=3)
+        Rule(**r.model_dump(by_alias=True))
+        Rule(**r.model_dump(by_alias=True, exclude_none=True))
+
+    def test_nearest_key_heuristics(self):
+        assert nearest_key("DateDiffField", RULE_KEYS) == "date_diff_field"
+        assert nearest_key("errormessage", RULE_KEYS) == "error_message"
+        assert nearest_key("comparto", RULE_KEYS) == "compare_to"
+        assert nearest_key("zzzz", RULE_KEYS) is None
+
+
+def _write(d: Path, name: str, doc: dict) -> Path:
+    p = d / f"{name}.yaml"
+    p.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    return p
+
+
+class TestContractKeys:
+    def test_unknown_block_key_refuses_the_file_at_load_with_the_hint(self, tmp_path, caplog):
+        _write(tmp_path, "ok", {"contract": {"name": "ok", "version": "1.0", "rules": []}})
+        _write(tmp_path, "bad", {"contract": {"name": "bad", "version": "1.0", "onwer": "x", "rules": []}})
+        with caplog.at_level(logging.ERROR):
+            reg = ContractRegistry(tmp_path)
+        assert reg.get("ok") is not None and reg.get("bad") is None
+        msg = " ".join(r.getMessage() for r in caplog.records)
+        assert "bad.yaml" in msg and '"onwer" (did you mean "owner"?)' in msg
+
+    def test_top_level_holder_key_for_anchors_is_unknown(self, tmp_path, caplog):
+        (tmp_path / "anch.yaml").write_text(
+            "_defaults: &d {severity: warning}\n"
+            "contract:\n  name: anch\n  version: '1.0'\n  rules:\n    - {<<: *d, name: a, type: not_empty, field: f, error_message: m}\n",
+            encoding="utf-8")
+        with caplog.at_level(logging.ERROR):
+            reg = ContractRegistry(tmp_path)
+        assert reg.get("anch") is None
+        assert '"_defaults"' in " ".join(r.getMessage() for r in caplog.records)
+
+    def test_misspelt_rule_key_in_a_stored_file_names_file_rule_and_key(self, tmp_path, caplog):
+        _write(tmp_path, "typo", {"contract": {"name": "typo", "version": "1.0", "rules": [
+            {"name": "span", "type": "date_diff", "field": "end", "date_diff_feild": "start", "date_diff_unit": "days", "min_value": 0, "error_message": "m"}]}})
+        with caplog.at_level(logging.ERROR):
+            reg = ContractRegistry(tmp_path)
+        assert reg.get("typo") is None
+        msg = " ".join(r.getMessage() for r in caplog.records)
+        assert "typo.yaml" in msg and 'rule "span"' in msg and '"date_diff_feild"' in msg
+
+    def test_legacy_flat_document_is_checked_too(self, tmp_path, caplog):
+        _write(tmp_path, "flat", {"name": "flat", "version": "1.0", "descripton": "x",
+                                  "rules": [{"name": "a", "type": "not_empty", "field": "f", "error_message": "m"}]})
+        with caplog.at_level(logging.ERROR):
+            reg = ContractRegistry(tmp_path)
+        assert reg.get("flat") is None
+        assert '"descripton" (did you mean "description"?)' in " ".join(r.getMessage() for r in caplog.records)
+
+    def test_context_override_with_unknown_key_is_refused_at_load(self, tmp_path, caplog):
+        _write(tmp_path, "ctx", {"contract": {"name": "ctx", "version": "1.0",
+                                              "rules": [{"name": "a", "type": "min", "field": "age", "min": 18, "error_message": "m"}],
+                                              "contexts": {"kids": {"a": {"mn": 13}}}}})
+        with caplog.at_level(logging.ERROR):
+            reg = ContractRegistry(tmp_path)
+        assert reg.get("ctx") is None
+        assert "context 'kids'" in " ".join(r.getMessage() for r in caplog.records)
+
+    def test_every_key_the_loader_reads_is_known(self):
+        src = (ROOT / "opendqv" / "core" / "contracts.py").read_text(encoding="utf-8")
+        body = src.split("def _parse_contract_format")[1].split("def _parse_legacy_format")[0]
+        import re
+        read = set(re.findall(r'c\.get\("([a-z_]+)"', body)) | set(re.findall(r'c\["([a-z_]+)"\]', body))
+        assert read <= CONTRACT_KEYS, read - CONTRACT_KEYS
+
+
+class TestLinter:
+    def test_codes_and_hints(self):
+        res = lint_contract_yaml(
+            "_anchors: {x: 1}\ncontract:\n  name: t\n  onwer: x\n  rules:\n    - {name: a, type: not_empty, field: f, banana: 7, error_message: m}\n", "t")
+        by_code = {}
+        for i in res.issues:
+            by_code.setdefault(i.code, []).append(i)
+        assert len(by_code["UNKNOWN_CONTRACT_KEY"]) == 2
+        assert any('"_anchors"' in i.message for i in by_code["UNKNOWN_CONTRACT_KEY"])
+        assert any('"onwer" (did you mean "owner"?)' in i.message for i in by_code["UNKNOWN_CONTRACT_KEY"])
+        assert [i.rule_name for i in by_code["UNKNOWN_RULE_KEY"]] == ["a"] and all(i.severity == "error" for i in by_code["UNKNOWN_RULE_KEY"])
+
+    def test_bundled_library_and_examples_carry_no_unknown_key(self):
+        paths = sorted((ROOT / "opendqv" / "contracts").glob("*.yaml")) + sorted((ROOT / "examples").rglob("*.yaml"))
+        assert len(paths) > 50
+        offenders = []
+        for p in paths:
+            res = lint_contract_yaml(p.read_text(encoding="utf-8"), p.stem)
+            hits = [i for i in res.issues if i.code in ("UNKNOWN_RULE_KEY", "UNKNOWN_CONTRACT_KEY")]
+            if hits:
+                offenders.append((str(p.relative_to(ROOT)), [i.message[:80] for i in hits]))
+        assert offenders == [], offenders
+
+
+class TestAttestationRoundTrip:
+    FOUR = {"proposed_by": "alice", "proposed_at": "2026-09-01T10:00:00Z",
+            "approved_by": "bob", "approved_at": "2026-09-02T10:00:00Z"}
+
+    def test_fresh_file_serialiser_writes_all_four_and_the_other_read_attributes(self, tmp_path):
+        reg = ContractRegistry(tmp_path)
+        c = DataContract(name="att", version="1.0", status="active", owner="o", owner_email="o@x.org",
+                         asset_id="urn:x", sensitive_fields=["ssn"], contexts={"eu": {"a": {"severity": "warning"}}},
+                         rules=[Rule(name="a", type="not_empty", field="f", error_message="m")], **self.FOUR)
+        raw = yaml.safe_load(reg._contract_to_yaml(c))["contract"]
+        for k, v in self.FOUR.items():
+            assert raw[k] == v, k
+        assert raw["owner_email"] == "o@x.org" and raw["asset_id"] == "urn:x"
+        assert raw["sensitive_fields"] == ["ssn"] and raw["contexts"] == {"eu": {"a": {"severity": "warning"}}}
+        assert set(raw) <= CONTRACT_KEYS   # and nothing the loader would refuse
+
+    def test_bundled_contract_survives_load_serialise_load(self, tmp_path):
+        src = ROOT / "opendqv" / "contracts" / "customer.yaml"
+        first = ContractRegistry(_copy(src, tmp_path / "a"))
+        c = first.get("customer")
+        assert c.proposed_by and c.approved_by and c.approved_at and c.proposed_at, "the bundled library carries all four"
+        out = tmp_path / "b"
+        out.mkdir()
+        (out / "customer.yaml").write_text(first._contract_to_yaml(c), encoding="utf-8")
+        again = ContractRegistry(out).get("customer")
+        for k in self.FOUR:
+            assert getattr(again, k) == getattr(c, k), k
+
+    def test_odcs_export_import_round_trip_keeps_the_trail(self):
+        from opendqv.core.importers.odcs import export_odcs, import_odcs
+        rules = [Rule(name="a", type="not_empty", field="f", error_message="m")]
+        doc = export_odcs("rt", rules, version="1.0", status="active", attestation=self.FOUR)
+        props = {p["property"]: p["value"] for p in doc["customProperties"]}
+        for k, v in self.FOUR.items():
+            assert props[f"opendqv.{k}"] == v
+        back = import_odcs(doc)["contract"]
+        for k, v in self.FOUR.items():
+            assert back[k] == v
+
+    def test_rest_odcs_export_carries_the_trail(self, client, auth_headers):
+        r = client.get("/api/v1/export/odcs/customer", headers=auth_headers)
+        assert r.status_code == 200, r.text
+        assert "opendqv.approved_by" in r.text and "opendqv.proposed_at" in r.text
+
+
+def _copy(src: Path, dest_dir: Path) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / src.name).write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    ref = src.parent / "ref"
+    if ref.exists():
+        import shutil
+        shutil.copytree(ref, dest_dir / "ref", dirs_exist_ok=True)
+    return dest_dir


### PR DESCRIPTION
Part 1 of the managed-engine maintainer's 2026-09-06 request: the unknown-type silent pass (#165) one level down. pydantic's default `extra="ignore"` let `date_diff_feild: start` load as a rule with no counterpart that never fired, and `banana: 7` load clean.

**Change**
- `RULE_KEYS` (model fields minus the hot-path caches, plus `min`/`max` aliases) gates `Rule()` in a before-validator. Message names the rule, each unknown key and the nearest known key when the miss is a typo: `rule "span": unknown key "date_diff_feild" (did you mean "date_diff_field"?) — this engine does not read it, so it would change nothing; remove it or fix the spelling. Known keys: …`. Nearest key = same letters ignoring case and underscores, else difflib within a couple of edits.
- Only the rule's own keys are checked; `condition` (own closed vocabulary), `required_if`, `forbidden_if`, `provenance` values are the author's maps, never walked. YAML merge keys and anchors keep working; an aliased rule still has its keys inspected.
- `CONTRACT_KEYS` / `DOCUMENT_KEYS` gate the `contract:` block, the document top level (an anchor holder key counts) and the legacy flat document. The field-keyed onboarding format keeps its own vocabulary.
- **Stored vs submitted:** Core refuses at load, as for unknown types — the log names the file, rule and key; the contract is absent. Linter: `UNKNOWN_RULE_KEY`, `UNKNOWN_CONTRACT_KEY` (errors) with the same hint.
- **The sweep the maintainer asked for found Core's own tests carrying junk keys that passed on defaults** — `date_format=` for `format=` (5 sites), `age_dob_field`, `condition_field`/`condition_value`, a linter fixture with `rules:` beside `contract:` — all corrected. Bundled library and every example: clean.
- **Attestation round trip (found by the sweep):** the fresh-file serialiser wrote `proposed_by`/`proposed_at` but dropped `approved_by`, `approved_at`, the rejection trail, `owner_email`, `owner_team`, `asset_id`, `sensitive_fields` and `contexts` on every `create_draft`/`create_version`/import write. Every attribute the loader reads is now written when set. ODCS export carries the four attestation keys as `opendqv.<key>` custom properties; import reads them.

**Tests:** `tests/test_unknown_keys_refused.py` (misspelt key + hint, every unknown key named, the maintainer's own `unit:` slip, aliases, nested maps not walked, merge key + alias, aliased junk refused, stored-file/legacy/top-level/context refusals with the file named, loader-reads ⊆ CONTRACT_KEYS, linter codes, library + examples clean, serialiser writes all four + the rest, bundled load→serialise→load, ODCS round trip, REST export). Sonnet red-team: no blockers, one consistency nit applied (ODCS importer allow-list built from `RULE_KEYS`). Full suite 5061 green.

Version 2.9.0 with #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm