### PR TITLE
ci: release.yml dispatches docker-publish.yml for the tag (#172)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,14 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  # A tag pushed by release.yml with GITHUB_TOKEN does not trigger the push
+  # event above (#172), so release.yml dispatches this workflow with the tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and publish (e.g. v2.9.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -21,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up QEMU
         # QEMU enables arm64 emulation on the amd64 runner
@@ -45,6 +55,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,5 +121,12 @@ jobs:
             --ref "v${{ needs.release.outputs.version }}" \
             -f version="${{ needs.release.outputs.version }}"
           echo "Dispatched publish.yml for v${{ needs.release.outputs.version }}; track it under Actions → Publish to PyPI."
+          # The tag we pushed with GITHUB_TOKEN does not fire docker-publish's
+          # push trigger (#172) — dispatch it with the tag explicitly.
+          gh workflow run docker-publish.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag="v${{ needs.release.outputs.version }}"
+          echo "Dispatched docker-publish.yml for v${{ needs.release.outputs.version }}."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #172. A tag pushed by `release.yml` with `GITHUB_TOKEN` does not fire `docker-publish.yml`'s `push: tags` trigger, so v2.9.0 got no versioned image build. `docker-publish.yml` gains `workflow_dispatch` with a `tag` input (checks out that ref; metadata-action derives the semver tags from the input), and `release.yml` dispatches it right after `publish.yml`. Once merged, dispatching with `tag=v2.9.0` produces the missing 2.9.0 / 2.9 image tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm