### PR TITLE
docker: apply the base image's outstanding Debian security updates at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@
 # See .github/workflows/docker-publish.yml for CI/CD pipeline
 FROM python:3.13-slim AS base
 
+# Apply the base image's outstanding Debian security updates before anything
+# else. `python:3.13-slim` is rebuilt on its own cadence, so between rebuilds
+# its OS packages drift behind the CVE feeds and the image ships known-fixed
+# vulnerabilities (2026-09-12: 3 CRITICAL + 9 HIGH across perl-base, libpcre2,
+# libsqlite3 and gzip, every one with a patched Debian version available).
+# Upgrading here picks them up at build time; the container scan in CI is the
+# check that this layer is doing its job.
+RUN apt-get update &&     apt-get upgrade -y --no-install-recommends &&     apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN useradd --create-home appuser
 
 WORKDIR /app


### PR DESCRIPTION
The container scan on #176 failed with 3 CRITICAL and 9 HIGH in the base image — `perl-base`, `libpcre2-8-0`, `libsqlite3-0`, `gzip` — none of them from that diff, all with a patched Debian version already published.

`main` is green only because its last CI run (2026-09-07) predates the advisories: this is the stale-green container-scan pattern, and a fresh run on `main` fails the same way. `python:3.13-slim` is rebuilt on its own cadence, so between rebuilds its OS packages drift behind the CVE feeds and the published image ships known-fixed vulnerabilities.

Adding an `apt-get upgrade` layer ahead of the Python install picks the fixes up at build time. The container scan in CI is the check that the layer keeps doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3b2mAxppRrU6oQgJNy9tm